### PR TITLE
fix: open in vscode

### DIFF
--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -370,7 +370,7 @@ export class StudioApiImpl implements StudioAPI {
     const unixPath: string = path.normalize(directory).replace(/[\\/]+/g, '/');
 
     podmanDesktopApi.env
-      .openExternal(podmanDesktopApi.Uri.parse(unixPath).with({ scheme: 'vscode', authority: 'file' }))
+      .openExternal(podmanDesktopApi.Uri.file(unixPath).with({ scheme: 'vscode', authority: 'file' }))
       .catch((err: unknown) => {
         console.error('Something went wrong while trying to open VSCode', err);
       });


### PR DESCRIPTION
### What does this PR do?

Replaces Uri.parse(path) with Uri.file(path) as path does not contain a scheme, which is mandatory with parse

### What issues does this PR fix or reference?


Fixes #726 

### How to test this PR?

Start a recipe and click on 'open in vscode'