### PR TITLE
feat: making tasks cancellable

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -42,6 +42,7 @@ import type {
   startupHandle,
 } from './podmanConnection';
 import { TaskRegistry } from '../registries/TaskRegistry';
+import type { CancellationTokenRegistry } from '../registries/CancellationTokenRegistry';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -233,6 +234,9 @@ describe('pullApplication', () => {
       } as CatalogManager,
       telemetryLogger,
       new TaskRegistry({ postMessage: vi.fn().mockResolvedValue(undefined) } as unknown as Webview),
+      {
+        createCancellationTokenSource: vi.fn(),
+      } as unknown as CancellationTokenRegistry,
     );
     manager = new ApplicationManager(
       '/home/user/aistudio',

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -26,6 +26,7 @@ import type { CatalogManager } from './catalogManager';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import * as utils from '../utils/utils';
 import { TaskRegistry } from '../registries/TaskRegistry';
+import type { CancellationTokenRegistry } from '../registries/CancellationTokenRegistry';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -79,6 +80,10 @@ vi.mock('../utils/downloader', () => ({
     getTarget = mocks.getTargetMock;
   },
 }));
+
+const cancellationTokenRegistryMock = {
+    createCancellationTokenSource: vi.fn(),
+} as unknown as CancellationTokenRegistry;
 
 let taskRegistry: TaskRegistry;
 
