### PR TITLE
fix(inference): adding missing host and port env

### DIFF
--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -63,7 +63,7 @@ describe('generateContainerCreateOptions', () => {
     expect(result).toStrictEqual({
       Cmd: ['--models-path', '/models', '--context-size', '700', '--threads', '4'],
       Detach: true,
-      Env: ['MODEL_PATH=/models/dummyFile'],
+      Env: ['MODEL_PATH=/models/dummyFile', 'HOST=0.0.0.0', 'PORT=8000'],
       ExposedPorts: {
         '8888': {},
       },

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -147,7 +147,7 @@ export function generateContainerCreateOptions(
       ...config.labels,
       [LABEL_INFERENCE_SERVER]: JSON.stringify(config.modelsInfo.map(model => model.id)),
     },
-    Env: [`MODEL_PATH=/models/${modelInfo.file.file}`],
+    Env: [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'],
     Cmd: ['--models-path', '/models', '--context-size', '700', '--threads', '4'],
   };
 }


### PR DESCRIPTION
### What does this PR do?

The default values for host/port are `0.0.0.0` and `8000`. This PR ensure those value are set manually, to avoid regression if the images change the default values.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related https://github.com/containers/podman-desktop-extension-ai-lab/issues/767

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/772

### How to test this PR?

- [x] unit tests ensure expected behaviour 