### PR TITLE
fix: models column size

### DIFF
--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -22,8 +22,8 @@ const columns: Column<ModelInfo>[] = [
   new Column<ModelInfo>('', { width: '40px', renderer: ModelColumnIcon }),
   new Column<ModelInfo>('Name', { width: '3fr', renderer: ModelColumnName }),
   new Column<ModelInfo>('Size', { width: '50px', renderer: ModelColumnSize }),
-  new Column<ModelInfo>('Age', { width: '50px', renderer: ModelColumnAge }),
-  new Column<ModelInfo>('', { width: '220px', align: 'right', renderer: ModelColumnLabels }),
+  new Column<ModelInfo>('Age', { width: '60px', renderer: ModelColumnAge }),
+  new Column<ModelInfo>('', { width: '225px', align: 'right', renderer: ModelColumnLabels }),
   new Column<ModelInfo>('Actions', { align: 'right', width: '120px', renderer: ModelColumnActions }),
 ];
 const row = new Row<ModelInfo>({});


### PR DESCRIPTION
### What does this PR do?

Increase slightly the size of the age and labels column

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/739

### How to test this PR?

Go to models page and see if labels and age are not cut in big enough screen