### PR TITLE
rename title to "Playground Environments"

### DIFF
--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -23,7 +23,7 @@ export let meta: TinroRouteMeta;
 
     <SettingsNavItem title="Models" href="/models" bind:meta="{meta}" />
 
-    <SettingsNavItem title="Playground" href="/playgrounds" bind:meta="{meta}" />
+    <SettingsNavItem title="Playgrounds" href="/playgrounds" bind:meta="{meta}" />
 
     <SettingsNavItem title="Model Services" href="/services" bind:meta="{meta}" />
 

--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -22,7 +22,7 @@ function createNewPlayground() {
 }
 </script>
 
-<NavPage title="Playgrounds environments" searchEnabled="{false}">
+<NavPage title="Playground Environments" searchEnabled="{false}">
   <svelte:fragment slot="additional-actions">
     <Button on:click="{() => createNewPlayground()}">New Playground</Button>
   </svelte:fragment>
@@ -34,7 +34,7 @@ function createNewPlayground() {
             <Table kind="playground" data="{$playgrounds}" columns="{columns}" row="{row}"></Table>
           {:else}
             <div role="status">
-              There is no playground environment for now. You can <a
+              There is no playground environment. You can <a
                 href="{'javascript:void(0);'}"
                 class="underline"
                 role="button"


### PR DESCRIPTION
### What does this PR do?
"Playgrounds environments" needed an apostrophe and capitalization.
Also remove the "for now" to avoid repetition of "now" and rename
the tile in the navigation bar to "Playgrounds" for consistency with
the breadcrumbs etc.

### Screenshot / video of UI

![Screenshot 2024-03-27 at 10 36 06](https://github.com/containers/podman-desktop-extension-ai-lab/assets/11679875/64b1fb22-f7d3-47c5-a546-305c9822196a)
