### PR TITLE
feat(Model Service Details): redirect after service deletion

### DIFF
--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -23,6 +23,7 @@ import { render, screen, fireEvent } from '@testing-library/svelte';
 import CreateService from '/@/pages/CreateService.svelte';
 import type { Task } from '@shared/src/models/ITask';
 import userEvent from '@testing-library/user-event';
+import type { InferenceServer } from '@shared/src/models/IInference';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -34,6 +35,8 @@ const mocks = vi.hoisted(() => {
         return () => {};
       },
     },
+    // server store
+    getInferenceServersMock: vi.fn(),
     // tasks store
     tasksSubscribeMock: vi.fn(),
     tasksQueriesMock: {
@@ -44,6 +47,15 @@ const mocks = vi.hoisted(() => {
     },
   };
 });
+
+vi.mock('../stores/inferenceServers', () => ({
+  inferenceServers: {
+    subscribe: (f: (msg: any) => void) => {
+      f(mocks.getInferenceServersMock());
+      return () => {};
+    },
+  },
+}));
 
 vi.mock('../stores/modelsInfo', async () => {
   return {
@@ -71,6 +83,9 @@ beforeEach(() => {
 
   vi.mocked(studioClient.requestCreateInferenceServer).mockResolvedValue('dummyTrackingId');
   vi.mocked(studioClient.getHostFreePort).mockResolvedValue(8888);
+  mocks.getInferenceServersMock.mockReturnValue([
+    { container: { containerId: 'dummyContainerId' } } as InferenceServer,
+  ]);
 });
 
 test('create button should be disabled when no model id provided', async () => {

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -13,6 +13,7 @@ import type { Task } from '@shared/src/models/ITask';
 import { filterByLabel } from '/@/utils/taskUtils';
 import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
 import ErrorMessage from '../lib/ErrorMessage.svelte';
+import { inferenceServers } from '/@/stores/inferenceServers';
 
 // List of the models available locally
 let localModels: ModelInfo[];
@@ -37,6 +38,7 @@ let error: boolean = false;
 // The containerId will be included in the tasks when the creation
 // process will be completed
 let containerId: string | undefined = undefined;
+$: available = containerId && $inferenceServers.some(server => server.container.containerId);
 
 const onContainerPortInput = (event: Event): void => {
   const raw = (event.target as HTMLInputElement).value;
@@ -182,7 +184,11 @@ onMount(async () => {
                 Create service
               </Button>
             {:else}
-              <Button title="Open service details" on:click="{openServiceDetails}" icon="{faLocationArrow}">
+              <Button
+                inProgress="{!available}"
+                title="Open service details"
+                on:click="{openServiceDetails}"
+                icon="{faLocationArrow}">
                 Open service details
               </Button>
             {/if}

--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -23,6 +23,7 @@ import type { InferenceServer } from '@shared/src/models/IInference';
 import InferenceServerDetails from '/@/pages/InferenceServerDetails.svelte';
 import type { Language } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
+import { router } from 'tinro';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -148,4 +149,13 @@ test('on mount should call createSnippet', async () => {
     'curl',
     'cURL',
   );
+});
+
+test('invalid container id should redirect to services page', async () => {
+  const gotoSpy = vi.spyOn(router, 'goto');
+  render(InferenceServerDetails, {
+    containerId: 'fakeContainerId',
+  });
+
+  expect(gotoSpy).toHaveBeenCalledWith('/services');
 });

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -9,11 +9,12 @@ import type { InferenceServer } from '@shared/src/models/IInference';
 import { snippetLanguages } from '/@/stores/snippetLanguages';
 import type { LanguageVariant } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
+import { onMount } from 'svelte';
+import { router } from 'tinro';
 
 export let containerId: string | undefined = undefined;
 
-let service: InferenceServer | undefined;
-$: service = $inferenceServers.find(server => server.container.containerId === containerId);
+let service: InferenceServer | undefined = undefined;
 
 let selectedLanguage: string = 'curl';
 $: selectedLanguage;
@@ -71,6 +72,15 @@ $: {
     generate('curl', 'cURL');
   }
 }
+
+onMount(() => {
+  return inferenceServers.subscribe(servers => {
+    service = servers.find(server => server.container.containerId === containerId);
+    if (service === undefined) {
+      router.goto('/services');
+    }
+  });
+});
 </script>
 
 <NavPage lastPage="{{ name: 'Model Services', path: '/services' }}" title="Service Details" searchEnabled="{false}">


### PR DESCRIPTION
### What does this PR do?

Redirect to the services page when the Service details page is open and the service is deleted.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/744

### How to test this PR?

- [x] unit tests cover the feature