### PR TITLE
feat: adding hidden utility class to experiment with GPU

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,13 +33,7 @@
           "icon": "${brain-icon}"
         }
       ]
-    },
-    "commands": [
-      {
-        "command": "ai-lab.gpu.collect",
-        "title": "AI-Lab: Collect GPU(s)"
-      }
-    ]
+    }
   },
   "scripts": {
     "build": "vite build",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,7 +33,13 @@
           "icon": "${brain-icon}"
         }
       ]
-    }
+    },
+    "commands": [
+      {
+        "command": "ai-lab.gpu.collect",
+        "title": "AI-Lab: Collect GPU(s)"
+      }
+    ]
   },
   "scripts": {
     "build": "vite build",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -44,6 +44,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
+    "fast-xml-parser": "^4.3.6",
     "mustache": "^4.2.0",
     "openai": "^4.29.2",
     "postman-code-generators": "^1.9.0",

--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -16,9 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { expect, test, vi, beforeEach } from 'vitest';
-import {
-  containerEngine,
-  env} from '@podman-desktop/api';
+import { containerEngine, env } from '@podman-desktop/api';
 import type {
   ContainerInspectInfo,
   type ContainerProviderConnection,

--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -83,6 +83,7 @@ beforeEach(() => {
         timestamp: 4,
         gpu: {
           uuid: 'dummyUUID',
+          product_name: 'dummyProductName',
         },
       },
     }),
@@ -103,13 +104,17 @@ test('non-windows host should throw error', async () => {
   }).rejects.toThrowError('Cannot collect GPUs information on this machine.');
 });
 
