### PR TITLE
feat: add local cloned repo link and delete action (#402)

### DIFF
--- a/packages/backend/src/registries/LocalRepositoryRegistry.spec.ts
+++ b/packages/backend/src/registries/LocalRepositoryRegistry.spec.ts
@@ -84,7 +84,7 @@ test('should notify webview when unregister', async () => {
   );
   vi.spyOn(fs.promises, 'rm').mockResolvedValue();
   localRepositories.register({ path: 'random', labels: { 'recipe-id': 'random' } });
-  await localRepositories.unregister('random');
+  await localRepositories.deleteLocalRepository('random');
 
   expect(mocks.postMessageMock).toHaveBeenLastCalledWith({
     id: Messages.MSG_LOCAL_REPOSITORY_UPDATE,
@@ -101,7 +101,7 @@ test('should register localRepo if it find the folder of the recipe', () => {
     '/appUserDirectory',
   );
   const registerMock = vi.spyOn(localRepositories, 'register');
-  localRepositories.loadLocalRecipeRepositories([
+  localRepositories.init([
     {
       id: 'recipe',
     } as unknown as Recipe,
@@ -122,7 +122,7 @@ test('should NOT register localRepo if it does not find the folder of the recipe
     '/appUserDirectory',
   );
   const registerMock = vi.spyOn(localRepositories, 'register');
-  localRepositories.loadLocalRecipeRepositories([
+  localRepositories.init([
     {
       id: 'recipe',
     } as unknown as Recipe,

--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -155,20 +155,22 @@ test('requestRemoveApplication should ask confirmation', async () => {
   expect(mocks.deleteApplicationMock).toHaveBeenCalled();
 });
 
-test('requestDeleteLocalRepo should ask confirmation', async () => {
+test('requestDeleteLocalRepository should ask confirmation', async () => {
   mocks.showWarningMessageMock.mockResolvedValue('Confirm');
-  const unregisterMock = vi.spyOn(localRepositoryRegistry, 'unregister').mockResolvedValue();
-  await studioApiImpl.requestDeleteLocalRepo('path');
+  const deleteLocalRepositoryMock = vi.spyOn(localRepositoryRegistry, 'deleteLocalRepository').mockResolvedValue();
+  await studioApiImpl.requestDeleteLocalRepository('path');
   await timeout(0);
-  expect(unregisterMock).toHaveBeenCalled();
+  expect(deleteLocalRepositoryMock).toHaveBeenCalled();
 });
 
-test('if requestDeleteLocalRepo fails an errorMessage should show up', async () => {
+test('if requestDeleteLocalRepository fails an errorMessage should show up', async () => {
   mocks.showWarningMessageMock.mockResolvedValue('Confirm');
-  const unregisterMock = vi.spyOn(localRepositoryRegistry, 'unregister').mockRejectedValue('error deleting');
+  const deleteLocalRepositoryMock = vi
+    .spyOn(localRepositoryRegistry, 'deleteLocalRepository')
+    .mockRejectedValue('error deleting');
   const errorMessageMock = vi.spyOn(window, 'showErrorMessage').mockResolvedValue('');
-  await studioApiImpl.requestDeleteLocalRepo('path');
+  await studioApiImpl.requestDeleteLocalRepository('path');
   await timeout(0);
-  expect(unregisterMock).toHaveBeenCalled();
+  expect(deleteLocalRepositoryMock).toHaveBeenCalled();
   expect(errorMessageMock).toBeCalledWith('Error deleting local path "path". Error: error deleting');
 });

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -388,4 +388,25 @@ export class StudioApiImpl implements StudioAPI {
   getHostFreePort(): Promise<number> {
     return getFreeRandomPort('0.0.0.0');
   }
+
+  async requestDeleteLocalRepo(path: string): Promise<void> {
+    // Do not wait on the promise as the api would probably timeout before the user answer.
+    podmanDesktopApi.window
+      .showWarningMessage(`Delete permanently "${path}"?`, 'Confirm', 'Cancel')
+      .then((result: string) => {
+        if (result === 'Confirm') {
+          this.localRepositories.unregister(path).catch((err: unknown) => {
+            console.error(`error deleting path: ${String(err)}`);
+            podmanDesktopApi.window
+              .showErrorMessage(`Error deleting local path "${path}". Error: ${String(err)}`)
+              .catch((err: unknown) => {
+                console.error(`Something went wrong with confirmation modals`, err);
+              });
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        console.error(`Something went wrong with confirmation modals`, err);
+      });
+  }
 }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -389,13 +389,13 @@ export class StudioApiImpl implements StudioAPI {
     return getFreeRandomPort('0.0.0.0');
   }
 
-  async requestDeleteLocalRepo(path: string): Promise<void> {
+  async requestDeleteLocalRepository(path: string): Promise<void> {
     // Do not wait on the promise as the api would probably timeout before the user answer.
     podmanDesktopApi.window
       .showWarningMessage(`Delete permanently "${path}"?`, 'Confirm', 'Cancel')
       .then((result: string) => {
         if (result === 'Confirm') {
-          this.localRepositories.unregister(path).catch((err: unknown) => {
+          this.localRepositories.deleteLocalRepository(path).catch((err: unknown) => {
             console.error(`error deleting path: ${String(err)}`);
             podmanDesktopApi.window
               .showErrorMessage(`Error deleting local path "${path}". Error: ${String(err)}`)

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -134,7 +134,7 @@ export class Studio {
       taskRegistry,
     );
     const localRepositoryRegistry = new LocalRepositoryRegistry(this.#panel.webview, appUserDirectory);
-    localRepositoryRegistry.loadLocalRecipeRepositories(this.catalogManager.getRecipes());
+    localRepositoryRegistry.init(this.catalogManager.getRecipes());
     const applicationManager = new ApplicationManager(
       appUserDirectory,
       gitManager,

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -124,6 +124,8 @@ export class Studio {
 
     // Create catalog manager, responsible for loading the catalog files and watching for changes
     this.catalogManager = new CatalogManager(this.#panel.webview, appUserDirectory);
+    this.catalogManager.init();
+
     this.modelsManager = new ModelsManager(
       appUserDirectory,
       this.#panel.webview,
@@ -131,7 +133,8 @@ export class Studio {
       this.telemetry,
       taskRegistry,
     );
-    const localRepositoryRegistry = new LocalRepositoryRegistry(this.#panel.webview);
+    const localRepositoryRegistry = new LocalRepositoryRegistry(this.#panel.webview, appUserDirectory);
+    localRepositoryRegistry.loadLocalRecipeRepositories(this.catalogManager.getRecipes());
     const applicationManager = new ApplicationManager(
       appUserDirectory,
       gitManager,
@@ -181,7 +184,6 @@ export class Studio {
       snippetManager,
     );
 
-    this.catalogManager.init();
     await this.modelsManager.loadLocalModels();
     podmanConnection.init();
     applicationManager.adoptRunningApplications();

--- a/packages/frontend/src/lib/RecipeDetails.spec.ts
+++ b/packages/frontend/src/lib/RecipeDetails.spec.ts
@@ -34,7 +34,7 @@ const mocks = vi.hoisted(() => {
     getLocalRepositoriesMock: vi.fn(),
     getTasksMock: vi.fn(),
     openFileMock: vi.fn(),
-    requestDeleteLocalRepoMock: vi.fn(),
+    requestDeleteLocalRepositoryMock: vi.fn(),
   };
 });
 
@@ -44,7 +44,7 @@ vi.mock('../utils/client', async () => {
       pullApplication: mocks.pullApplicationMock,
       getApplicationsState: mocks.getApplicationsStateMock,
       openFile: mocks.openFileMock,
-      requestDeleteLocalRepo: mocks.requestDeleteLocalRepoMock,
+      requestDeleteLocalRepository: mocks.requestDeleteLocalRepositoryMock,
     },
     rpcBrowser: {
       subscribe: () => {
@@ -279,5 +279,5 @@ test('local clone and delete local clone buttons should be visible if local repo
   expect(buttonDeleteClone).toBeInTheDocument();
   await userEvent.click(buttonDeleteClone);
 
-  expect(mocks.requestDeleteLocalRepoMock).toBeCalled();
+  expect(mocks.requestDeleteLocalRepositoryMock).toBeCalled();
 });

--- a/packages/frontend/src/lib/RecipeDetails.spec.ts
+++ b/packages/frontend/src/lib/RecipeDetails.spec.ts
@@ -33,6 +33,8 @@ const mocks = vi.hoisted(() => {
     findMock: vi.fn(),
     getLocalRepositoriesMock: vi.fn(),
     getTasksMock: vi.fn(),
+    openFileMock: vi.fn(),
+    requestDeleteLocalRepoMock: vi.fn(),
   };
 });
 
@@ -41,6 +43,8 @@ vi.mock('../utils/client', async () => {
     studioClient: {
       pullApplication: mocks.pullApplicationMock,
       getApplicationsState: mocks.getApplicationsStateMock,
+      openFile: mocks.openFileMock,
+      requestDeleteLocalRepo: mocks.requestDeleteLocalRepoMock,
     },
     rpcBrowser: {
       subscribe: () => {
@@ -245,4 +249,35 @@ test('start application button should be the only one displayed', async () => {
 
   const btnRestart = screen.queryByTitle('Restart AI App');
   expect(btnRestart).toBeNull();
+});
+
+test('local clone and delete local clone buttons should be visible if local repository is not empty', async () => {
+  mocks.getApplicationsStateMock.mockResolvedValue([]);
+  mocks.getLocalRepositoriesMock.mockReturnValue([
+    {
+      path: 'random-path',
+      labels: {
+        'recipe-id': 'recipe 1',
+      },
+    },
+  ]);
+  vi.mocked(catalogStore).catalog = readable<ApplicationCatalog>(initialCatalog);
+  render(RecipeDetails, {
+    recipeId: 'recipe 1',
+    modelId: 'model2',
+  });
+
+  const buttonLocalClone = screen.getByRole('button', { name: 'Local clone' });
+  expect(buttonLocalClone).toBeDefined();
+  expect(buttonLocalClone).toBeInTheDocument();
+  await userEvent.click(buttonLocalClone);
+
+  expect(mocks.openFileMock).toBeCalled();
+
+  const buttonDeleteClone = screen.getByTitle('Delete local clone');
+  expect(buttonDeleteClone).toBeDefined();
+  expect(buttonDeleteClone).toBeInTheDocument();
+  await userEvent.click(buttonDeleteClone);
+
+  expect(mocks.requestDeleteLocalRepoMock).toBeCalled();
 });

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -74,7 +74,7 @@ const openLocalClone = () => {
 
 const deleteLocalClone = () => {
   if (localPath) {
-    studioClient.requestDeleteLocalRepo(localPath.path);
+    studioClient.requestDeleteLocalRepository(localPath.path);
   }
 };
 </script>

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faList } from '@fortawesome/free-solid-svg-icons';
+import { faFolderOpen, faList, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { getDisplayName } from '/@/utils/versionControlUtils';
 import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
@@ -65,6 +65,18 @@ function startApplication() {
     console.error('Something went wrong while pulling AI App', err);
   });
 }
+
+const openLocalClone = () => {
+  if (localPath) {
+    studioClient.openFile(localPath.path);
+  }
+};
+
+const deleteLocalClone = () => {
+  if (localPath) {
+    studioClient.requestDeleteLocalRepo(localPath.path);
+  }
+};
 </script>
 
 <div class="w-full bg-charcoal-600 rounded-md p-4">
@@ -147,15 +159,26 @@ function startApplication() {
       </div>
     </div>
   {/if}
-  <div class="flex flex-col space-y-2 w-[45px]">
+  <div class="flex flex-col w-full space-y-2 w-[45px]">
     <div class="text-base">Repository</div>
-    <div class="cursor-pointer flex text-nowrap items-center">
+    <div class="cursor-pointer flex flex-col w-full space-y-2 text-nowrap">
       <button on:click="{onClickRepository}">
-        <div class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-2">
+        <div class="flex flex-row p-0 m-0 bg-transparent items-center space-x-2">
           <Fa size="lg" icon="{faGithub}" />
           <span>{getDisplayName(recipe?.repository)}</span>
         </div>
       </button>
+      {#if localPath}
+        <div class="flex flex-row w-full justify-between">
+          <button on:click="{openLocalClone}" aria-label="Local clone">
+            <div class="flex flex-row p-0 m-0 bg-transparent items-center space-x-2">
+              <Fa size="lg" icon="{faFolderOpen}" />
+              <span>Local clone</span>
+            </div>
+          </button>
+          <Button title="Delete local clone" on:click="{deleteLocalClone}" icon="{faTrash}" />
+        </div>
+      {/if}
     </div>
   </div>
   {#if localPath}

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -160,5 +160,5 @@ export abstract class StudioAPI {
    * Delete a local path
    * @param path path to delete
    */
-  abstract requestDeleteLocalRepo(path: string): Promise<void>;
+  abstract requestDeleteLocalRepository(path: string): Promise<void>;
 }

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -155,4 +155,10 @@ export abstract class StudioAPI {
    * @param conversationId the conversation identifier that will be deleted
    */
   abstract requestDeleteConversation(conversationId: string): Promise<void>;
+
+  /**
+   * Delete a local path
+   * @param path path to delete
+   */
+  abstract requestDeleteLocalRepo(path: string): Promise<void>;
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the local clone and delete local clone buttons.
The first open the local clone repo and the delete button deletes it.

### Screenshot / video of UI

![delete_clone](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/0abcda12-98e8-427a-b3f1-6b712a9115d2)

### What issues does this PR fix or reference?

it resolves #402 

### How to test this PR?

1. open a recipe
1.1 if already started previously you should have the local cloned repo buttons already there
1.2 if a new recipe, start it and you should see the local clone buttons when the repo is downloaded