### PR TITLE
fix: remove breadcrumb from playgrounds page

### DIFF
--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -22,9 +22,7 @@ function createNewPlayground() {
 }
 </script>
 
-<NavPage
-  title="Playgrounds environments"
-  searchEnabled="{false}">
+<NavPage title="Playgrounds environments" searchEnabled="{false}">
   <svelte:fragment slot="additional-actions">
     <Button on:click="{() => createNewPlayground()}">New Playground</Button>
   </svelte:fragment>

--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -23,7 +23,6 @@ function createNewPlayground() {
 </script>
 
 <NavPage
-  lastPage="{{ name: 'Playgrounds', path: '/playgrounds' }}"
   title="Playgrounds environments"
   searchEnabled="{false}">
   <svelte:fragment slot="additional-actions">


### PR DESCRIPTION
### What does this PR do?

There was a useless breadcrumb as shown below 
![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/c857074b-35b1-4d1e-ad85-35ecb2142342)

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/711

### How to test this PR?

<!-- Please explain steps to reproduce -->