### PR TITLE
fix(inference-details-ui): forcing refresh on health change

### DIFF
--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -88,7 +88,11 @@ beforeEach(() => {
 
   mocks.getInferenceServersMock.mockReturnValue([
     {
-      health: undefined,
+      health: {
+        Status: 'healthy',
+        Log: [],
+        FailingStreak: 0,
+      },
       models: [],
       connection: { port: 9999 },
       status: 'running',
@@ -135,4 +139,13 @@ test('on mount should call createSnippet', async () => {
   });
 
   expect(studioClient.createSnippet).toHaveBeenCalled();
+});
+
+test('ensure status is visible when running', async () => {
+  render(InferenceServerDetails, {
+    containerId: 'dummyContainerId',
+  });
+
+  const status = screen.getByRole('status');
+  expect(status).toBeDefined();
 });

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -84,7 +84,9 @@ onMount(() => {
               <span class="text-sm">Container</span>
               <div class="w-full bg-charcoal-600 rounded-md p-2 flex items-center">
                 <div class="grow ml-2 flex flex-row">
-                  <ServiceStatus object="{service}" />
+                  {#key service.health?.Status}
+                    <ServiceStatus object="{service}" />
+                  {/key}
                   <div class="flex flex-col text-xs ml-2">
                     <span>{service.container.containerId}</span>
                   </div>


### PR DESCRIPTION
### What does this PR do?

The health status is a nested properties in the `InferenceServer` object, leading to miss-render on properties change. This PR is forcing the re-render using svelte `key`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/655

### How to test this PR?

- [x] unit test provided