### PR TITLE
feat: ensuring podman desktop version is >= 1.8.0

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,6 +49,7 @@
     "openai": "^4.31.0",
     "postman-code-generators": "^1.9.0",
     "postman-collection": "^4.4.0",
+    "semver": "^7.6.0",
     "simple-git": "^3.24.0",
     "xml-js": "^1.6.11"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,7 +7,7 @@
   "publisher": "redhat",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": "^1.6.0"
+    "podman-desktop": "^1.8.0"
   },
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,7 +7,7 @@
   "publisher": "redhat",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": "^1.8.0"
+    "podman-desktop": ">=1.8.0"
   },
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -125,7 +125,7 @@ test('check activate incompatible', async () => {
   // expect the activate method to be called on the studio class
   expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {
     version: '1.7.0',
-    message: 'error activating extension on version bellow 1.8.0',
+    message: 'error activating extension on version below 1.8.0',
   });
 });
 

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -120,7 +120,7 @@ test('check activate incompatible', async () => {
   (version as string) = '1.7.0';
   await expect(async () => {
     await studio.activate();
-  }).rejects.toThrowError('Extension is not compatible with PodmanDesktop version bellow 1.8.');
+  }).rejects.toThrowError('Extension is not compatible with Podman Desktop version below 1.8.');
 
   // expect the activate method to be called on the studio class
   expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -39,6 +39,12 @@ const mocks = vi.hoisted(() => ({
   logErrorMock: vi.fn(),
 }));
 
+vi.mock('../package.json', () => ({
+  engines: {
+    'podman-desktop': '>=1.0.0',
+  },
+}));
+
 vi.mock('@podman-desktop/api', async () => {
   return {
     version: '1.8.0',
@@ -117,15 +123,15 @@ test('check activate', async () => {
 });
 
 test('check activate incompatible', async () => {
-  (version as string) = '1.7.0';
+  (version as string) = '0.7.0';
   await expect(async () => {
     await studio.activate();
-  }).rejects.toThrowError('Extension is not compatible with Podman Desktop version below 1.8.');
+  }).rejects.toThrowError('Extension is not compatible with Podman Desktop version below 1.0.0.');
 
   // expect the activate method to be called on the studio class
   expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {
-    version: '1.7.0',
-    message: 'error activating extension on version below 1.8.0',
+    version: '0.7.0',
+    message: 'error activating extension on version below 1.0.0',
   });
 });
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { Uri, window, env, version } from '@podman-desktop/api';
-import { satisfies } from 'semver';
+import { satisfies, minVersion } from 'semver';
 import type {
   ExtensionContext,
   TelemetryLogger,
@@ -72,11 +72,12 @@ export class Studio {
 
     // Ensure version is above minimum podman desktop version supported
     if (!version || !satisfies(version, engines['podman-desktop'])) {
+      const min = minVersion(engines['podman-desktop']);
       this.telemetry.logError('start.incompatible', {
         version: version,
-        message: 'error activating extension on version below 1.8.0',
+        message: `error activating extension on version below ${min.version}`,
       });
-      throw new Error('Extension is not compatible with Podman Desktop version below 1.8.');
+      throw new Error(`Extension is not compatible with Podman Desktop version below ${min.version}.`);
     }
 
     this.telemetry = env.createTelemetryLogger();

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -73,9 +73,9 @@ export class Studio {
     if (!version || lt(version, '1.8.0')) {
       this.telemetry.logError('start.incompatible', {
         version: version,
-        message: 'error activating extension on version bellow 1.8.0',
+        message: 'error activating extension on version below 1.8.0',
       });
-      throw new Error('Extension is not compatible with PodmanDesktop version bellow 1.8.');
+      throw new Error('Extension is not compatible with Podman Desktop version below 1.8.');
     }
 
     this.telemetry = env.createTelemetryLogger();

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { Uri, window, env, version } from '@podman-desktop/api';
-import { lt } from 'semver';
+import { satisfies } from 'semver';
 import type {
   ExtensionContext,
   TelemetryLogger,
@@ -42,6 +42,7 @@ import { InferenceManager } from './managers/inference/inferenceManager';
 import { PlaygroundV2Manager } from './managers/playgroundV2Manager';
 import { SnippetManager } from './managers/SnippetManager';
 import { CancellationTokenRegistry } from './registries/CancellationTokenRegistry';
+import { engines } from '../package.json';
 
 // TODO: Need to be configured
 export const AI_LAB_FOLDER = path.join('podman-desktop', 'ai-lab');
@@ -69,8 +70,8 @@ export class Studio {
     console.log('starting AI Lab extension');
     this.telemetry = env.createTelemetryLogger();
 
-    // Ensure version is above 1.8.0
-    if (!version || lt(version, '1.8.0')) {
+    // Ensure version is above minimum podman desktop version supported
+    if (!version || !satisfies(version, engines['podman-desktop'])) {
       this.telemetry.logError('start.incompatible', {
         version: version,
         message: 'error activating extension on version below 1.8.0',

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { Uri, window, env } from '@podman-desktop/api';
+import { Uri, window, env, version } from '@podman-desktop/api';
+import { lt } from 'semver';
 import type {
   ExtensionContext,
   TelemetryLogger,
@@ -66,6 +67,16 @@ export class Studio {
 
   public async activate(): Promise<void> {
     console.log('starting AI Lab extension');
+    this.telemetry = env.createTelemetryLogger();
+
+    // Ensure version is above 1.8.0
+    if (!version || lt(version, '1.8.0')) {
+      this.telemetry.logError('start.incompatible', {
+        version: version,
+        message: 'error activating extension on version bellow 1.8.0',
+      });
+      throw new Error('Extension is not compatible with PodmanDesktop version bellow 1.8.');
+    }
 
     this.telemetry = env.createTelemetryLogger();
     this.telemetry.logUsage('start');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,7 +4106,7 @@ semver@^6.2.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2:
+semver@^7.3.2, semver@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==


### PR DESCRIPTION
### What does this PR do?

This PR is adding a check for the PodmanDesktop version used. If bellow 1.8.0 we throw an error in the extension activate.

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/f14468c8-7e45-447e-9829-a27df2dbe3d1)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/765

### How to test this PR?

- [x] unit tests has been provided


**manually**

launch the extension using an old version of PodmanDesktop (E.g. 1.7.0)