-test('windows host should start container', async () => {
+test('windows host should start then delete container with proper configuration', async () => {
   vi.mocked(env).isWindows = true;
 
   const manager = new GPUManager(webviewMock);
-  await manager.collectGPUs({
+  const gpus = await manager.collectGPUs({
     providerId: 'dummyProviderId',
   });
+
+  expect(gpus.length).toBe(1);
+  expect(gpus[0].uuid).toBe('dummyUUID');
+  expect(gpus[0].product_name).toBe('dummyProductName');
 
   expect(getProviderContainerConnection).toHaveBeenCalledWith('dummyProviderId');
 

--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -17,11 +17,11 @@
  ***********************************************************************/
 import { expect, test, vi, beforeEach } from 'vitest';
 import { containerEngine, env } from '@podman-desktop/api';
-import {
+import type {
   ContainerInspectInfo,
-  type ContainerProviderConnection,
-  type ImageInfo,
-  type Webview,
+  ContainerProviderConnection,
+  ImageInfo,
+  Webview,
 } from '@podman-desktop/api';
 import { GPUManager } from './GPUManager';
 import { getImageInfo, getProviderContainerConnection } from '../utils/inferenceUtils';

--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -1,0 +1,124 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { expect, test, vi, beforeEach } from 'vitest';
+import {
+  containerEngine,
+  type ContainerProviderConnection,
+  env,
+  type ImageInfo,
+  type Webview,
+} from '@podman-desktop/api';
+import { GPUManager } from './GPUManager';
+import { getImageInfo, getProviderContainerConnection } from '../utils/inferenceUtils';
+import { XMLParser } from 'fast-xml-parser';
+
+vi.mock('../utils/inferenceUtils', () => ({
+  getProviderContainerConnection: vi.fn(),
+  getImageInfo: vi.fn(),
+}));
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    containerEngine: {
+      createContainer: vi.fn(),
+      logsContainer: vi.fn(),
+      deleteContainer: vi.fn(),
+    },
+    env: {
+      isWindows: false,
+    },
+  };
+});
+
+vi.mock('fast-xml-parser', () => ({
+  XMLParser: vi.fn(),
+}));
+
+const webviewMock = {
+  postMessage: vi.fn(),
+} as unknown as Webview;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(webviewMock.postMessage).mockResolvedValue(undefined);
+
+  vi.mocked(getProviderContainerConnection).mockReturnValue({
+    providerId: 'dummyProviderId',
+    connection: {} as unknown as ContainerProviderConnection,
+  });
+  vi.mocked(getImageInfo).mockResolvedValue({
+    engineId: 'dummyEngineId',
+    Id: 'dummyImageId',
+  } as unknown as ImageInfo);
+
+  vi.mocked(containerEngine.createContainer).mockResolvedValue({
+    id: 'dummyContainerId',
+  });
+
+  vi.mocked(containerEngine.logsContainer).mockImplementation(async (_engineId, _containerId, callback) => {
+    callback('', '</nvidia_smi_log>');
+  });
+
+  vi.mocked(XMLParser).mockReturnValue({
+    parse: vi.fn().mockReturnValue({
+      nvidia_smi_log: {
+        attached_gpus: 1,
+        cuda_version: 2,
+        driver_version: 3,
+        timestamp: 4,
+        gpu: {
+          uuid: 'dummyUUID',
+        },
+      },
+    }),
+  } as unknown as XMLParser);
+});
+
+test('post constructor should have no items', () => {
+  const manager = new GPUManager(webviewMock);
+  expect(manager.getAll().length).toBe(0);
+});
+
+test('non-windows host should throw error', async () => {
+  vi.mocked(env).isWindows = false;
+
+  const manager = new GPUManager(webviewMock);
+  await expect(() => {
+    return manager.collectGPUs();
+  }).rejects.toThrowError('Cannot collect GPUs information on this machine.');
+});
+
+test('windows host should start container', async () => {
+  vi.mocked(env).isWindows = true;
+
+  const manager = new GPUManager(webviewMock);
+  await manager.collectGPUs({
+    providerId: 'dummyProviderId',
+  });
+
+  expect(getProviderContainerConnection).toHaveBeenCalledWith('dummyProviderId');
+
+  expect(containerEngine.createContainer).toHaveBeenCalledWith('dummyEngineId', {
+    Image: 'dummyImageId',
+    Cmd: expect.anything(),
+    Detach: false,
+    Entrypoint: '/usr/bin/sh',
+    HostConfig: expect.anything(),
+  });
+  expect(containerEngine.deleteContainer).toHaveBeenCalledWith('dummyEngineId', 'dummyContainerId');
+});

--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import { expect, test, vi, beforeEach } from 'vitest';
 import { containerEngine, env } from '@podman-desktop/api';
-import type {
+import {
   ContainerInspectInfo,
   type ContainerProviderConnection,
   type ImageInfo,

--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -17,9 +17,11 @@
  ***********************************************************************/
 import { expect, test, vi, beforeEach } from 'vitest';
 import {
-  containerEngine, ContainerInspectInfo,
+  containerEngine,
+  env} from '@podman-desktop/api';
+import type {
+  ContainerInspectInfo,
   type ContainerProviderConnection,
-  env,
   type ImageInfo,
   type Webview,
 } from '@podman-desktop/api';
@@ -90,12 +92,12 @@ beforeEach(() => {
     }),
   } as unknown as XMLParser);
 
-  vi.mocked(containerEngine.inspectContainer).mockImplementation( async(_engineId, _id) => {
+  vi.mocked(containerEngine.inspectContainer).mockImplementation(async (_engineId, _id) => {
     return {
       State: {
         Running: false,
         ExitCode: 0,
-      }
+      },
     } as unknown as ContainerInspectInfo;
   });
 });

--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -17,12 +17,7 @@
  ***********************************************************************/
 import { expect, test, vi, beforeEach } from 'vitest';
 import { containerEngine, env } from '@podman-desktop/api';
-import type {
-  ContainerInspectInfo,
-  ContainerProviderConnection,
-  ImageInfo,
-  Webview,
-} from '@podman-desktop/api';
+import type { ContainerInspectInfo, ContainerProviderConnection, ImageInfo, Webview } from '@podman-desktop/api';
 import { GPUManager } from './GPUManager';
 import { getImageInfo, getProviderContainerConnection } from '../utils/inferenceUtils';
 import { XMLParser } from 'fast-xml-parser';

--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import { expect, test, vi, beforeEach } from 'vitest';
 import {
-  containerEngine,
+  containerEngine, ContainerInspectInfo,
   type ContainerProviderConnection,
   env,
   type ImageInfo,
@@ -38,6 +38,7 @@ vi.mock('@podman-desktop/api', async () => {
       createContainer: vi.fn(),
       logsContainer: vi.fn(),
       deleteContainer: vi.fn(),
+      inspectContainer: vi.fn(),
     },
     env: {
       isWindows: false,
@@ -88,6 +89,15 @@ beforeEach(() => {
       },
     }),
   } as unknown as XMLParser);
+
+  vi.mocked(containerEngine.inspectContainer).mockImplementation( async(_engineId, _id) => {
+    return {
+      State: {
+        Running: false,
+        ExitCode: 0,
+      }
+    } as unknown as ContainerInspectInfo;
+  });
 });
 
 test('post constructor should have no items', () => {

--- a/packages/backend/src/managers/GPUManager.ts
+++ b/packages/backend/src/managers/GPUManager.ts
@@ -1,0 +1,118 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { containerEngine, type Disposable, type Webview, type ImageInfo, type PullEvent } from '@podman-desktop/api';
+import { getImageInfo, getProviderContainerConnection } from '../utils/inferenceUtils';
+import { XMLParser } from 'fast-xml-parser';
+import type { IGPUInfo } from '@shared/src/models/IGPUInfo';
+import { Publisher } from '../utils/Publisher';
+import { Messages } from '@shared/Messages';
+
+export const CUDA_11_7_IMAGES = 'nvcr.io/nvidia/cuda:11.7.0-base-ubuntu20.04';
+
+/**
+ * @experimental
+ */
+export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
+  // Map uuid -> info
+  #gpus: Map<string, IGPUInfo>;
+
+  constructor(webview: Webview) {
+    super(webview, Messages.MSG_GPUS_UPDATE, () => this.getAll());
+    this.#gpus = new Map();
+  }
+  dispose(): void {
+    this.#gpus.clear();
+  }
+
+  getAll(): IGPUInfo[] {
+    return Array.from(this.#gpus.values());
+  }
+
+  async collectGPUs(options?: { providerId: string }): Promise<void> {
+    const provider = getProviderContainerConnection(options?.providerId);
+    const imageInfo: ImageInfo = await getImageInfo(provider.connection, CUDA_11_7_IMAGES, (_event: PullEvent) => {});
+
+    console.log('getGPUs createContainer');
+    const result = await containerEngine.createContainer(
+      imageInfo.engineId,
+      {
+        Image: imageInfo.Id,
+        Detach: false,
+        HostConfig: {
+          AutoRemove: false,
+          Mounts: [
+            {
+              Target: '/usr/lib/wsl',
+              Source: '/usr/lib/wsl',
+              Type: 'bind',
+            },
+          ],
+          DeviceRequests: [{
+            Capabilities: [['gpu']],
+            Count: -1, // -1: all
+          }],
+          Devices: [{
+            PathOnHost: '/dev/dxg',
+            PathInContainer: '/dev/dxg',
+            CgroupPermissions: 'r',
+          }],
+        },
+        Cmd: ['bash', '-c', '/usr/bin/ln -s /usr/lib/wsl/lib/* /usr/lib/x86_64-linux-gnu/ && PATH="${PATH}:/usr/lib/wsl/lib/" && nvidia-smi -x -q'],
+      },
+    );
+
+    try {
+      const logs = await this.getLogs(imageInfo.engineId, result.id);
+      const parsed: {
+        nvidia_smi_log: {
+          attached_gpus: number,
+          cuda_version: number,
+          driver_version: number,
+          timestamp: string,
+          gpu: IGPUInfo,
+        }
+      } = new XMLParser().parse(logs);
+
+      if(parsed.nvidia_smi_log.attached_gpus > 1)
+        throw new Error('machine with more than one GPU are not supported.');
+
+      this.#gpus.set(parsed.nvidia_smi_log.gpu.uuid, parsed.nvidia_smi_log.gpu);
+      this.notify();
+    } finally {
+      await containerEngine.deleteContainer(imageInfo.engineId, result.id);
+    }
+  }
+
+  private getLogs(engineId: string, containerId: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const interval = setTimeout(() => {
+        reject(new Error('timeout'));
+      }, 10000);
+
+      let logs = '';
+      containerEngine.logsContainer(engineId, containerId, (name, data) => {
+        logs += data;
+        if(data.includes('</nvidia_smi_log>')) {
+          clearTimeout(interval);
+          resolve(logs);
+        }
+      }).catch(reject);
+    });
+  }
+
+}

