### PR TITLE
fix: display status of recipe/model

### DIFF
--- a/packages/frontend/src/lib/RecipeDetails.spec.ts
+++ b/packages/frontend/src/lib/RecipeDetails.spec.ts
@@ -281,3 +281,50 @@ test('local clone and delete local clone buttons should be visible if local repo
 
   expect(mocks.requestDeleteLocalRepositoryMock).toBeCalled();
 });
+
+test('should display app state for default model when model is the recommended', async () => {
+  mocks.getApplicationsStateMock.mockResolvedValue([
+    {
+      recipeId: 'recipe 1',
+      modelId: 'model1',
+      pod: {
+        Name: 'pod1',
+        Status: 'Running',
+      },
+    },
+  ]);
+  vi.mocked(catalogStore).catalog = readable<ApplicationCatalog>(initialCatalog);
+  render(RecipeDetails, {
+    recipeId: 'recipe 1',
+    modelId: 'model1',
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+  const appStatus = screen.getByLabelText('app-status');
+  expect(appStatus.textContent).toContain('RUNNING');
+  expect(appStatus.textContent).toContain('pod1');
+});
+
+test('should display app state for other model when model is not the recommended', async () => {
+  mocks.getApplicationsStateMock.mockResolvedValue([
+    {
+      recipeId: 'recipe 1',
+      modelId: 'model1',
+      pod: {
+        Name: 'pod1',
+        Status: 'Running',
+      },
+    },
+  ]);
+  vi.mocked(catalogStore).catalog = readable<ApplicationCatalog>(initialCatalog);
+  render(RecipeDetails, {
+    recipeId: 'recipe 1',
+    modelId: 'model2',
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+  const appStatus = screen.queryByLabelText('app-status');
+  expect(appStatus).not.toBeInTheDocument();
+  const btnRunApplication = screen.getByText('Start AI App');
+  expect(btnRunApplication).toBeInTheDocument();
+});

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -23,7 +23,7 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 export let recipeId: string;
 export let modelId: string;
 
-$: appState = $applicationStates.find((app: ApplicationState) => app.recipeId === recipeId);
+$: appState = $applicationStates.find((app: ApplicationState) => app.recipeId === recipeId && app.modelId === modelId);
 $: recipe = $catalog.recipes.find(r => r.id === recipeId);
 
 $: filteredTasks = filterByLabel($tasks, {

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -82,7 +82,7 @@ const deleteLocalClone = () => {
 <div class="w-full bg-charcoal-600 rounded-md p-4">
   <div class="flex flex-row items-center">
     {#if appState && appState.pod}
-      <div class="grow flex overflow-hidden whitespace-nowrap items-center">
+      <div class="grow flex overflow-hidden whitespace-nowrap items-center" aria-label="app-status">
         <a title="Navigate to Pod details" href="{'javascript:void(0);'}" on:click="{navigateToPod}">
           <StatusIcon size="{22}" status="{appState.pod.Status.toUpperCase()}" icon="{PodIcon}" />
         </a>


### PR DESCRIPTION
### What does this PR do?

Display the state of an application for a recipe AND a given model, not for the first one found for a recipe.

### Screenshot / video of UI


https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/03a6223b-6d4c-468d-99bd-d3b5e85bcf57


### What issues does this PR fix or reference?

fixes #574 

### How to test this PR?

- Start a recipe with a first model
- switch to another model, the button "Start AI App" should appear
- start the recipe with the second model
- navigating to one or other model should display the information of the running app with the selected model (for example the link should point to the good instance - check the port)