### PR TITLE
feat: adding regenerate button for assistant chats

### DIFF
--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -22,14 +22,14 @@ import type { ChatCompletionChunk, ChatCompletionMessageParam } from 'openai/src
 import type { ModelOptions } from '@shared/src/models/IModelOptions';
 import type { Stream } from 'openai/streaming';
 import { ConversationRegistry } from '../registries/conversationRegistry';
-import {
+import type {
   Conversation,
-  isAssistantChat,
   PendingChat,
   SystemPrompt,
-  UserChat,
-} from '@shared/src/models/IPlaygroundMessage';
-import { isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
+  UserChat} from '@shared/src/models/IPlaygroundMessage';
+import {
+  isAssistantChat
+ isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
 import type { PlaygroundV2 } from '@shared/src/models/IPlaygroundV2';
 import { Publisher } from '../utils/Publisher';
 import { Messages } from '@shared/Messages';
@@ -37,7 +37,7 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { withDefaultConfiguration } from '../utils/inferenceUtils';
 import { getRandomString } from '../utils/randomUtils';
 import type { TaskRegistry } from '../registries/TaskRegistry';
-import { InferenceServer } from '@shared/src/models/IInference';
+import type { InferenceServer } from '@shared/src/models/IInference';
 
 export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Disposable {
   #playgrounds: Map<string, PlaygroundV2>;
@@ -196,11 +196,9 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
     if (conversation === undefined) throw new Error(`conversation with id ${conversationId} does not exist.`);
 
     const messageIndex = conversation.messages.findIndex(message => message.id === messageId);
-    if(messageIndex === -1)
-      throw new Error(`Cannot find a message with id ${messageId} to regenerate.`);
+    if (messageIndex === -1) throw new Error(`Cannot find a message with id ${messageId} to regenerate.`);
 
-    if(!isAssistantChat(conversation.messages[messageIndex]))
-      throw new Error('Only assistant chat can be replayed.');
+    if (!isAssistantChat(conversation.messages[messageIndex])) throw new Error('Only assistant chat can be replayed.');
 
     this.#conversationRegistry.removeMessages(
       conversationId,

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -22,14 +22,8 @@ import type { ChatCompletionChunk, ChatCompletionMessageParam } from 'openai/src
 import type { ModelOptions } from '@shared/src/models/IModelOptions';
 import type { Stream } from 'openai/streaming';
 import { ConversationRegistry } from '../registries/conversationRegistry';
-import type {
-  Conversation,
-  PendingChat,
-  SystemPrompt,
-  UserChat} from '@shared/src/models/IPlaygroundMessage';
-import {
-  isAssistantChat
- isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
+import type { Conversation, PendingChat, SystemPrompt, UserChat } from '@shared/src/models/IPlaygroundMessage';
+import { isAssistantChat, isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
 import type { PlaygroundV2 } from '@shared/src/models/IPlaygroundV2';
 import { Publisher } from '../utils/Publisher';
 import { Messages } from '@shared/Messages';

--- a/packages/backend/src/registries/conversationRegistry.ts
+++ b/packages/backend/src/registries/conversationRegistry.ts
@@ -46,18 +46,18 @@ export class ConversationRegistry extends Publisher<Conversation[]> implements D
   }
 
   /**
-   * Remove a message from a conversation
+   * Remove messages from a conversation
    * @param conversationId
-   * @param messageId
+   * @param messageIds
    */
-  removeMessage(conversationId: string, messageId: string) {
+  removeMessages(conversationId: string, ...messageIds: string[]) {
     const conversation = this.#conversations.get(conversationId);
 
     if (conversation === undefined) {
       throw new Error(`conversation with id ${conversationId} does not exist.`);
     }
 
-    conversation.messages = conversation.messages.filter(message => message.id !== messageId);
+    conversation.messages = conversation.messages.filter(message => !messageIds.includes(message.id));
     this.notify();
   }
 

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -87,8 +87,12 @@ export class StudioApiImpl implements StudioAPI {
     return this.playgroundV2.getPlaygrounds();
   }
 
-  submitPlaygroundMessage(containerId: string, userInput: string, options?: ModelOptions): Promise<void> {
-    return this.playgroundV2.submit(containerId, userInput, options);
+  submitPlaygroundMessage(conversationId: string, userInput: string, options?: ModelOptions): Promise<void> {
+    return this.playgroundV2.submit(conversationId, userInput, options);
+  }
+
+  requestRegeneratePlaygroundMessage(conversationId: string, messageId: string, options?: ModelOptions): Promise<void> {
+    return this.playgroundV2.regenerate(conversationId, messageId, options);
   }
 
   async setPlaygroundSystemPrompt(conversationId: string, content: string | undefined): Promise<void> {

--- a/packages/frontend/src/lib/conversation/ChatMessage.spec.ts
+++ b/packages/frontend/src/lib/conversation/ChatMessage.spec.ts
@@ -17,24 +17,16 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { expect, test, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import ChatMessage from '/@/lib/conversation/ChatMessage.svelte';
 import type { AssistantChat } from '@shared/src/models/IPlaygroundMessage';
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.useFakeTimers();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
 });
 
 test('assistant message should show elapsed time', () => {
-  const date = new Date(2000, 0, 0, 0);
-  vi.setSystemTime(date);
-
   render(ChatMessage, {
     disabled: false,
     onRegenerate: vi.fn(),
@@ -42,14 +34,15 @@ test('assistant message should show elapsed time', () => {
       id: 'dummyId',
       content: 'dummyContent',
       role: 'assistant',
-      timestamp: 0,
+      timestamp: 5000,
       choices: [],
+      completed: 10000,
     } as AssistantChat,
   });
 
   const elapsed = screen.getByLabelText('elapsed');
   expect(elapsed).toBeInTheDocument();
-  expect(elapsed.textContent).toBe('946594800.0 s');
+  expect(elapsed.textContent).toBe('5.0 s');
 });
 
 test('clicking on regenerate should call onRegenerate', async () => {

--- a/packages/frontend/src/lib/conversation/ChatMessage.spec.ts
+++ b/packages/frontend/src/lib/conversation/ChatMessage.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import ChatMessage from '/@/lib/conversation/ChatMessage.svelte';
+import type { AssistantChat } from '@shared/src/models/IPlaygroundMessage';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('assistant message should show elapsed time', () => {
+  const date = new Date(2000, 0, 0, 0);
+  vi.setSystemTime(date);
+
+  render(ChatMessage, {
+    disabled: false,
+    onRegenerate: vi.fn(),
+    message: {
+      id: 'dummyId',
+      content: 'dummyContent',
+      role: 'assistant',
+      timestamp: 0,
+      choices: [],
+    } as AssistantChat,
+  });
+
+  const elapsed = screen.getByLabelText('elapsed');
+  expect(elapsed).toBeInTheDocument();
+  expect(elapsed.textContent).toBe('946594800.0 s');
+});
+
+test('clicking on regenerate should call onRegenerate', async () => {
+  const onRegenerateMock = vi.fn();
+
+  render(ChatMessage, {
+    disabled: false,
+    onRegenerate: onRegenerateMock,
+    message: {
+      id: 'dummyId',
+      content: 'dummyContent',
+      role: 'assistant',
+      timestamp: 0,
+      choices: [],
+    } as AssistantChat,
+  });
+
+  const regenerateBtn = screen.getByTitle('Regenerate');
+  expect(regenerateBtn).toBeInTheDocument();
+
+  await fireEvent.click(regenerateBtn);
+
+  expect(onRegenerateMock).toHaveBeenCalledWith('dummyId');
+});

--- a/packages/frontend/src/lib/conversation/ChatMessage.svelte
+++ b/packages/frontend/src/lib/conversation/ChatMessage.svelte
@@ -11,6 +11,7 @@ import Fa from 'svelte-fa';
 import { faRotateRight } from '@fortawesome/free-solid-svg-icons';
 
 export let message: ChatMessage;
+export let disabled: boolean;
 export let onRegenerate: (messageId: string) => void;
 
 const roles = {
@@ -64,7 +65,11 @@ function elapsedTime(msg: AssistantChat): string {
   </div>
   {#if isAssistantChat(message)}
     <div class="flex w-full justify-end items-center gap-x-2">
-      <button on:click={() => onRegenerate(message.id)} title="Regenerate"><Fa icon="{faRotateRight}"/></button>
+      <button
+        class:text-gray-900="{disabled}"
+        disabled="{disabled}"
+        on:click="{() => onRegenerate(message.id)}"
+        title="Regenerate"><Fa icon="{faRotateRight}" /></button>
       <div class="text-sm text-gray-400 text-right" aria-label="elapsed">
         {elapsedTime(message)} s
       </div>

--- a/packages/frontend/src/lib/conversation/ChatMessage.svelte
+++ b/packages/frontend/src/lib/conversation/ChatMessage.svelte
@@ -7,8 +7,11 @@ import {
   isSystemPrompt,
   isUserChat,
 } from '@shared/src/models/IPlaygroundMessage';
+import Fa from 'svelte-fa';
+import { faRotateRight } from '@fortawesome/free-solid-svg-icons';
 
 export let message: ChatMessage;
+export let onRegenerate: (messageId: string) => void;
 
 const roles = {
   system: 'System prompt',
@@ -60,8 +63,11 @@ function elapsedTime(msg: AssistantChat): string {
     {/each}
   </div>
   {#if isAssistantChat(message)}
-    <div class="text-sm text-gray-400 text-right" aria-label="elapsed">
-      {elapsedTime(message)} s
+    <div class="flex w-full justify-end items-center gap-x-2">
+      <button on:click={() => onRegenerate(message.id)} title="Regenerate"><Fa icon="{faRotateRight}"/></button>
+      <div class="text-sm text-gray-400 text-right" aria-label="elapsed">
+        {elapsedTime(message)} s
+      </div>
     </div>
   {/if}
   <div></div>

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -76,11 +76,12 @@ async function scrollToBottom(element: Element) {
 function onRegenerate(messageId: string): void {
   errorMsg = '';
   sendEnabled = false;
-  studioClient.requestRegeneratePlaygroundMessage(playgroundId, messageId, {
-    temperature,
-    max_tokens,
-    top_p,
-  })
+  studioClient
+    .requestRegeneratePlaygroundMessage(playgroundId, messageId, {
+      temperature,
+      max_tokens,
+      top_p,
+    })
     .catch((err: unknown) => {
       errorMsg = String(err);
       sendEnabled = true;
@@ -152,7 +153,7 @@ function getSendPromptTitle(sendEnabled: boolean, status?: string, health?: stri
                     <ul>
                       {#each messages as message}
                         <li>
-                          <ChatMessage onRegenerate="{onRegenerate}" message="{message}" />
+                          <ChatMessage disabled="{!sendEnabled}" onRegenerate="{onRegenerate}" message="{message}" />
                         </li>
                       {/each}
                     </ul>

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -73,6 +73,20 @@ async function scrollToBottom(element: Element) {
   element.scroll?.({ top: element.scrollHeight, behavior: 'smooth' });
 }
 
+function onRegenerate(messageId: string): void {
+  errorMsg = '';
+  sendEnabled = false;
+  studioClient.requestRegeneratePlaygroundMessage(playgroundId, messageId, {
+    temperature,
+    max_tokens,
+    top_p,
+  })
+    .catch((err: unknown) => {
+      errorMsg = String(err);
+      sendEnabled = true;
+    });
+}
+
 function isHealthy(status?: string, health?: string): boolean {
   return status === 'running' && (!health || health === 'healthy');
 }
@@ -138,7 +152,7 @@ function getSendPromptTitle(sendEnabled: boolean, status?: string, health?: stri
                     <ul>
                       {#each messages as message}
                         <li>
-                          <ChatMessage message="{message}" />
+                          <ChatMessage onRegenerate="{onRegenerate}" message="{message}" />
                         </li>
                       {/each}
                     </ul>

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -112,13 +112,20 @@ export abstract class StudioAPI {
 
   /**
    * Submit a user input to the Playground linked to a conversation, model, and inference server
-   * @param containerId the container id of the inference server we want to use
-   * @param modelId the model to use
+   * @param conversationId the id of the conversation
    * @param conversationId the conversation to input the message in
    * @param userInput the user input, e.g. 'What is the capital of France ?'
    * @param options the options for the model, e.g. temperature
    */
-  abstract submitPlaygroundMessage(containerId: string, userInput: string, options?: ModelOptions): Promise<void>;
+  abstract submitPlaygroundMessage(conversationId: string, userInput: string, options?: ModelOptions): Promise<void>;
+
+  /**
+   * Regenerate an assistant message with the model options
+   * @param conversationId the id of the conversation where the message is listed
+   * @param messageId the id of the message
+   * @param options the new options to apply
+   */
+  abstract requestRegeneratePlaygroundMessage(conversationId: string, messageId: string, options?: ModelOptions): Promise<void>;
 
   /**
    * Given a conversation, update the system prompt.

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -125,7 +125,11 @@ export abstract class StudioAPI {
    * @param messageId the id of the message
    * @param options the new options to apply
    */
-  abstract requestRegeneratePlaygroundMessage(conversationId: string, messageId: string, options?: ModelOptions): Promise<void>;
+  abstract requestRegeneratePlaygroundMessage(
+    conversationId: string,
+    messageId: string,
+    options?: ModelOptions,
+  ): Promise<void>;
 
   /**
    * Given a conversation, update the system prompt.


### PR DESCRIPTION
### What does this PR do?

Adding a `regenerate` button bellow the assistant message. Allowing to regenerate an assistant message using current parameters.

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/a0727f69-c3c0-4780-b987-c5b3814630e7

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/735

### How to test this PR?

- [x] unit tests has been provided

**manually**

- Start a playground
- Ask stuff to the assistant
- Use the regenerate button