@@ -166,6 +171,7 @@ test('getModelsInfo should get models in local directory', async () => {
     } as CatalogManager,
     telemetryLogger,
     taskRegistry,
+    cancellationTokenRegistryMock,
   );
   await manager.loadLocalModels();
   expect(manager.getModelsInfo()).toEqual([
@@ -212,6 +218,7 @@ test('getModelsInfo should return an empty array if the models folder does not e
     } as CatalogManager,
     telemetryLogger,
     taskRegistry,
+    cancellationTokenRegistryMock,
   );
   manager.getLocalModelsFromDisk();
   expect(manager.getModelsInfo()).toEqual([]);
@@ -249,6 +256,7 @@ test('getLocalModelsFromDisk should return undefined Date and size when stat fai
     } as CatalogManager,
     telemetryLogger,
     taskRegistry,
+    cancellationTokenRegistryMock,
   );
   await manager.loadLocalModels();
   expect(manager.getModelsInfo()).toEqual([
@@ -305,6 +313,7 @@ test('getLocalModelsFromDisk should skip folders containing tmp files', async ()
     } as CatalogManager,
     telemetryLogger,
     taskRegistry,
+    cancellationTokenRegistryMock,
   );
   await manager.loadLocalModels();
   expect(manager.getModelsInfo()).toEqual([
@@ -342,6 +351,7 @@ test('loadLocalModels should post a message with the message on disk and on cata
     } as CatalogManager,
     telemetryLogger,
     taskRegistry,
+    cancellationTokenRegistryMock,
   );
   await manager.loadLocalModels();
   expect(postMessageMock).toHaveBeenNthCalledWith(1, {
@@ -388,6 +398,7 @@ test('deleteModel deletes the model folder', async () => {
     } as CatalogManager,
     telemetryLogger,
     taskRegistry,
+    cancellationTokenRegistryMock,
   );
   await manager.loadLocalModels();
   await manager.deleteModel('model-id-1');
@@ -447,6 +458,7 @@ describe('deleting models', () => {
       } as CatalogManager,
       telemetryLogger,
       taskRegistry,
+      cancellationTokenRegistryMock,
     );
     await manager.loadLocalModels();
     await manager.deleteModel('model-id-1');
@@ -512,6 +524,7 @@ describe('deleting models', () => {
       } as CatalogManager,
       telemetryLogger,
       taskRegistry,
+      cancellationTokenRegistryMock,
     );
 
     await manager.loadLocalModels();
@@ -558,6 +571,7 @@ describe('deleting models', () => {
       } as CatalogManager,
       telemetryLogger,
       taskRegistry,
+      cancellationTokenRegistryMock,
     );
 
     await manager.loadLocalModels();
@@ -570,6 +584,7 @@ describe('deleting models', () => {
 
 describe('downloadModel', () => {
   test('download model if not already on disk', async () => {
+    vi.mocked(cancellationTokenRegistryMock.createCancellationTokenSource).mockReturnValue(99);
     const manager = new ModelsManager(
       'appdir',
       {} as Webview,
@@ -580,6 +595,7 @@ describe('downloadModel', () => {
       } as CatalogManager,
       telemetryLogger,
       taskRegistry,
+      cancellationTokenRegistryMock,
     );
 
     vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(false);
@@ -590,6 +606,8 @@ describe('downloadModel', () => {
       url: 'url',
       name: 'name',
     } as ModelInfo);
+
+    expect(cancellationTokenRegistryMock.createCancellationTokenSource).toHaveBeenCalled();
     expect(updateTaskMock).toHaveBeenLastCalledWith({
       id: expect.any(String),
       name: 'Downloading model name',
@@ -597,6 +615,7 @@ describe('downloadModel', () => {
         'model-pulling': 'id',
       },
       state: 'loading',
+      cancellationToken: 99,
     });
   });
   test('retrieve model path if already on disk', async () => {
@@ -610,6 +629,7 @@ describe('downloadModel', () => {
       } as CatalogManager,
       telemetryLogger,
       taskRegistry,
+      cancellationTokenRegistryMock,
     );
     const updateTaskMock = vi.spyOn(taskRegistry, 'updateTask');
     vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(true);
@@ -642,6 +662,7 @@ describe('downloadModel', () => {
       } as CatalogManager,
       telemetryLogger,
       taskRegistry,
+      cancellationTokenRegistryMock,
     );
 
     vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(false);
@@ -677,6 +698,7 @@ describe('downloadModel', () => {
       } as CatalogManager,
       telemetryLogger,
       taskRegistry,
+      cancellationTokenRegistryMock,
     );
 
     vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(false);

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -82,7 +82,7 @@ vi.mock('../utils/downloader', () => ({
 }));
 
 const cancellationTokenRegistryMock = {
-    createCancellationTokenSource: vi.fn(),
+  createCancellationTokenSource: vi.fn(),
 } as unknown as CancellationTokenRegistry;
 
 let taskRegistry: TaskRegistry;

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -705,14 +705,19 @@ describe('downloadModel', () => {
     vi.spyOn(utils, 'getDurationSecondsSince').mockReturnValue(99);
 
     mocks.onEventDownloadMock.mockImplementation(listener => {
-      listener({
-        id: 'id',
-        status: 'completed',
-        duration: 1000,
-      });
+      setTimeout(() => {
+        listener({
+          id: 'id',
+          status: 'completed',
+          duration: 1000,
+        });
+      }, 1000);
+      return {
+        dispose: vi.fn(),
+      };
     });
 
-    await manager.requestDownloadModel({
+    void manager.requestDownloadModel({
       id: 'id',
       url: 'url',
       name: 'name',

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -295,6 +295,9 @@ export class ModelsManager implements Disposable {
         this.sendModelsInfo().catch((err: unknown) => {
           console.error('Something went wrong while sending models info.', err);
         });
+
+        // cleanup downloader
+        this.#downloaders.delete(event.id);
       }
       this.taskRegistry.updateTask(task); // update task
     });

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -229,7 +229,7 @@ export class ModelsManager implements Disposable {
     }
 
     // Propagate cancellation token from existing task to the new one
-    task.cancellationToken = this.taskRegistry.findTaskByLabels({'model-pulling': model.id})?.cancellationToken;
+    task.cancellationToken = this.taskRegistry.findTaskByLabels({ 'model-pulling': model.id })?.cancellationToken;
     this.taskRegistry.updateTask(task);
 
     // If we have an existing downloader running we subscribe on its events

--- a/packages/backend/src/registries/CancellationTokenRegistry.spec.ts
+++ b/packages/backend/src/registries/CancellationTokenRegistry.spec.ts
@@ -85,3 +85,11 @@ test('disposing registry should dispose with cancel all tokens', () => {
   expect(source.cancel).toHaveBeenCalled();
   expect(source.dispose).toHaveBeenCalled();
 });
+
+test('creating cancellation token with function should register it', () => {
+  const registry = new CancellationTokenRegistry();
+  const func = vi.fn();
+  const source = registry.getCancellationTokenSource(registry.createCancellationTokenSource(func));
+
+  expect(source.token.onCancellationRequested).toHaveBeenCalledWith(func);
+});

--- a/packages/backend/src/registries/CancellationTokenRegistry.ts
+++ b/packages/backend/src/registries/CancellationTokenRegistry.ts
@@ -35,7 +35,7 @@ export class CancellationTokenRegistry implements Disposable {
     this.#callbackId++;
 
     const token = new CancellationTokenSource();
-    if(func !== undefined) {
+    if (func !== undefined) {
       token.token.onCancellationRequested(func);
     }
 

--- a/packages/backend/src/registries/CancellationTokenRegistry.ts
+++ b/packages/backend/src/registries/CancellationTokenRegistry.ts
@@ -26,11 +26,18 @@ export class CancellationTokenRegistry implements Disposable {
     this.#callbacksCancellableToken = new Map<number, CancellationTokenSource>();
   }
 
-  createCancellationTokenSource(): number {
+  /**
+   * Creating a cancellation token.
+   * @param func an optional function that will be called when the cancel action will be triggered
+   */
+  createCancellationTokenSource(func?: () => void): number {
     // keep track of this request
     this.#callbackId++;
 
     const token = new CancellationTokenSource();
+    if(func !== undefined) {
+      token.token.onCancellationRequested(func);
+    }
 
     // store the callback that will resolve the promise
     this.#callbacksCancellableToken.set(this.#callbackId, token);

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -139,6 +139,7 @@ export class Studio {
       this.catalogManager,
       this.telemetry,
       taskRegistry,
+      cancellationTokenRegistry,
     );
     const localRepositoryRegistry = new LocalRepositoryRegistry(this.#panel.webview, appUserDirectory);
     localRepositoryRegistry.init(this.catalogManager.getRecipes());

--- a/packages/frontend/src/lib/progress/TaskItem.spec.ts
+++ b/packages/frontend/src/lib/progress/TaskItem.spec.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import TaskItem from '/@/lib/progress/TaskItem.svelte';
+import { studioClient } from '/@/utils/client';
+
+vi.mock('../../utils/client', async () => {
+  return {
+    studioClient: {
+      requestCancelToken: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(studioClient.requestCancelToken).mockResolvedValue(undefined);
+})
+
+test('Task item should no show cancel button if no cancellation token provided', async () => {
+  // render the component
+  render(TaskItem, {
+    task: {
+    name: 'dummyName',
+      state: 'loading',
+      id: 'dummyId',
+    }
+  });
+
+  const cancelBtn = screen.queryByTitle('Cancel');
+  expect(cancelBtn).toBeNull();
+});
+
+test('Task item should no show cancel button if state not loading', async () => {
+  // render the component
+  render(TaskItem, {
+    task: {
+      name: 'dummyName',
+      state: 'success',
+      id: 'dummyId',
+      cancellationToken: 1,
+    }
+  });
+
+  const cancelBtn = screen.queryByTitle('Cancel');
+  expect(cancelBtn).toBeNull();
+});
+
+test('Task item should show cancel button if state loading and cancellation token provided', async () => {
+  // render the component
+  render(TaskItem, {
+    task: {
+      name: 'dummyName',
+      state: 'loading',
+      id: 'dummyId',
+      cancellationToken: 1,
+    }
+  });
+
+  const cancelBtn = screen.getByTitle('Cancel');
+  expect(cancelBtn).toBeDefined();
+
+  await fireEvent.click(cancelBtn);
+
+  expect(studioClient.requestCancelToken).toHaveBeenCalledWith(1);
+});

--- a/packages/frontend/src/lib/progress/TaskItem.spec.ts
+++ b/packages/frontend/src/lib/progress/TaskItem.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 import { test, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { render, screen, fireEvent } from '@testing-library/svelte';
 import TaskItem from '/@/lib/progress/TaskItem.svelte';
 import { studioClient } from '/@/utils/client';
 
@@ -33,16 +33,16 @@ vi.mock('../../utils/client', async () => {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(studioClient.requestCancelToken).mockResolvedValue(undefined);
-})
+});
 
 test('Task item should no show cancel button if no cancellation token provided', async () => {
   // render the component
   render(TaskItem, {
     task: {
-    name: 'dummyName',
+      name: 'dummyName',
       state: 'loading',
       id: 'dummyId',
-    }
+    },
   });
 
   const cancelBtn = screen.queryByTitle('Cancel');
@@ -57,7 +57,7 @@ test('Task item should no show cancel button if state not loading', async () => 
       state: 'success',
       id: 'dummyId',
       cancellationToken: 1,
-    }
+    },
   });
 
   const cancelBtn = screen.queryByTitle('Cancel');
@@ -72,7 +72,7 @@ test('Task item should show cancel button if state loading and cancellation toke
       state: 'loading',
       id: 'dummyId',
       cancellationToken: 1,
-    }
+    },
   });
 
   const cancelBtn = screen.getByTitle('Cancel');

--- a/packages/frontend/src/lib/progress/TaskItem.svelte
+++ b/packages/frontend/src/lib/progress/TaskItem.svelte
@@ -7,12 +7,12 @@ import { studioClient } from '/@/utils/client';
 export let task: Task;
 
 const cancel = () => {
-  if(task.cancellationToken !== undefined) {
+  if (task.cancellationToken !== undefined) {
     studioClient.requestCancelToken(task.cancellationToken).catch((err: unknown) => {
       console.error('Something went wrong while trying to cancel token', err);
-    })
+    });
   }
-}
+};
 </script>
 
 <div class="flex flex-row items-center">
@@ -61,7 +61,7 @@ const cancel = () => {
   </span>
   <div class="flex flex-grow justify-end">
     {#if task.state === 'loading' && task.cancellationToken !== undefined}
-      <button on:click={cancel} title="Cancel"><Fa icon="{faClose}"/></button>
+      <button on:click="{cancel}" title="Cancel"><Fa icon="{faClose}" /></button>
     {/if}
   </div>
 </div>

--- a/packages/frontend/src/lib/progress/TaskItem.svelte
+++ b/packages/frontend/src/lib/progress/TaskItem.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
 import type { Task } from '@shared/src/models/ITask';
+import Fa from 'svelte-fa';
+import { faClose } from '@fortawesome/free-solid-svg-icons';
+import { studioClient } from '/@/utils/client';
 
 export let task: Task;
+
+const cancel = () => {
+  if(task.cancellationToken !== undefined) {
+    studioClient.requestCancelToken(task.cancellationToken).catch((err: unknown) => {
+      console.error('Something went wrong while trying to cancel token', err);
+    })
+  }
+}
 </script>
 
 <div class="flex flex-row items-center">
@@ -48,4 +59,9 @@ export let task: Task;
     {task.name}
     {#if task.progress}({Math.floor(task.progress)}%){/if}
   </span>
+  <div class="flex flex-grow justify-end">
+    {#if task.state === 'loading' && task.cancellationToken !== undefined}
+      <button on:click={cancel} title="Cancel"><Fa icon="{faClose}"/></button>
+    {/if}
+  </div>
 </div>

--- a/packages/frontend/src/lib/progress/TasksProgress.spec.ts
+++ b/packages/frontend/src/lib/progress/TasksProgress.spec.ts
@@ -17,9 +17,17 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { test, expect, describe } from 'vitest';
+import { test, expect, describe, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
+
+vi.mock('../../utils/client', async () => {
+  return {
+    studioClient: {
+      requestCancelToken: vi.fn(),
+    },
+  };
+});
 
 test('TasksProgress should not renderer any tasks', async () => {
   // render the component

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -99,7 +99,7 @@ onMount(() => {
           {#if !loading}
             {#if pullingTasks.length > 0}
               <Card classes="bg-charcoal-800 mt-4">
-                <div slot="content" class="text-base font-normal p-2">
+                <div slot="content" class="text-base font-normal p-2 w-full">
                   <div class="text-base mb-2">Downloading models</div>
                   <TasksProgress tasks="{pullingTasks}" />
                 </div>

--- a/packages/frontend/src/utils/client.ts
+++ b/packages/frontend/src/utils/client.ts
@@ -39,3 +39,5 @@ export const getRouterState = (): RouterState => {
   if (isRouterState(state)) return state;
   return { url: '/' };
 };
+
+(window as any).studioClient = studioClient;

--- a/packages/shared/src/models/ITask.ts
+++ b/packages/shared/src/models/ITask.ts
@@ -25,4 +25,5 @@ export interface Task {
   state: TaskState;
   progress?: number;
   labels?: { [id: string]: string };
+  cancellationToken?: number;
 }


### PR DESCRIPTION
### What does this PR do?

This PR is the continuity of https://github.com/containers/podman-desktop-extension-ai-lab/pull/725. It adds the `cancellationToken` to the Task object.

This allow the frontend to call `studioClient.requestCancelToken` on user action.

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/0b85edea-946e-4b6c-8eed-af2ba7232861

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/520

### How to test this PR?

- [x] unit tests has been provided