### PR TITLE
feat: disable send prompt when model not served + display status

### DIFF
--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -86,9 +86,11 @@ function getStatusText(status?: string, health?: string): string {
     case 'running':
       switch (health) {
         case 'healthy':
-          return 'Model Service healthy';
+          return 'Model Service running';
+        case 'starting':
+          return 'Model Service starting';
         default:
-          return 'Model Service not healthy';
+          return 'Model Service not running';
       }
     default:
       return 'Model Service not running';


### PR DESCRIPTION
### What does this PR do?

- in the playground page, displays the status of the model server. 
-  if the server model is not running/healthy, the 'send prompt' button is disabled and the tooltip indicates the status of the server.

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/307d806a-0021-495a-8063-bf4a0c26a03d

### What issues does this PR fix or reference?

Fixes #646

### How to test this PR?

- Start a playground on a model with no server running and check the model server is marked as not healthy
- stop a model server, and check that is is displayed as not running on a related playground