### PR TITLE
feat(models): delete remote model when delete local one

### DIFF
--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -532,6 +532,40 @@ describe('deleting models', () => {
       '/home/user/ai-studio/models/dummyFile',
     ]);
   });
+
+  test('deleting on windows should check if models is uploaded', async () => {
+    vi.mocked(env).isWindows = false;
+
+    const rmSpy = vi.spyOn(fs.promises, 'rm');
+    rmSpy.mockResolvedValue(undefined);
+    const manager = new ModelsManager(
+      '/home/user/aistudio',
+      {
+        postMessage: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Webview,
+      {
+        getModels: () => {
+          return [
+            {
+              id: 'model-id-1',
+              file: {
+                file: 'dummyFile',
+                path: 'dummyPath',
+              }
+            },
+          ] as ModelInfo[];
+        },
+      } as CatalogManager,
+      telemetryLogger,
+      taskRegistry,
+    );
+
+    await manager.loadLocalModels();
+    await manager.deleteModel('model-id-1');
+    expect(coreProcess.exec).not.toHaveBeenCalled();
+    expect(mocks.getFirstRunningMachineNameMock).not.toHaveBeenCalled();
+    expect(mocks.getPodmanCliMock).not.toHaveBeenCalled();
+  });
 });
 
 

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -505,7 +505,7 @@ describe('deleting models', () => {
               file: {
                 file: 'dummyFile',
                 path: 'dummyPath',
-              }
+              },
             },
           ] as ModelInfo[];
         },
@@ -551,7 +551,7 @@ describe('deleting models', () => {
               file: {
                 file: 'dummyFile',
                 path: 'dummyPath',
-              }
+              },
             },
           ] as ModelInfo[];
         },
@@ -567,7 +567,6 @@ describe('deleting models', () => {
     expect(mocks.getPodmanCliMock).not.toHaveBeenCalled();
   });
 });
-
 
 describe('downloadModel', () => {
   test('download model if not already on disk', async () => {

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -184,7 +184,7 @@ export class ModelsManager implements Disposable {
 
   private async deleteRemoteModel(modelInfo: ModelInfo): Promise<void> {
     // currently only Window is supported
-    if(!env.isWindows) {
+    if (!env.isWindows) {
       return;
     }
 
@@ -196,8 +196,7 @@ export class ModelsManager implements Disposable {
 
     // check if model already loaded on the podman machine
     const existsRemote = await isModelUploaded(machineName, modelInfo);
-    if(!existsRemote)
-      return;
+    if (!existsRemote) return;
 
     return deleteRemoteModel(machineName, modelInfo);
   }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -198,7 +198,7 @@ export class StudioApiImpl implements StudioAPI {
       )
       .then((result: string) => {
         if (result === 'Confirm') {
-          this.modelsManager.deleteLocalModel(modelId).catch((err: unknown) => {
+          this.modelsManager.deleteModel(modelId).catch((err: unknown) => {
             console.error('Something went wrong while deleting the models', err);
             // Lets reloads the models (could fix the issue)
             this.modelsManager.loadLocalModels().catch((err: unknown) => {

--- a/packages/backend/src/utils/modelsUtils.spec.ts
+++ b/packages/backend/src/utils/modelsUtils.spec.ts
@@ -1,0 +1,141 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { process as apiProcess } from '@podman-desktop/api';
+import {
+  deleteRemoteModel,
+  getLocalModelFile,
+  getRemoteModelFile,
+  isModelUploaded,
+  MACHINE_BASE_FOLDER,
+} from './modelsUtils';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { getPodmanCli } from './podman';
+
+vi.mock('@podman-desktop/api', () => {
+  return {
+    process: {
+      exec: vi.fn(),
+    },
+  };
+});
+
+vi.mock('./podman', () => ({
+  getPodmanCli: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(getPodmanCli).mockReturnValue('dummyPodmanCli');
+});
+
+describe('getLocalModelFile', () => {
+  test('file in ModelInfo undefined', () => {
+    expect(() => {
+      getLocalModelFile({
+        id: 'dummyModelId',
+        file: undefined,
+      } as unknown as ModelInfo);
+    }).toThrowError('model is not available locally.');
+  });
+
+  test('should join path with respect to system host', () => {
+    const path = getLocalModelFile({
+      id: 'dummyModelId',
+      file: {
+        path: 'dummyPath',
+        file: 'dummy.guff',
+      },
+    } as unknown as ModelInfo);
+
+    if (process.platform === 'win32') {
+      expect(path).toBe('dummyPath\\dummy.guff');
+    } else {
+      expect(path).toBe('dummyPath/dummy.guff');
+    }
+  });
+});
+
+describe('getRemoteModelFile', () => {
+  test('file in ModelInfo undefined', () => {
+    expect(() => {
+      getRemoteModelFile({
+        id: 'dummyModelId',
+        file: undefined,
+      } as unknown as ModelInfo);
+    }).toThrowError('model is not available locally.');
+  });
+
+  test('should join path using posix', () => {
+    const path = getRemoteModelFile({
+      id: 'dummyModelId',
+      file: {
+        path: 'dummyPath',
+        file: 'dummy.guff',
+      },
+    } as unknown as ModelInfo);
+
+    expect(path).toBe(`${MACHINE_BASE_FOLDER}dummy.guff`);
+  });
+});
+
+describe('isModelUploaded', () => {
+  test('execute stat on targeted machine', async () => {
+    expect(
+      await isModelUploaded('dummyMachine', {
+        id: 'dummyModelId',
+        file: {
+          path: 'dummyPath',
+          file: 'dummy.guff',
+        },
+      } as unknown as ModelInfo),
+    ).toBeTruthy();
+
+    expect(getPodmanCli).toHaveBeenCalled();
+    expect(apiProcess.exec).toHaveBeenCalledWith('dummyPodmanCli', [
+      'machine',
+      'ssh',
+      'dummyMachine',
+      'stat',
+      expect.anything(),
+    ]);
+  });
+});
+
+describe('deleteRemoteModel', () => {
+  test('execute stat on targeted machine', async () => {
+    await deleteRemoteModel('dummyMachine', {
+      id: 'dummyModelId',
+      file: {
+        path: 'dummyPath',
+        file: 'dummy.guff',
+      },
+    } as unknown as ModelInfo);
+
+    expect(getPodmanCli).toHaveBeenCalled();
+    expect(apiProcess.exec).toHaveBeenCalledWith('dummyPodmanCli', [
+      'machine',
+      'ssh',
+      'dummyMachine',
+      'rm',
+      '-f',
+      expect.anything(),
+    ]);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

On windows we have a WSL Uploader, which makes the models possibly available on the podman machine.

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/6dafb91e-c472-4521-9659-0d010b3fbf28

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/635

### How to test this PR?

- [x] unit tests has been provided

#### **manually**

**windows**
- (1) download a model
- (2) start an inference server to ensure it is uploaded on the Podman Machine
- (3) stop the inference server
- (4) delete the model from the models page

**mac&linux**
- (1) download a model
- (2) delete a model
