### PR TITLE
feat: enhance navigation bar

### DIFF
--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -2,7 +2,7 @@
 import SettingsNavItem from '/@/lib/SettingsNavItem.svelte';
 import type { TinroRouteMeta } from 'tinro';
 import Fa from 'svelte-fa';
-import { faBrain } from '@fortawesome/free-solid-svg-icons';
+import { faBookOpen, faBrain, faMessage, faRocket, faServer } from '@fortawesome/free-solid-svg-icons';
 
 export let meta: TinroRouteMeta;
 </script>
@@ -17,16 +17,17 @@ export let meta: TinroRouteMeta;
     </a>
   </div>
   <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
-    <SettingsNavItem title="Recipe Catalog" href="/recipes" bind:meta="{meta}" />
+    <!-- AI Apps -->
+    <span class="pl-3 text-sm text-gray-700">AI APPS</span>
+    <SettingsNavItem icon="{faBookOpen}" title="Recipes Catalog" href="/recipes" bind:meta="{meta}" />
+    <SettingsNavItem icon="{faServer}" title="Running" href="/applications" bind:meta="{meta}" />
 
-    <SettingsNavItem title="AI Apps" href="/applications" bind:meta="{meta}" />
-
-    <SettingsNavItem title="Models" href="/models" bind:meta="{meta}" />
-
-    <SettingsNavItem title="Playgrounds" href="/playgrounds" bind:meta="{meta}" />
-
-    <SettingsNavItem title="Model Services" href="/services" bind:meta="{meta}" />
-
-    <SettingsNavItem title="Preferences" href="/preferences" bind:meta="{meta}" />
+    <!-- Models -->
+    <div class="pl-3 mt-2">
+      <span class="text-sm text-gray-700">MODELS</span>
+    </div>
+    <SettingsNavItem icon="{faBookOpen}" title="Catalog" href="/models" bind:meta="{meta}" />
+    <SettingsNavItem icon="{faRocket}" title="Services" href="/services" bind:meta="{meta}" />
+    <SettingsNavItem icon="{faMessage}" title="Playgrounds" href="/playgrounds" bind:meta="{meta}" />
   </div>
 </nav>

--- a/packages/frontend/src/lib/SettingsNavItem.spec.ts
+++ b/packages/frontend/src/lib/SettingsNavItem.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { vi, test, expect, beforeEach } from 'vitest';
+import { test, expect } from 'vitest';
 import { screen, render } from '@testing-library/svelte';
 import SettingsNavItem from '/@/lib/SettingsNavItem.svelte';
 import type { TinroRouteMeta } from 'tinro';

--- a/packages/frontend/src/lib/SettingsNavItem.spec.ts
+++ b/packages/frontend/src/lib/SettingsNavItem.spec.ts
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { vi, test, expect, beforeEach } from 'vitest';
+import { screen, render } from '@testing-library/svelte';
+import SettingsNavItem from '/@/lib/SettingsNavItem.svelte';
+import type { TinroRouteMeta } from 'tinro';
+import { faBookOpen } from '@fortawesome/free-solid-svg-icons';
+
+test('should be selected', () => {
+  render(SettingsNavItem, {
+    title: 'DummyTitle',
+    href: '/dummy/path',
+    meta: {
+      url: '/dummy/path',
+    } as unknown as TinroRouteMeta,
+  });
+  const container = screen.getByLabelText('DummyTitle');
+  expect(container).toBeInTheDocument();
+  expect(container.firstElementChild).toHaveClass('border-purple-500');
+});
+
+test('should not be selected', () => {
+  render(SettingsNavItem, {
+    title: 'DummyTitle',
+    href: '/dummy/path',
+    meta: {
+      url: '/other/path',
+    } as unknown as TinroRouteMeta,
+  });
+  const container = screen.getByLabelText('DummyTitle');
+  expect(container).toBeInTheDocument();
+  expect(container.firstElementChild).toHaveClass('text-gray-400');
+});
+
+test('icon should be visible', () => {
+  render(SettingsNavItem, {
+    title: 'DummyTitle',
+    href: '/dummy/path',
+    meta: {
+      url: '/dummy/path',
+    } as unknown as TinroRouteMeta,
+    icon: faBookOpen,
+  });
+  const svg = screen.getByRole('img', { hidden: true });
+  expect(svg).toBeInTheDocument();
+});

--- a/packages/frontend/src/lib/SettingsNavItem.svelte
+++ b/packages/frontend/src/lib/SettingsNavItem.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 // Full duplicates
 import type { TinroRouteMeta } from 'tinro';
+import type { IconDefinition } from '@fortawesome/free-regular-svg-icons';
+import Fa from 'svelte-fa';
 
 export let title: string;
 export let href: string;
@@ -8,6 +10,7 @@ export let meta: TinroRouteMeta;
 export let section = false;
 export let expanded = false;
 export let child = false;
+export let icon: IconDefinition | undefined = undefined;
 
 let selected: boolean;
 $: selected = meta.url === href;
@@ -27,7 +30,7 @@ function rotate(node: unknown, { clockwise = true }) {
 
 <a class="no-underline" href="{href}" aria-label="{title}" on:click="{() => (expanded = !expanded)}">
   <div
-    class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px] border-charcoal-600"
+    class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px] border-charcoal-800"
     class:text-white="{selected}"
     class:pl-3="{!child}"
     class:pl-4="{child}"
@@ -41,7 +44,12 @@ function rotate(node: unknown, { clockwise = true }) {
     class:hover:text-gray-300="{!selected}"
     class:hover:bg-charcoal-500="{!selected}"
     class:hover:border-charcoal-500="{!selected}">
-    <span class="block group-hover:block" class:capitalize="{!child}">{title}</span>
+    <span class="group-hover:block flex flex-row items-center" class:capitalize="{!child}">
+      {#if icon}
+        <Fa class="mr-4" icon="{icon}" />
+      {/if}
+      {title}
+    </span>
     {#if section}
       <div class="px-2 relative w-4 h-4">
         {#if expanded}


### PR DESCRIPTION
### What does this PR do?

Enhancing the navigation bar following the discussion in https://github.com/containers/podman-desktop-extension-ai-lab/issues/672

- Fixing the border color resulting in weird left pixels
- Splitting in two section (AI Apps & Models)
- Adding icons

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/65e27719-341d-4e5f-884f-a194ade40ece) | ![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/3cbaacc5-4ac8-43c3-8704-c6125dcbb322) |

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/672

### How to test this PR?

- [x] unit tests has been provided