### PR TITLE
fix: show error if create playground/service actions fail

### DIFF
--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -50,7 +50,7 @@ const onContainerPortInput = (event: Event): void => {
 
 // Submit method when the form is valid
 const submit = async () => {
-  errorMsg = '';
+  errorMsg = undefined;
   const model: ModelInfo | undefined = localModels.find(model => model.id === modelId);
   if (model === undefined) throw new Error('model id not valid.');
   if (containerPort === undefined) throw new Error('invalid container port');

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -23,7 +23,7 @@ let containerPort: number | undefined = undefined;
 // The modelId is the bind value to form input
 let modelId: string | undefined = undefined;
 // If the creation of a new inference service fail
-let errorMsg = '';
+let errorMsg: string | undefined = undefined;
 
 // The tracking id is a unique identifier provided by the
 // backend when calling requestCreateInferenceServer

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -167,7 +167,7 @@ onMount(async () => {
             name="containerPort"
             required />
         </div>
-        {#if errorMsg}
+        {#if errorMsg !== undefined}
           <ErrorMessage error="{errorMsg}" />
         {/if}
         <footer>

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -12,6 +12,7 @@ import { tasks } from '/@/stores/tasks';
 import type { Task } from '@shared/src/models/ITask';
 import { filterByLabel } from '/@/utils/taskUtils';
 import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
+import ErrorMessage from '../lib/ErrorMessage.svelte';
 
 // List of the models available locally
 let localModels: ModelInfo[];
@@ -21,6 +22,8 @@ $: localModels = $modelsInfo.filter(model => model.file);
 let containerPort: number | undefined = undefined;
 // The modelId is the bind value to form input
 let modelId: string | undefined = undefined;
+// If the creation of a new inference service fail
+let errorMsg = '';
 
 // The tracking id is a unique identifier provided by the
 // backend when calling requestCreateInferenceServer
@@ -47,6 +50,7 @@ const onContainerPortInput = (event: Event): void => {
 
 // Submit method when the form is valid
 const submit = async () => {
+  errorMsg = '';
   const model: ModelInfo | undefined = localModels.find(model => model.id === modelId);
   if (model === undefined) throw new Error('model id not valid.');
   if (containerPort === undefined) throw new Error('invalid container port');
@@ -60,6 +64,7 @@ const submit = async () => {
   } catch (err: unknown) {
     trackingId = undefined;
     console.error('Something wrong while trying to create the inference server.', err);
+    errorMsg = String(err);
   }
 };
 
@@ -162,6 +167,9 @@ onMount(async () => {
             name="containerPort"
             required />
         </div>
+        {#if errorMsg}
+          <ErrorMessage error="{errorMsg}" />
+        {/if}
         <footer>
           <div class="w-full flex flex-col">
             {#if containerId === undefined}

--- a/packages/frontend/src/pages/PlaygroundCreate.spec.ts
+++ b/packages/frontend/src/pages/PlaygroundCreate.spec.ts
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+import { studioClient } from '../utils/client';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { writable } from 'svelte/store';
+import userEvent from '@testing-library/user-event';
+import * as tasksStore from '/@/stores/tasks';
+import * as modelsInfoStore from '/@/stores/modelsInfo';
+import type { Task } from '@shared/src/models/ITask';
+import PlaygroundCreate from './PlaygroundCreate.svelte';
+
+vi.mock('../utils/client', async () => {
+  return {
+    studioClient: {
+      requestCreatePlayground: vi.fn(),
+    },
+    rpcBrowser: {
+      subscribe: () => {
+        return {
+          unsubscribe: () => {},
+        };
+      },
+    },
+  };
+});
+
+vi.mock('/@/stores/tasks', async () => {
+  return {
+    tasks: vi.fn(),
+  };
+});
+
+vi.mock('/@/stores/modelsInfo', async () => {
+  return {
+    modelsInfo: vi.fn(),
+  };
+});
+
+test('should display error message if createPlayground fails', async () => {
+  const tasksList = writable<Task[]>([]);
+  vi.mocked(tasksStore).tasks = tasksList;
+
+  const modelsInfoList = writable<ModelInfo[]>([
+    {
+      id: 'id',
+      file: {
+        file: 'file',
+        path: '/tmp/path',
+      },
+    } as unknown as ModelInfo,
+  ]);
+  vi.mocked(modelsInfoStore).modelsInfo = modelsInfoList;
+
+  vi.mocked(studioClient.requestCreatePlayground).mockRejectedValue('error creating playground');
+
+  render(PlaygroundCreate);
+
+  const errorMessage = screen.queryByLabelText('Error message');
+  expect(errorMessage).not.toBeInTheDocument();
+
+  const createButton = screen.getByTitle('Create playground');
+  await userEvent.click(createButton);
+
+  const errorMessageAfterSubmit = screen.queryByLabelText('Error message');
+  expect(errorMessageAfterSubmit).toBeInTheDocument();
+  expect(errorMessageAfterSubmit?.textContent).equal('error creating playground');
+});

--- a/packages/frontend/src/pages/PlaygroundCreate.spec.ts
+++ b/packages/frontend/src/pages/PlaygroundCreate.spec.ts
@@ -74,13 +74,13 @@ test('should display error message if createPlayground fails', async () => {
 
   render(PlaygroundCreate);
 
-  const errorMessage = screen.queryByLabelText('Error message');
+  const errorMessage = screen.queryByLabelText('Error Message Content');
   expect(errorMessage).not.toBeInTheDocument();
 
   const createButton = screen.getByTitle('Create playground');
   await userEvent.click(createButton);
 
-  const errorMessageAfterSubmit = screen.queryByLabelText('Error message');
+  const errorMessageAfterSubmit = screen.queryByLabelText('Error Message Content');
   expect(errorMessageAfterSubmit).toBeInTheDocument();
   expect(errorMessageAfterSubmit?.textContent).equal('error creating playground');
 });

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -22,7 +22,7 @@ let modelId: string | undefined = undefined;
 let systemPrompt: string | undefined = undefined;
 let submitted: boolean = false;
 let playgroundName: string;
-let errorMsg = '';
+let errorMsg: string | undefined = undefined;
 
 // The tracking id is a unique identifier provided by the
 // backend when calling requestCreateInferenceServer

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -21,6 +21,7 @@ let modelId: string | undefined = undefined;
 let systemPrompt: string | undefined = undefined;
 let submitted: boolean = false;
 let playgroundName: string;
+let errorMsg = '';
 
 // The tracking id is a unique identifier provided by the
 // backend when calling requestCreateInferenceServer
@@ -51,6 +52,7 @@ function onNameInput(event: Event) {
 }
 
 async function submit() {
+  errorMsg = '';
   const model: ModelInfo | undefined = localModels.find(model => model.id === modelId);
   if (model === undefined) throw new Error('model id not valid.');
   // disable submit button
@@ -61,6 +63,8 @@ async function submit() {
   } catch (err: unknown) {
     trackingId = undefined;
     console.error('Something wrong while trying to create the playground.', err);
+    errorMsg = String(err);
+    submitted = false;
   }
 }
 
@@ -178,6 +182,9 @@ onDestroy(() => {
             placeholder="Optionally provide system prompt to define general context, instructions or guidelines to be used with each query"
           ></textarea>
         </div>
+        {#if errorMsg}
+          <div aria-label="Error message" class="text-red-500 text-sm">{errorMsg}</div>
+        {/if}
         <footer>
           <div class="w-full flex flex-col">
             <Button

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -13,6 +13,7 @@ import TasksProgress from '../lib/progress/TasksProgress.svelte';
 import { tasks } from '../stores/tasks';
 import { filterByLabel } from '../utils/taskUtils';
 import type { Unsubscriber } from 'svelte/store';
+import ErrorMessage from '../lib/ErrorMessage.svelte';
 
 let localModels: ModelInfo[];
 $: localModels = $modelsInfo.filter(model => model.file);
@@ -183,7 +184,7 @@ onDestroy(() => {
           ></textarea>
         </div>
         {#if errorMsg}
-          <div aria-label="Error message" class="text-red-500 text-sm">{errorMsg}</div>
+          <ErrorMessage error="{errorMsg}" />
         {/if}
         <footer>
           <div class="w-full flex flex-col">

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -53,7 +53,7 @@ function onNameInput(event: Event) {
 }
 
 async function submit() {
-  errorMsg = '';
+  errorMsg = undefined;
   const model: ModelInfo | undefined = localModels.find(model => model.id === modelId);
   if (model === undefined) throw new Error('model id not valid.');
   // disable submit button

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -183,7 +183,7 @@ onDestroy(() => {
             placeholder="Optionally provide system prompt to define general context, instructions or guidelines to be used with each query"
           ></textarea>
         </div>
-        {#if errorMsg}
+        {#if errorMsg !== undefined}
           <ErrorMessage error="{errorMsg}" />
         {/if}
         <footer>


### PR DESCRIPTION
### What does this PR do?

It shows the error message if the create playground action fails and re-enable the button

### Screenshot / video of UI

![show_error_create_playground](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/34c606bd-deec-4591-8d92-4aa6fa9793cc)

### What issues does this PR fix or reference?

it fixes #334 

### How to test this PR?

1. run test or make the `requestCreatePlayground` fails somehow (e.g update code to throw) and see if the error is displayed and you're able to click again the button 