### PR TITLE
fix: model deletion

### DIFF
--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -400,7 +400,7 @@ describe('deleting models', () => {
     await manager.deleteModel('model-id-1');
     // check that the model's folder is removed from disk
     if (process.platform === 'win32') {
-      expect(rmSpy).toBeCalledWith('C:\\home\\user\\appstudio-dir\\model-id-1\\model-id-1-model');
+      expect(rmSpy).toBeCalledWith(expect.stringContaining('\\home\\user\\appstudio-dir\\model-id-1\\model-id-1-model'));
     } else {
       expect(rmSpy).toBeCalledWith('/home/user/appstudio-dir/model-id-1/model-id-1-model');
     }

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -400,7 +400,9 @@ describe('deleting models', () => {
     await manager.deleteModel('model-id-1');
     // check that the model's folder is removed from disk
     if (process.platform === 'win32') {
-      expect(rmSpy).toBeCalledWith(expect.stringContaining('\\home\\user\\appstudio-dir\\model-id-1\\model-id-1-model'));
+      expect(rmSpy).toBeCalledWith(
+        expect.stringContaining('\\home\\user\\appstudio-dir\\model-id-1\\model-id-1-model'),
+      );
     } else {
       expect(rmSpy).toBeCalledWith('/home/user/appstudio-dir/model-id-1/model-id-1-model');
     }

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -163,7 +163,7 @@ export class ModelsManager implements Disposable {
 
   async deleteModel(modelId: string): Promise<void> {
     const model = this.#models.get(modelId);
-    if(model === undefined) throw new Error('Model with id does not exist.');
+    if (model === undefined) throw new Error('Model with id does not exist.');
 
     // set state deleting
     model.state = 'deleting';


### PR DESCRIPTION
### What does this PR do?

When trying to delete a model we faced "EPERM: operation not permitted". When the deletion start, it was blocking itself trying to delete the directory with the model in it. I was not able to find exactly why there was this problem, but deleting first the file, then the directory solved the issue.

> I suspect some kind of weird behaviour with the filesystem watcher and the rm retry/force arguments.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/730

### How to test this PR?

- [x] unit tests cover the chage

**Please test manually**

#### Scenario 1

- (1) download a model
- (2) delete it

#### Scenario 2

- (1) download a model
- (2) start a recipe/model service
- (3) stop the model service/recipe
- (4) delete the mode

Please update the following after testing

- [x] Windows (Axel)
- [x] Mac (Philippe)
- [ ] Linux