--- a/packages/backend/src/managers/GPUManager.ts
+++ b/packages/backend/src/managers/GPUManager.ts
@@ -22,7 +22,7 @@ import type { IGPUInfo } from '@shared/src/models/IGPUInfo';
 import { Publisher } from '../utils/Publisher';
 import { Messages } from '@shared/Messages';
 
-export const CUDA_11_7_IMAGES = 'nvcr.io/nvidia/cuda:11.7.0-base-ubuntu20.04';
+export const CUDA_UBI8_IMAGE = 'nvcr.io/nvidia/cuda:12.3.2-devel-ubi8';
 
 /**
  * @experimental
@@ -45,7 +45,7 @@ export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
 
   async collectGPUs(options?: { providerId: string }): Promise<void> {
     const provider = getProviderContainerConnection(options?.providerId);
-    const imageInfo: ImageInfo = await getImageInfo(provider.connection, CUDA_11_7_IMAGES, (_event: PullEvent) => {});
+    const imageInfo: ImageInfo = await getImageInfo(provider.connection, CUDA_UBI8_IMAGE, (_event: PullEvent) => {});
 
     console.log('getGPUs createContainer');
     const result = await containerEngine.createContainer(
@@ -72,7 +72,8 @@ export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
             CgroupPermissions: 'r',
           }],
         },
-        Cmd: ['bash', '-c', '/usr/bin/ln -s /usr/lib/wsl/lib/* /usr/lib/x86_64-linux-gnu/ && PATH="${PATH}:/usr/lib/wsl/lib/" && nvidia-smi -x -q'],
+        Entrypoint: '/usr/bin/sh',
+        Cmd: ['-c', '/usr/bin/ln -s /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && nvidia-smi -x -q'],
       },
     );
 

--- a/packages/backend/src/managers/GPUManager.ts
+++ b/packages/backend/src/managers/GPUManager.ts
@@ -135,16 +135,19 @@ export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
 
         retry++;
 
-        containerEngine.inspectContainer(engineId, containerId).then(inspectInfo => {
-          if (inspectInfo.State.Running) return;
+        containerEngine
+          .inspectContainer(engineId, containerId)
+          .then(inspectInfo => {
+            if (inspectInfo.State.Running) return;
 
-          clearInterval(interval);
-          resolve(inspectInfo.State.ExitCode);
-        }).catch((err: unknown) => {
-          console.error('Something went wrong while trying to inspect container', err);
-          clearInterval(interval);
-          reject(new Error(`Failed to inspect container ${containerId}.`));
-        })
+            clearInterval(interval);
+            resolve(inspectInfo.State.ExitCode);
+          })
+          .catch((err: unknown) => {
+            console.error('Something went wrong while trying to inspect container', err);
+            clearInterval(interval);
+            reject(new Error(`Failed to inspect container ${containerId}.`));
+          });
       }, 2000);
     });
   }

--- a/packages/backend/src/managers/GPUManager.ts
+++ b/packages/backend/src/managers/GPUManager.ts
@@ -140,7 +140,11 @@ export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
 
           clearInterval(interval);
           resolve(inspectInfo.State.ExitCode);
-        });
+        }).catch((err: unknown) => {
+          console.error('Something went wrong while trying to inspect container', err);
+          clearInterval(interval);
+          reject(new Error(`Failed to inspect container ${containerId}.`));
+        })
       }, 2000);
     });
   }

--- a/packages/backend/src/managers/GPUManager.ts
+++ b/packages/backend/src/managers/GPUManager.ts
@@ -65,8 +65,7 @@ export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
     );
 
     const exitCode = await this.waitForExit(imageInfo.engineId, result.id);
-    if(exitCode !== 0)
-      throw new Error(`nvidia CUDA Container exited with code ${exitCode}.`);
+    if (exitCode !== 0) throw new Error(`nvidia CUDA Container exited with code ${exitCode}.`);
 
     try {
       const logs = await this.getLogs(imageInfo.engineId, result.id);
@@ -129,21 +128,20 @@ export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
     return new Promise<number>((resolve, reject) => {
       let retry = 0;
       const interval = setInterval(() => {
-        if(retry === 3) {
-          reject('timeout: container never exited.');
+        if (retry === 3) {
+          reject(new Error('timeout: container never exited.'));
           return;
         }
 
         retry++;
 
-        containerEngine.inspectContainer(engineId, containerId).then((inspectInfo) => {
-          if(inspectInfo.State.Running)
-            return;
+        containerEngine.inspectContainer(engineId, containerId).then(inspectInfo => {
+          if (inspectInfo.State.Running) return;
 
           clearInterval(interval);
           resolve(inspectInfo.State.ExitCode);
         });
-      }, 2000)
+      }, 2000);
     });
   }
 

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -71,6 +71,9 @@ vi.mock('@podman-desktop/api', async () => {
       onDidUpdateContainerConnection: vi.fn(),
       getContainerConnections: mocks.getContainerConnections,
     },
+    commands: {
+      registerCommand: vi.fn(),
+    },
     Disposable: {
       create: vi.fn(),
     },

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { Uri, window, env, commands } from '@podman-desktop/api';
+import { Uri, window, env } from '@podman-desktop/api';
 import type {
   ExtensionContext,
   TelemetryLogger,
@@ -40,7 +40,6 @@ import { LocalRepositoryRegistry } from './registries/LocalRepositoryRegistry';
 import { InferenceManager } from './managers/inference/inferenceManager';
 import { PlaygroundV2Manager } from './managers/playgroundV2Manager';
 import { SnippetManager } from './managers/SnippetManager';
-import { GPUManager } from './managers/GPUManager';
 
 // TODO: Need to be configured
 export const AI_LAB_FOLDER = path.join('podman-desktop', 'ai-lab');
@@ -124,26 +123,6 @@ export class Studio {
 
     const podmanConnection = new PodmanConnection();
     const taskRegistry = new TaskRegistry(this.#panel.webview);
-
-    const gpuManager = new GPUManager(this.#panel.webview);
-    this.#extensionContext.subscriptions.push(
-      commands.registerCommand(AI_LAB_COLLECT_GPU_COMMAND, () => {
-        gpuManager
-          .collectGPUs()
-          .then(gpus => {
-            if (gpus.length === 0) {
-              return window.showInformationMessage(`No GPU was found on this machine.`);
-            } else {
-              return window.showInformationMessage(
-                `Found ${gpus.length} device(s): ${gpus.map(gpu => gpu.product_name).join(', ')}`,
-              );
-            }
-          })
-          .catch((err: unknown) => {
-            return window.showErrorMessage(`Something went wrong while collecting GPUs: ${String(err)}`);
-          });
-      }),
-    );
 
     // Create catalog manager, responsible for loading the catalog files and watching for changes
     this.catalogManager = new CatalogManager(this.#panel.webview, appUserDirectory);

--- a/packages/shared/src/models/IGPUInfo.ts
+++ b/packages/shared/src/models/IGPUInfo.ts
@@ -16,16 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum Messages {
-  MSG_NEW_CATALOG_STATE = 'new-catalog-state',
-  MSG_TASKS_UPDATE = 'tasks-update',
-  MSG_NEW_MODELS_STATE = 'new-models-state',
-  MSG_APPLICATIONS_STATE_UPDATE = 'applications-state-update',
-  MSG_LOCAL_REPOSITORY_UPDATE = 'local-repository-update',
-  MSG_INFERENCE_SERVERS_UPDATE = 'inference-servers-update',
-  MSG_MONITORING_UPDATE = 'monitoring-update',
-  MSG_SUPPORTED_LANGUAGES_UPDATE = 'supported-languages-supported',
-  MSG_CONVERSATIONS_UPDATE = 'conversations-update',
-  MSG_PLAYGROUNDS_V2_UPDATE = 'playgrounds-v2-update',
-  MSG_GPUS_UPDATE = 'gpus-update',
+export interface IGPUInfo {
+  uuid: string;
+  product_name: string,
+  product_brand: string,
+  product_architecture: string,
+  fb_memory_usage: {
+    total: string,
+    used: string,
+    free: string,
+  },
+  temperature: {
+    gpu_temp: string,
+    gpu_temp_max_threshold: string,
+    gpu_temp_slow_threshold: string,
+  }
 }

--- a/packages/shared/src/models/IGPUInfo.ts
+++ b/packages/shared/src/models/IGPUInfo.ts
@@ -18,17 +18,17 @@
 
 export interface IGPUInfo {
   uuid: string;
-  product_name: string,
-  product_brand: string,
-  product_architecture: string,
+  product_name: string;
+  product_brand: string;
+  product_architecture: string;
   fb_memory_usage: {
-    total: string,
-    used: string,
-    free: string,
-  },
+    total: string;
+    used: string;
+    free: string;
+  };
   temperature: {
-    gpu_temp: string,
-    gpu_temp_max_threshold: string,
-    gpu_temp_slow_threshold: string,
-  }
+    gpu_temp: string;
+    gpu_temp_max_threshold: string;
+    gpu_temp_slow_threshold: string;
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2015,6 +2015,13 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-xml-parser@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz#190f9d99097f0c8f2d3a0e681a10404afca052ff"
+  integrity sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==
+  dependencies:
+    strnum "^1.0.5"
+
 fastq@^1.6.0:
   version "1.15.0"
   resolved "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz"
@@ -3938,6 +3945,11 @@ strip-literal@^2.0.0:
   integrity sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==
   dependencies:
     js-tokens "^8.0.2"
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 sucrase@^3.32.0:
   version "3.35.0"


### PR DESCRIPTION
### What does this PR do?

This PR is adding an hidden, experimental manager called `GPUManager`. This class is responsible to detect if GPUs are available on the host machine.

We cannot rely on host configuration, and need to create a container, mounting properly the expected devices, especially in WSL, then to detect the gpus a container can access to. 

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/60d48b77-9a16-4052-a76d-4417727617b2

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

> hint: run `podman pull nvcr.io/nvidia/cuda:12.3.2-devel-ubi8` before, as this can take a looooot of time.

- (1) Open the command palette (F1)
- (2) Select the `AI-Lab: Collect GPU(s)`.
- (3) Wait for the notification popup 