### PR TITLE
feat: allow to import local models

### DIFF
--- a/packages/backend/src/managers/catalogManager.spec.ts
+++ b/packages/backend/src/managers/catalogManager.spec.ts
@@ -172,6 +172,7 @@ test('expect to call writeFile in addLocalModelsToCatalog with catalog updated',
       size: 1,
       creation: mtimeDate,
     },
+    memory: 1,
   });
   const writeFileMock = vi.spyOn(promises, 'writeFile').mockResolvedValue();
 

--- a/packages/backend/src/managers/catalogManager.spec.ts
+++ b/packages/backend/src/managers/catalogManager.spec.ts
@@ -153,8 +153,10 @@ test('expect to call writeFile in addLocalModelsToCatalog with catalog updated',
   catalogManager.init();
   await vi.waitUntil(() => catalogManager.getRecipes().length > 0);
 
+  const mtimeDate = new Date('2024-04-03T09:51:15.766Z');
   vi.spyOn(promises, 'stat').mockResolvedValue({
     size: 1,
+    mtime: mtimeDate,
   } as Stats);
   vi.spyOn(path, 'resolve').mockReturnValue('path');
 
@@ -167,6 +169,8 @@ test('expect to call writeFile in addLocalModelsToCatalog with catalog updated',
     file: {
       path: '/root/path',
       file: 'file.gguf',
+      size: 1,
+      creation: mtimeDate,
     },
     memory: 1,
   });

--- a/packages/backend/src/managers/catalogManager.spec.ts
+++ b/packages/backend/src/managers/catalogManager.spec.ts
@@ -172,7 +172,6 @@ test('expect to call writeFile in addLocalModelsToCatalog with catalog updated',
       size: 1,
       creation: mtimeDate,
     },
-    memory: 1,
   });
   const writeFileMock = vi.spyOn(promises, 'writeFile').mockResolvedValue();
 

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -64,7 +64,16 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
   }
 
   private onCatalogUpdated(content: ApplicationCatalog): void {
+    // when reading the content on the catalog, the creation is just a string and we need to convert it back to a Date object
+    content.models
+      .filter(m => m.file?.creation)
+      .forEach(m => {
+        if (m.file?.creation) {
+          m.file.creation = new Date(m.file.creation);
+        }
+      });
     this.catalog = content;
+
     this.#catalogUpdateListeners.forEach(listener => listener());
     this.notify();
   }
@@ -123,6 +132,8 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
         file: {
           path: path.dirname(model.path),
           file: path.basename(model.path),
+          size: statFile.size,
+          creation: statFile.mtime,
         },
         memory: statFile.size,
       });

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -135,6 +135,7 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
           size: statFile.size,
           creation: statFile.mtime,
         },
+        memory: statFile.size,
       });
     }
 

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -23,7 +23,7 @@ import defaultCatalog from '../assets/ai.json';
 import type { Recipe } from '@shared/src/models/IRecipe';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { Messages } from '@shared/Messages';
-import { type Disposable, type Webview } from '@podman-desktop/api';
+import { Disposable, type Webview } from '@podman-desktop/api';
 import { JsonWatcher } from '../utils/JsonWatcher';
 import { Publisher } from '../utils/Publisher';
 import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
@@ -69,8 +69,11 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
     this.notify();
   }
 
-  onCatalogUpdate(listener: catalogUpdateHandle): void {
+  onCatalogUpdate(listener: catalogUpdateHandle): Disposable {
     this.#catalogUpdateListeners.push(listener);
+    return Disposable.create(() => {
+      this.#catalogUpdateListeners.splice(this.#catalogUpdateListeners.indexOf(listener), 1);
+    });
   }
 
   dispose(): void {

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { ApplicationCatalog } from '@shared/src/models/IApplicationCatalog';
-import fs from 'node:fs';
+import { promises } from 'node:fs';
 import path from 'node:path';
 import defaultCatalog from '../assets/ai.json';
 import type { Recipe } from '@shared/src/models/IRecipe';
@@ -111,7 +111,7 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
     const tmpCatalog: ApplicationCatalog = Object.assign({}, this.catalog);
 
     for (const model of models) {
-      const statFile = await fs.promises.stat(model.path);
+      const statFile = await promises.stat(model.path);
       tmpCatalog.models.push({
         id: model.path,
         name: model.name,
@@ -126,7 +126,7 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
     }
 
     const customCatalog = path.resolve(this.appUserDirectory, 'catalog.json');
-    return fs.promises.writeFile(customCatalog, JSON.stringify(tmpCatalog, undefined, 2), 'utf-8');
+    return promises.writeFile(customCatalog, JSON.stringify(tmpCatalog, undefined, 2), 'utf-8');
   }
 
   async removeLocalModelFromCatalog(modelId: string): Promise<void> {
@@ -136,6 +136,6 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
     tmpCatalog.models = tmpCatalog.models.filter(m => m.url !== '' && m.id !== modelId);
 
     const customCatalog = path.resolve(this.appUserDirectory, 'catalog.json');
-    return fs.promises.writeFile(customCatalog, JSON.stringify(tmpCatalog, undefined, 2), 'utf-8');
+    return promises.writeFile(customCatalog, JSON.stringify(tmpCatalog, undefined, 2), 'utf-8');
   }
 }

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -135,7 +135,6 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
           size: statFile.size,
           creation: statFile.mtime,
         },
-        memory: statFile.size,
       });
     }
 

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -39,6 +39,7 @@ import type { ModelsManager } from '../modelsManager';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { getRandomString } from '../../utils/randomUtils';
 import { basename, dirname } from 'node:path';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export class InferenceManager extends Publisher<InferenceServer[]> implements Disposable {
   // Inference server map (containerId -> InferenceServer)
@@ -363,16 +364,24 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
 
     // clean existing disposables
     this.cleanDisposables();
-    this.#servers = new Map<string, InferenceServer>(
-      filtered.map(containerInfo => {
-        let modelsId: string[] = [];
-        try {
-          modelsId = JSON.parse(containerInfo.Labels[LABEL_INFERENCE_SERVER]);
-        } catch (err: unknown) {
-          console.error('Something went wrong while getting the models ids from the label.', err);
+    const serversList: [string, InferenceServer][] = filtered.flatMap(containerInfo => {
+      let modelsId: string[] = [];
+      const models: ModelInfo[] = [];
+      try {
+        modelsId = JSON.parse(containerInfo.Labels[LABEL_INFERENCE_SERVER]);
+        // we retrieve all models Info. As the user may have started an inference server with a custom model and have deleted it in the meantime
+        // getModelInfo could fail bc the model does not exist anymore
+        for (const id of modelsId) {
+          const model = this.modelsManager.getModelInfo(id);
+          models.push(model);
         }
+      } catch (err: unknown) {
+        console.error('Something went wrong while getting the models ids from the label.', err);
+        return [];
+      }
 
-        return [
+      return [
+        [
           containerInfo.Id,
           {
             container: {
@@ -383,11 +392,12 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
               port: !!containerInfo.Ports && containerInfo.Ports.length > 0 ? containerInfo.Ports[0].PublicPort : -1,
             },
             status: containerInfo.Status === 'running' ? 'running' : 'stopped',
-            models: modelsId.map(id => this.modelsManager.getModelInfo(id)),
+            models: models,
           },
-        ];
-      }),
-    );
+        ],
+      ];
+    });
+    this.#servers = new Map<string, InferenceServer>(serversList);
 
     // (re-)create container watchers
     this.#servers.forEach(server => this.watchContainerStatus(server.container.engineId, server.container.containerId));

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -392,6 +392,7 @@ test('deleteModel deletes the model folder', async () => {
         return [
           {
             id: 'model-id-1',
+            url: 'model-url',
           },
         ] as ModelInfo[];
       },
@@ -423,6 +424,7 @@ test('deleteModel deletes the model folder', async () => {
     body: [
       {
         id: 'model-id-1',
+        url: 'model-url',
       },
     ],
   });
@@ -452,6 +454,7 @@ describe('deleting models', () => {
           return [
             {
               id: 'model-id-1',
+              url: 'model-url',
             },
           ] as ModelInfo[];
         },
@@ -483,6 +486,7 @@ describe('deleting models', () => {
       body: [
         {
           id: 'model-id-1',
+          url: 'model-url',
           file: {
             creation: now,
             file: 'model-id-1-model',
@@ -494,6 +498,40 @@ describe('deleting models', () => {
     });
     expect(mocks.showErrorMessageMock).toHaveBeenCalledOnce();
     expect(mocks.logErrorMock).toHaveBeenCalled();
+  });
+
+  test('delete local model should call catalogManager', async () => {
+    vi.mocked(env).isWindows = false;
+    const postMessageMock = vi.fn();
+    const removeLocalModelFromCatalogMock = vi.fn();
+    const manager = new ModelsManager(
+      'appdir',
+      {
+        postMessage: postMessageMock,
+      } as unknown as Webview,
+      {
+        getModels: () => {
+          return [
+            {
+              id: 'model-id-1',
+              file: {
+                file: 'model-id-1-model',
+                size: 32000,
+                path: path.resolve(dirent[0].path, dirent[0].name),
+              },
+            },
+          ] as ModelInfo[];
+        },
+        removeLocalModelFromCatalog: removeLocalModelFromCatalogMock,
+      } as unknown as CatalogManager,
+      telemetryLogger,
+      taskRegistry,
+      cancellationTokenRegistryMock,
+    );
+    await manager.loadLocalModels();
+    await manager.deleteModel('model-id-1');
+
+    expect(removeLocalModelFromCatalogMock).toBeCalledWith('model-id-1');
   });
 
   test('deleting on windows should check if models is uploaded', async () => {
@@ -514,6 +552,7 @@ describe('deleting models', () => {
           return [
             {
               id: 'model-id-1',
+              url: 'model-url',
               file: {
                 file: 'dummyFile',
                 path: 'dummyPath',
@@ -561,6 +600,7 @@ describe('deleting models', () => {
           return [
             {
               id: 'model-id-1',
+              url: 'model-url',
               file: {
                 file: 'dummyFile',
                 path: 'dummyPath',

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -38,6 +38,7 @@ export class ModelsManager implements Disposable {
   #modelsDir: string;
   #models: Map<string, ModelInfo>;
   #watcher?: podmanDesktopApi.FileSystemWatcher;
+  #disposables: Disposable[];
 
   #downloaders: Map<string, Downloader> = new Map<string, Downloader>();
 
@@ -51,19 +52,22 @@ export class ModelsManager implements Disposable {
   ) {
     this.#modelsDir = path.join(this.appUserDirectory, 'models');
     this.#models = new Map();
+    this.#disposables = [];
   }
 
   init() {
-    this.catalogManager.onCatalogUpdate(() => {
+    const disposable = this.catalogManager.onCatalogUpdate(() => {
       this.loadLocalModels().catch((err: unknown) => {
         console.error(`Something went wrong when loading local models`, err);
       });
     });
+    this.#disposables.push(disposable);
   }
 
   dispose(): void {
     this.#models.clear();
     this.#watcher.dispose();
+    this.#disposables.forEach(d => d.dispose());
   }
 
   async loadLocalModels() {

--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -244,3 +244,52 @@ test('importModels should call catalogManager', async () => {
   await studioApiImpl.importModels(models);
   expect(addLocalModelsMock).toBeCalledWith(models);
 });
+
+test('Expect checkInvalidModels to returns an empty array if all paths are valid', async () => {
+  vi.spyOn(studioApiImpl, 'getModelsInfo').mockResolvedValue([
+    {
+      id: 'model',
+      file: {
+        path: 'path1',
+        file: 'file.gguf',
+      },
+    } as unknown as ModelInfo,
+  ]);
+  const result = await studioApiImpl.checkInvalidModels(['path/file.gguf']);
+  expect(result).toStrictEqual([]);
+});
+
+test('Expect checkInvalidModels to returns an array with the invalid value', async () => {
+  vi.spyOn(studioApiImpl, 'getModelsInfo').mockResolvedValue([
+    {
+      id: 'model',
+      file: {
+        path: 'path1',
+        file: 'file.gguf',
+      },
+    } as unknown as ModelInfo,
+  ]);
+  const result = await studioApiImpl.checkInvalidModels(['path/file.gguf', 'path1/file.gguf']);
+  expect(result).toStrictEqual(['path1/file.gguf']);
+});
+
+test('Expect checkInvalidModels to returns an array with the invalid values', async () => {
+  vi.spyOn(studioApiImpl, 'getModelsInfo').mockResolvedValue([
+    {
+      id: 'model',
+      file: {
+        path: 'path',
+        file: 'file.gguf',
+      },
+    } as unknown as ModelInfo,
+    {
+      id: 'model',
+      file: {
+        path: 'path2',
+        file: 'file.gguf',
+      },
+    } as unknown as ModelInfo,
+  ]);
+  const result = await studioApiImpl.checkInvalidModels(['path/file.gguf', 'path1/file.gguf', 'path2/file.gguf']);
+  expect(result).toStrictEqual(['path/file.gguf', 'path2/file.gguf']);
+});

--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -119,7 +119,7 @@ beforeEach(async () => {
       deleteApplication: mocks.deleteApplicationMock,
     } as unknown as ApplicationManager,
     catalogManager,
-    {} as unknown as ModelsManager,
+    {} as ModelsManager,
     {} as TelemetryLogger,
     localRepositoryRegistry,
     {} as unknown as TaskRegistry,
@@ -246,6 +246,11 @@ test('importModels should call catalogManager', async () => {
 });
 
 test('Expect checkInvalidModels to returns an empty array if all paths are valid', async () => {
+  vi.mock('node:path');
+  vi.spyOn(path, 'resolve').mockImplementation((path: string) => {
+    return path;
+  });
+  vi.spyOn(path, 'join').mockImplementation((path1: string, path2: string) => `${path1}/${path2}`);
   vi.spyOn(studioApiImpl, 'getModelsInfo').mockResolvedValue([
     {
       id: 'model',
@@ -260,6 +265,11 @@ test('Expect checkInvalidModels to returns an empty array if all paths are valid
 });
 
 test('Expect checkInvalidModels to returns an array with the invalid value', async () => {
+  vi.mock('node:path');
+  vi.spyOn(path, 'resolve').mockImplementation((path: string) => {
+    return path;
+  });
+  vi.spyOn(path, 'join').mockImplementation((path1: string, path2: string) => `${path1}/${path2}`);
   vi.spyOn(studioApiImpl, 'getModelsInfo').mockResolvedValue([
     {
       id: 'model',
@@ -274,6 +284,11 @@ test('Expect checkInvalidModels to returns an array with the invalid value', asy
 });
 
 test('Expect checkInvalidModels to returns an array with the invalid values', async () => {
+  vi.mock('node:path');
+  vi.spyOn(path, 'resolve').mockImplementation((path: string) => {
+    return path;
+  });
+  vi.spyOn(path, 'join').mockImplementation((path1: string, path2: string) => `${path1}/${path2}`);
   vi.spyOn(studioApiImpl, 'getModelsInfo').mockResolvedValue([
     {
       id: 'model',

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -42,6 +42,7 @@ import type { SnippetManager } from './managers/SnippetManager';
 import type { Language } from 'postman-code-generators';
 import type { ModelOptions } from '@shared/src/models/IModelOptions';
 import type { CancellationTokenRegistry } from './registries/CancellationTokenRegistry';
+import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
 
 interface PortQuickPickItem extends podmanDesktopApi.QuickPickItem {
   port: number;
@@ -163,6 +164,10 @@ export class StudioApiImpl implements StudioAPI {
 
   async openFile(file: string): Promise<boolean> {
     return await podmanDesktopApi.env.openExternal(podmanDesktopApi.Uri.file(file));
+  }
+
+  async openDialog(options?: podmanDesktopApi.OpenDialogOptions): Promise<podmanDesktopApi.Uri[]> {
+    return await podmanDesktopApi.window.showOpenDialog(options);
   }
 
   async pullApplication(recipeId: string, modelId: string): Promise<void> {
@@ -414,5 +419,9 @@ export class StudioApiImpl implements StudioAPI {
     if (!this.cancellationTokenRegistry.hasCancellationTokenSource(tokenId))
       throw new Error(`Cancellation token with id ${tokenId} does not exist.`);
     this.cancellationTokenRegistry.getCancellationTokenSource(tokenId).cancel();
+  }
+
+  async importModels(models: LocalModelImportInfo[]): Promise<void> {
+    return this.catalogManager.addLocalModelsToCatalog(models);
   }
 }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -426,7 +426,6 @@ export class StudioApiImpl implements StudioAPI {
   }
 
   async checkInvalidModels(models: string[]): Promise<string[]> {
-    console.log(models);
     const invalidPaths = [];
     const catalogModels = await this.getModelsInfo();
     for (const model of models) {

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -424,4 +424,24 @@ export class StudioApiImpl implements StudioAPI {
   async importModels(models: LocalModelImportInfo[]): Promise<void> {
     return this.catalogManager.addLocalModelsToCatalog(models);
   }
+
+  async checkInvalidModels(models: string[]): Promise<string[]> {
+    console.log(models);
+    const invalidPaths = [];
+    const catalogModels = await this.getModelsInfo();
+    for (const model of models) {
+      const modelPath = path.resolve(model);
+      for (const catalogModel of catalogModels) {
+        if (!catalogModel.file) {
+          continue;
+        }
+        const catalogModelPath = path.resolve(path.join(catalogModel.file.path, catalogModel.file.file));
+        if (modelPath === catalogModelPath) {
+          invalidPaths.push(model);
+          break;
+        }
+      }
+    }
+    return invalidPaths;
+  }
 }

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -163,6 +163,7 @@ export class Studio {
       taskRegistry,
       cancellationTokenRegistry,
     );
+    this.modelsManager.init();
     const localRepositoryRegistry = new LocalRepositoryRegistry(this.#panel.webview, appUserDirectory);
     localRepositoryRegistry.init(this.catalogManager.getRecipes());
     const applicationManager = new ApplicationManager(

--- a/packages/backend/src/tests/ai-user-test.json
+++ b/packages/backend/src/tests/ai-user-test.json
@@ -25,7 +25,8 @@
       "hw": "CPU",
       "registry": "Hugging Face",
       "license": "?",
-      "url": "https://model1.example.com"
+      "url": "https://model1.example.com",
+      "memory": 0
     },
     {
       "id": "model2",
@@ -34,7 +35,8 @@
       "hw": "CPU",
       "registry": "Civital",
       "license": "?",
-      "url": ""
+      "url": "https://model2.example.com",
+      "memory": 0
     }
   ],
   "categories": [

--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -19,6 +19,7 @@ import ServiceDetails from '/@/pages/InferenceServerDetails.svelte';
 import Playgrounds from './pages/Playgrounds.svelte';
 import Playground from './pages/Playground.svelte';
 import PlaygroundCreate from './pages/PlaygroundCreate.svelte';
+import ImportModels from './pages/ImportModels.svelte';
 
 router.mode.hash();
 
@@ -73,8 +74,13 @@ onMount(() => {
         <Recipe recipeId="{meta.params.id}" />
       </Route>
 
-      <Route path="/models/*">
-        <Models />
+      <Route path="/models/*" firstmatch>
+        <Route path="/import">
+          <ImportModels />
+        </Route>
+        <Route path="/*">
+          <Models />
+        </Route>
       </Route>
 
       <Route path="/model/:id/*" let:meta>

--- a/packages/frontend/src/lib/table/model/ModelColumnLabels.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnLabels.svelte
@@ -8,11 +8,13 @@ export let object: ModelInfo;
 
 <div class="text-sm text-gray-700">
   <div class="flex gap-x-2">
-    <div
-      class="bg-charcoal-600 rounded-md px-2 py-1 flex flex-row w-min h-min text-xs text-charcoal-100 text-nowrap items-center">
-      <Fa class="mr-2" icon="{faMemory}" />
-      RAM usage: {filesize(object.memory, { base: 2 })}
-    </div>
+    {#if object.memory}
+      <div
+        class="bg-charcoal-600 rounded-md px-2 py-1 flex flex-row w-min h-min text-xs text-charcoal-100 text-nowrap items-center">
+        <Fa class="mr-2" icon="{faMemory}" />
+        RAM usage: {filesize(object.memory, { base: 2 })}
+      </div>
+    {/if}
     <div
       class="bg-charcoal-600 rounded-md px-2 py-1 flex flex-row w-min h-min text-xs text-charcoal-100 text-nowrap items-center">
       <Fa class="mr-2" icon="{faMicrochip}" />

--- a/packages/frontend/src/lib/table/model/ModelColumnLabels.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnLabels.svelte
@@ -8,13 +8,11 @@ export let object: ModelInfo;
 
 <div class="text-sm text-gray-700">
   <div class="flex gap-x-2">
-    {#if object.memory}
-      <div
-        class="bg-charcoal-600 rounded-md px-2 py-1 flex flex-row w-min h-min text-xs text-charcoal-100 text-nowrap items-center">
-        <Fa class="mr-2" icon="{faMemory}" />
-        RAM usage: {filesize(object.memory, { base: 2 })}
-      </div>
-    {/if}
+    <div
+      class="bg-charcoal-600 rounded-md px-2 py-1 flex flex-row w-min h-min text-xs text-charcoal-100 text-nowrap items-center">
+      <Fa class="mr-2" icon="{faMemory}" />
+      RAM usage: {object.memory ? filesize(object.memory, { base: 2 }) : 'N/A'}
+    </div>
     <div
       class="bg-charcoal-600 rounded-md px-2 py-1 flex flex-row w-min h-min text-xs text-charcoal-100 text-nowrap items-center">
       <Fa class="mr-2" icon="{faMicrochip}" />

--- a/packages/frontend/src/lib/table/model/ModelColumnName.spec.ts
+++ b/packages/frontend/src/lib/table/model/ModelColumnName.spec.ts
@@ -1,0 +1,89 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import ModelColumnName from './ModelColumnName.svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+
+test('Expect model info lower bar to be visible', async () => {
+  const routerMock = vi.spyOn(router, 'goto');
+  const object: ModelInfo = {
+    id: 'my-model',
+    description: '',
+    hw: '',
+    license: 'apache-2',
+    name: 'My model',
+    registry: 'registry',
+    url: 'url',
+    file: {
+      file: 'file',
+      size: 1000,
+      path: 'path',
+    },
+    memory: 1000,
+  };
+  render(ModelColumnName, { object });
+  const name = screen.getByLabelText('Model Name');
+  expect(name.textContent).equal('My model');
+
+  const info = screen.getByLabelText('Model Info');
+  expect(info.textContent).equal('registry - apache-2');
+
+  const importedInfo = screen.queryByLabelText('Imported Model Info');
+  expect(importedInfo).not.toBeInTheDocument();
+
+  const modelNameBtn = screen.getByRole('button', { name: 'Open Model Details' });
+  await userEvent.click(modelNameBtn);
+  expect(routerMock).toBeCalledWith('/model/my-model');
+});
+
+test('Expect model info lower bar to be visible', async () => {
+  const routerMock = vi.spyOn(router, 'goto');
+  const object: ModelInfo = {
+    id: 'my-model',
+    description: '',
+    hw: '',
+    license: '',
+    name: 'My model',
+    registry: '',
+    url: '',
+    file: {
+      file: 'file',
+      size: 1000,
+      path: 'path',
+    },
+    memory: 1000,
+  };
+  render(ModelColumnName, { object });
+  const name = screen.getByLabelText('Model Name');
+  expect(name.textContent).equal('My model');
+
+  const info = screen.queryByLabelText('Model Info');
+  expect(info).not.toBeInTheDocument();
+
+  const importedInfo = screen.getByLabelText('Imported Model Info');
+  expect(importedInfo.textContent).equal('Imported by User');
+
+  const modelNameBtn = screen.getByRole('button', { name: 'Open Model Details' });
+  await userEvent.click(modelNameBtn);
+  expect(routerMock).toBeCalledWith('/model/my-model');
+});

--- a/packages/frontend/src/lib/table/model/ModelColumnName.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnName.svelte
@@ -8,14 +8,18 @@ function openDetails() {
 }
 </script>
 
-<button class="flex flex-col w-full" title="{object.name}" on:click="{() => openDetails()}">
-  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis w-full">
+<button
+  class="flex flex-col w-full"
+  title="{object.name}"
+  on:click="{() => openDetails()}"
+  aria-label="Open Model Details">
+  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis w-full" aria-label="Model Name">
     {object.name}
   </div>
   {#if object.registry || object.license}
-    <span class="text-xs text-gray-700">{object.registry} - {object.license}</span>
+    <span class="text-xs text-gray-700" aria-label="Model Info">{object.registry} - {object.license}</span>
   {/if}
-  {#if !object.registry && !object.url}
-    <span class="text-xs text-gray-700">Imported by User</span>
+  {#if !object.registry && !object.license && !object.url}
+    <span class="text-xs text-gray-700" aria-label="Imported Model Info">Imported by User</span>
   {/if}
 </button>

--- a/packages/frontend/src/lib/table/model/ModelColumnName.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnName.svelte
@@ -13,7 +13,7 @@ function openDetails() {
   title="{object.name}"
   on:click="{() => openDetails()}"
   aria-label="Open Model Details">
-  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis w-full" aria-label="Model Name">
+  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis w-full text-left" aria-label="Model Name">
     {object.name}
   </div>
   {#if object.registry || object.license}

--- a/packages/frontend/src/lib/table/model/ModelColumnName.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnName.svelte
@@ -12,5 +12,10 @@ function openDetails() {
   <div class="text-sm text-gray-300 overflow-hidden text-ellipsis w-full">
     {object.name}
   </div>
-  <span class="text-xs text-gray-700">{object.registry} - {object.license}</span>
+  {#if object.registry || object.license}
+    <span class="text-xs text-gray-700">{object.registry} - {object.license}</span>
+  {/if}
+  {#if !object.registry && !object.url}
+    <span class="text-xs text-gray-700">Imported by User</span>
+  {/if}
 </button>

--- a/packages/frontend/src/pages/ImportModels.spec.ts
+++ b/packages/frontend/src/pages/ImportModels.spec.ts
@@ -67,6 +67,37 @@ test('Expect importModels button to be enabled when atleast one model is selecte
   expect(btnImportModels).toBeEnabled();
 });
 
+test('Expect an error is displayed if adding a new model fails', async () => {
+  vi.mocked(studioClient.openDialog).mockRejectedValue('Unknown error');
+  render(ImportModels);
+  const btnAddModels = screen.getByRole('button', { name: 'Add models' });
+  expect(btnAddModels).toBeInTheDocument();
+  await userEvent.click(btnAddModels);
+
+  const errorDiv = screen.getByLabelText('Error Message Content');
+  expect(errorDiv).toBeInTheDocument();
+  expect((errorDiv as HTMLDivElement).innerHTML).toContain('Unknown error');
+});
+
+test('Expect an error is displayed if user select a model already present in the catalog when adding a new model', async () => {
+  vi.mocked(studioClient.openDialog).mockResolvedValue([
+    {
+      path: 'path/file.gguf',
+    } as Uri,
+  ]);
+  vi.mocked(studioClient.checkInvalidModels).mockResolvedValue(['path/file.gguf']);
+  render(ImportModels);
+  const btnAddModels = screen.getByRole('button', { name: 'Add models' });
+  expect(btnAddModels).toBeInTheDocument();
+  await userEvent.click(btnAddModels);
+
+  const errorDiv = screen.getByLabelText('Error Message Content');
+  expect(errorDiv).toBeInTheDocument();
+  expect((errorDiv as HTMLDivElement).innerHTML).toContain(
+    'the following model is already in the catalog and cannot be imported',
+  );
+});
+
 test('Expect import button calls importModels func', async () => {
   vi.mocked(studioClient.openDialog).mockResolvedValue([
     {

--- a/packages/frontend/src/pages/ImportModels.spec.ts
+++ b/packages/frontend/src/pages/ImportModels.spec.ts
@@ -1,0 +1,122 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { studioClient } from '../utils/client';
+
+import ImportModels from './ImportModels.svelte';
+import type { Uri } from '@shared/src/uri/Uri';
+
+vi.mock('../utils/client', async () => {
+  return {
+    studioClient: {
+      openDialog: vi.fn(),
+      importModels: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Expect import button to be disabled', async () => {
+  render(ImportModels);
+  const btnImportModels = screen.getByRole('button', { name: 'Import models' });
+  expect(btnImportModels).toBeInTheDocument();
+  expect(btnImportModels).toBeDisabled();
+});
+
+test('Expect importModels button to be enabled when atleast one model is selected', async () => {
+  vi.mocked(studioClient.openDialog).mockResolvedValue([
+    {
+      path: 'path/file.gguf',
+    } as Uri,
+  ]);
+  render(ImportModels);
+  const btnAddModels = screen.getByRole('button', { name: 'Add models' });
+  expect(btnAddModels).toBeInTheDocument();
+  await userEvent.click(btnAddModels);
+
+  const btnImportModels = screen.getByRole('button', { name: 'Import models' });
+  expect(btnImportModels).toBeInTheDocument();
+  expect(btnImportModels).toBeEnabled();
+});
+
+test('Expect import button calls importModels func', async () => {
+  vi.mocked(studioClient.openDialog).mockResolvedValue([
+    {
+      path: 'path/file.gguf',
+    } as Uri,
+  ]);
+  vi.mocked(studioClient.importModels).mockResolvedValue();
+  const goToMock = vi.spyOn(router, 'goto');
+  render(ImportModels);
+  const btnAddModels = screen.getByRole('button', { name: 'Add models' });
+  expect(btnAddModels).toBeInTheDocument();
+  await userEvent.click(btnAddModels);
+
+  const btnImportModels = screen.getByRole('button', { name: 'Import models' });
+  expect(btnImportModels).toBeInTheDocument();
+  expect(btnImportModels).toBeEnabled();
+  await userEvent.click(btnImportModels);
+
+  expect(studioClient.importModels).toBeCalledWith([
+    {
+      name: 'file',
+      path: 'path/file.gguf',
+    },
+  ]);
+  expect(goToMock).toBeCalledWith('/models');
+});
+
+test('Expect error shown if importModels function fails', async () => {
+  vi.mocked(studioClient.openDialog).mockResolvedValue([
+    {
+      path: 'path/file.gguf',
+    } as Uri,
+  ]);
+  vi.mocked(studioClient.importModels).mockRejectedValue('import failed');
+  render(ImportModels);
+  const btnAddModels = screen.getByRole('button', { name: 'Add models' });
+  expect(btnAddModels).toBeInTheDocument();
+  await userEvent.click(btnAddModels);
+
+  const btnImportModels = screen.getByRole('button', { name: 'Import models' });
+  expect(btnImportModels).toBeInTheDocument();
+  expect(btnImportModels).toBeEnabled();
+  await userEvent.click(btnImportModels);
+
+  expect(studioClient.importModels).toBeCalledWith([
+    {
+      name: 'file',
+      path: 'path/file.gguf',
+    },
+  ]);
+
+  const errorDiv = screen.getByLabelText('Error Message Content');
+  expect(errorDiv).toBeInTheDocument();
+  expect((errorDiv as HTMLDivElement).innerHTML).toContain('import failed');
+});

--- a/packages/frontend/src/pages/ImportModels.spec.ts
+++ b/packages/frontend/src/pages/ImportModels.spec.ts
@@ -34,6 +34,7 @@ vi.mock('../utils/client', async () => {
     studioClient: {
       openDialog: vi.fn(),
       importModels: vi.fn(),
+      checkInvalidModels: vi.fn(),
     },
   };
 });
@@ -55,6 +56,7 @@ test('Expect importModels button to be enabled when atleast one model is selecte
       path: 'path/file.gguf',
     } as Uri,
   ]);
+  vi.mocked(studioClient.checkInvalidModels).mockResolvedValue([]);
   render(ImportModels);
   const btnAddModels = screen.getByRole('button', { name: 'Add models' });
   expect(btnAddModels).toBeInTheDocument();
@@ -71,6 +73,7 @@ test('Expect import button calls importModels func', async () => {
       path: 'path/file.gguf',
     } as Uri,
   ]);
+  vi.mocked(studioClient.checkInvalidModels).mockResolvedValue([]);
   vi.mocked(studioClient.importModels).mockResolvedValue();
   const goToMock = vi.spyOn(router, 'goto');
   render(ImportModels);
@@ -98,6 +101,7 @@ test('Expect error shown if importModels function fails', async () => {
       path: 'path/file.gguf',
     } as Uri,
   ]);
+  vi.mocked(studioClient.checkInvalidModels).mockResolvedValue([]);
   vi.mocked(studioClient.importModels).mockRejectedValue('import failed');
   render(ImportModels);
   const btnAddModels = screen.getByRole('button', { name: 'Add models' });

--- a/packages/frontend/src/pages/ImportModels.svelte
+++ b/packages/frontend/src/pages/ImportModels.svelte
@@ -92,7 +92,7 @@ async function importModels() {
   <svelte:fragment slot="content">
     <div class="p-5 min-w-full h-fit">
       <div class="bg-charcoal-800 rounded-lg px-6 py-6 space-y-2">
-              <span class="block mb-2 text-sm font-medium text-gray-400">Models to import:</span>
+        <span class="block mb-2 text-sm font-medium text-gray-400">Models to import:</span>
         <Button on:click="{addModelsToImport}" icon="{faPlusCircle}" type="link" aria-label="Add models"
           >Add .GGUF Models</Button>
         <div aria-label="importError">

--- a/packages/frontend/src/pages/ImportModels.svelte
+++ b/packages/frontend/src/pages/ImportModels.svelte
@@ -91,7 +91,8 @@ async function importModels() {
 <NavPage lastPage="{{ name: 'Models', path: '/models' }}" title="Import Models" searchEnabled="{false}">
   <svelte:fragment slot="content">
     <div class="p-5 min-w-full h-fit">
-      <div class="bg-charcoal-800 rounded-lg px-6 py-4 space-y-2">
+      <div class="bg-charcoal-800 rounded-lg px-6 py-6 space-y-2">
+              <span class="block mb-2 text-sm font-medium text-gray-400">Models to import:</span>
         <Button on:click="{addModelsToImport}" icon="{faPlusCircle}" type="link" aria-label="Add models"
           >Add .GGUF Models</Button>
         <div aria-label="importError">

--- a/packages/frontend/src/pages/ImportModels.svelte
+++ b/packages/frontend/src/pages/ImportModels.svelte
@@ -91,7 +91,7 @@ async function importModels() {
 <NavPage lastPage="{{ name: 'Models', path: '/models' }}" title="Import Models" searchEnabled="{false}">
   <svelte:fragment slot="content">
     <div class="p-5 min-w-full h-fit">
-      <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
+      <div class="bg-charcoal-800 rounded-lg px-6 py-4 space-y-2">
         <Button on:click="{addModelsToImport}" icon="{faPlusCircle}" type="link" aria-label="Add models"
           >Add .GGUF Models</Button>
         <div aria-label="importError">

--- a/packages/frontend/src/pages/ImportModels.svelte
+++ b/packages/frontend/src/pages/ImportModels.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { faMinusCircle, faPlusCircle, faUpload } from '@fortawesome/free-solid-svg-icons';
 import { router } from 'tinro';
 import { studioClient } from '../utils/client';
 import { Uri } from '@shared/src/uri/Uri';
@@ -78,7 +78,8 @@ async function importModels() {
   <svelte:fragment slot="content">
     <div class="p-5 min-w-full h-fit">
       <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
-        <Button on:click="{addModelsToImport}" icon="{faPlusCircle}" type="link">Add .GGUF Models</Button>
+        <Button on:click="{addModelsToImport}" icon="{faPlusCircle}" type="link" aria-label="Add models"
+          >Add .GGUF Models</Button>
         <!-- Display the list of existing containersToImport -->
         {#if modelsToImport.length > 0}
           <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
@@ -108,7 +109,7 @@ async function importModels() {
           on:click="{() => importModels()}"
           inProgress="{inProgress}"
           class="w-full"
-          icon="{faPlay}"
+          icon="{faUpload}"
           aria-label="Import models"
           bind:disabled="{importDisabled}">
           Import Models

--- a/packages/frontend/src/pages/ImportModels.svelte
+++ b/packages/frontend/src/pages/ImportModels.svelte
@@ -10,41 +10,55 @@ import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
 
 let modelsToImport: LocalModelImportInfo[] = [];
 let importError: string = '';
+let addModelError: string = '';
 
 let inProgress = false;
 
 $: importDisabled = modelsToImport.length === 0;
 
 async function addModelsToImport() {
-  const models = await studioClient.openDialog({
-    title: 'Select models to import',
-    selectors: ['multiSelections', 'openFile'],
-    filters: [
-      {
-        name: 'GGUF files',
-        extensions: ['gguf'],
-      },
-    ],
-  });
-
-  if (!models) {
-    return;
-  }
-
-  const modelsInfo: LocalModelImportInfo[] = [];
-  models.forEach(model => {
-    model = Uri.revive(model);
-    const modelPath = model.path;
-    // we show an initial name that can be modified by the user.
-    const lastSlashIndex = modelPath.replace(/\\/g, '/').lastIndexOf('/') + 1;
-
-    modelsInfo.push({
-      path: modelPath,
-      name: modelPath.substring(lastSlashIndex).replace('.gguf', ''),
+  addModelError = '';
+  try {
+    const models = await studioClient.openDialog({
+      title: 'Select models to import',
+      selectors: ['multiSelections', 'openFile'],
+      filters: [
+        {
+          name: 'GGUF files',
+          extensions: ['gguf'],
+        },
+      ],
     });
-  });
+    if (!models) {
+      return;
+    }
+    const modelsInfo: LocalModelImportInfo[] = [];
+    models.forEach(model => {
+      model = Uri.revive(model);
+      const modelPath = model.path;
+      // we show an initial name that can be modified by the user.
+      const lastSlashIndex = modelPath.replace(/\\/g, '/').lastIndexOf('/') + 1;
 
-  modelsToImport = [...modelsToImport, ...modelsInfo];
+      if (!modelsToImport.find(i => i.path === modelPath)) {
+        modelsInfo.push({
+          path: modelPath,
+          name: modelPath.substring(lastSlashIndex).replace('.gguf', ''),
+        });
+      }
+    });
+    const invalidModelsToImport = await studioClient.checkInvalidModels(modelsInfo.map(m => m.path));
+    if (invalidModelsToImport.length > 0) {
+      addModelError = `Error: the following ${invalidModelsToImport.length === 1 ? 'model is' : 'models are'} already in the catalog and cannot be imported: `;
+      invalidModelsToImport.forEach(path => {
+        addModelError += `${path} ; `;
+      });
+      modelsToImport = [...modelsToImport, ...modelsInfo.filter(m => !invalidModelsToImport.includes(m.path))];
+    } else {
+      modelsToImport = [...modelsToImport, ...modelsInfo];
+    }
+  } catch (e) {
+    addModelError = `Error while adding models: ${String(e)}`;
+  }
 }
 
 function onModelNameInput(event: Event, index: number) {
@@ -74,12 +88,17 @@ async function importModels() {
 }
 </script>
 
-<NavPage title="Import Models" searchEnabled="{false}">
+<NavPage lastPage="{{ name: 'Models', path: '/models' }}" title="Import Models" searchEnabled="{false}">
   <svelte:fragment slot="content">
     <div class="p-5 min-w-full h-fit">
       <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
         <Button on:click="{addModelsToImport}" icon="{faPlusCircle}" type="link" aria-label="Add models"
           >Add .GGUF Models</Button>
+        <div aria-label="importError">
+          {#if addModelError !== ''}
+            <ErrorMessage class="py-2 text-sm" error="{addModelError}" />
+          {/if}
+        </div>
         <!-- Display the list of existing containersToImport -->
         {#if modelsToImport.length > 0}
           <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
@@ -89,22 +108,30 @@ async function importModels() {
         {/if}
         {#each modelsToImport as modelToImport, index}
           <div class="flex flex-row w-full py-1">
-            <input
-              class="flex flex-col grow pl-2 outline-none text-sm bg-transparent rounded-sm text-gray-700 placeholder-gray-700"
-              bind:value="{modelToImport.path}"
-              aria-label="model path"
-              readonly="{true}" />
-            <input
-              bind:value="{modelToImport.name}"
-              on:input="{event => onModelNameInput(event, index)}"
-              aria-label="model importing name"
-              placeholder="Model Name displayed"
-              class="flex w-2/4 mr-2.5 p-2 outline-none text-sm bg-transparent rounded-sm text-gray-700 placeholder-gray-700" />
+            <div class="flex flex-col grow">
+              <input
+                class="flex flex-col grow p-2 outline-none text-sm bg-transparent rounded-sm text-gray-700 placeholder-gray-700 border-charcoal-100 border-b mr-2"
+                bind:value="{modelToImport.path}"
+                aria-label="model path"
+                readonly="{true}" />
+            </div>
+            <div class="flex flex-col grow">
+              <input
+                bind:value="{modelToImport.name}"
+                on:input="{event => onModelNameInput(event, index)}"
+                aria-label="model importing name"
+                placeholder="Model Name displayed"
+                class="flex flex-col grow ml-2 p-1 outline-none text-sm bg-transparent rounded-sm text-gray-700 placeholder-gray-700 border-charcoal-100 border-b hover:border-purple-400 focus:border-purple-400 focus:border focus:rounded-lg focus:bg-charcoal-900" />
+            </div>
             <Button type="link" on:click="{() => deleteModelToImport(index)}" icon="{faMinusCircle}" />
           </div>
         {/each}
 
-        <div class="pt-5 border-zinc-600 border-t-2"></div>
+        <div aria-label="importError">
+          {#if importError !== ''}
+            <ErrorMessage class="py-2 text-sm" error="{importError}" />
+          {/if}
+        </div>
         <Button
           on:click="{() => importModels()}"
           inProgress="{inProgress}"
@@ -114,11 +141,6 @@ async function importModels() {
           bind:disabled="{importDisabled}">
           Import Models
         </Button>
-        <div aria-label="importError">
-          {#if importError !== ''}
-            <ErrorMessage class="py-2 text-sm" error="{importError}" />
-          {/if}
-        </div>
       </div>
     </div>
   </svelte:fragment>

--- a/packages/frontend/src/pages/ImportModels.svelte
+++ b/packages/frontend/src/pages/ImportModels.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { router } from 'tinro';
+import { studioClient } from '../utils/client';
+import { Uri } from '@shared/src/uri/Uri';
+import Button from '../lib/button/Button.svelte';
+import ErrorMessage from '../lib/ErrorMessage.svelte';
+import NavPage from '../lib/NavPage.svelte';
+import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
+
+let modelsToImport: LocalModelImportInfo[] = [];
+let importError: string = '';
+
+let inProgress = false;
+
+$: importDisabled = modelsToImport.length === 0;
+
+async function addModelsToImport() {
+  const models = await studioClient.openDialog({
+    title: 'Select models to import',
+    selectors: ['multiSelections', 'openFile'],
+    filters: [
+      {
+        name: 'GGUF files',
+        extensions: ['gguf'],
+      },
+    ],
+  });
+
+  if (!models) {
+    return;
+  }
+
+  const modelsInfo: LocalModelImportInfo[] = [];
+  models.forEach(model => {
+    model = Uri.revive(model);
+    const modelPath = model.path;
+    // we show an initial name that can be modified by the user.
+    const lastSlashIndex = modelPath.replace(/\\/g, '/').lastIndexOf('/') + 1;
+
+    modelsInfo.push({
+      path: modelPath,
+      name: modelPath.substring(lastSlashIndex).replace('.gguf', ''),
+    });
+  });
+
+  modelsToImport = [...modelsToImport, ...modelsInfo];
+}
+
+function onModelNameInput(event: Event, index: number) {
+  const target = event.currentTarget as HTMLInputElement;
+  modelsToImport[index].name = target.value;
+  modelsToImport = modelsToImport;
+}
+
+function deleteModelToImport(index: number) {
+  modelsToImport = modelsToImport.filter((_, i) => i !== index);
+}
+
+async function importModels() {
+  importError = '';
+  inProgress = true;
+
+  try {
+    await studioClient.importModels(modelsToImport);
+  } catch (e) {
+    importError = `Error while importing models: ${String(e)}\n`;
+  }
+
+  inProgress = false;
+  if (importError === '') {
+    router.goto(`/models`);
+  }
+}
+</script>
+
+<NavPage title="Import Models" searchEnabled="{false}">
+  <svelte:fragment slot="content">
+    <div class="p-5 min-w-full h-fit">
+      <div class="bg-charcoal-600 px-6 py-4 space-y-2 lg:px-8 sm:pb-6 xl:pb-8">
+        <Button on:click="{addModelsToImport}" icon="{faPlusCircle}" type="link">Add .GGUF Models</Button>
+        <!-- Display the list of existing containersToImport -->
+        {#if modelsToImport.length > 0}
+          <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-gray-400">
+            <div class="flex flex-col grow pl-2">Path</div>
+            <div class="flex flex-col w-2/4 mr-2.5">Name</div>
+          </div>
+        {/if}
+        {#each modelsToImport as modelToImport, index}
+          <div class="flex flex-row w-full py-1">
+            <input
+              class="flex flex-col grow pl-2 outline-none text-sm bg-transparent rounded-sm text-gray-700 placeholder-gray-700"
+              bind:value="{modelToImport.path}"
+              aria-label="model path"
+              readonly="{true}" />
+            <input
+              bind:value="{modelToImport.name}"
+              on:input="{event => onModelNameInput(event, index)}"
+              aria-label="model importing name"
+              placeholder="Model Name displayed"
+              class="flex w-2/4 mr-2.5 p-2 outline-none text-sm bg-transparent rounded-sm text-gray-700 placeholder-gray-700" />
+            <Button type="link" on:click="{() => deleteModelToImport(index)}" icon="{faMinusCircle}" />
+          </div>
+        {/each}
+
+        <div class="pt-5 border-zinc-600 border-t-2"></div>
+        <Button
+          on:click="{() => importModels()}"
+          inProgress="{inProgress}"
+          class="w-full"
+          icon="{faPlay}"
+          aria-label="Import models"
+          bind:disabled="{importDisabled}">
+          Import Models
+        </Button>
+        <div aria-label="importError">
+          {#if importError !== ''}
+            <ErrorMessage class="py-2 text-sm" error="{importError}" />
+          {/if}
+        </div>
+      </div>
+    </div>
+  </svelte:fragment>
+</NavPage>

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -20,6 +20,7 @@ import { vi, test, expect } from 'vitest';
 import { screen, render, waitFor, within } from '@testing-library/svelte';
 import Models from './Models.svelte';
 import { router } from 'tinro';
+import userEvent from '@testing-library/user-event';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -230,4 +231,15 @@ test('should display no model in available tab', async () => {
     const status = screen.getByRole('status');
     expect(status).toBeDefined();
   });
+});
+
+test('Import button should redirect to import page', async () => {
+  const routerMock = vi.spyOn(router, 'goto');
+
+  render(Models);
+
+  const importButton = screen.getByRole('button', { name: 'Import Models' });
+  await userEvent.click(importButton);
+
+  expect(routerMock).toBeCalledWith('/models/import');
 });

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -16,7 +16,10 @@ import ModelColumnActions from '../lib/table/model/ModelColumnActions.svelte';
 import Tab from '/@/lib/Tab.svelte';
 import Route from '/@/Route.svelte';
 import { tasks } from '/@/stores/tasks';
+import { catalog } from '../stores/catalog';
 import ModelColumnIcon from '../lib/table/model/ModelColumnIcon.svelte';
+import Button from '../lib/button/Button.svelte';
+import { router } from 'tinro';
 
 const columns: Column<ModelInfo>[] = [
   new Column<ModelInfo>('', { width: '40px', renderer: ModelColumnIcon }),
@@ -83,6 +86,10 @@ onMount(() => {
     localModelsUnsubscribe();
   };
 });
+
+async function importModel() {
+  router.goto('/models/import');
+}
 </script>
 
 <NavPage title="Models" searchEnabled="{false}" loading="{loading}">
@@ -91,7 +98,9 @@ onMount(() => {
     <Tab title="Downloaded" url="models/downloaded" />
     <Tab title="Available" url="models/available" />
   </svelte:fragment>
-
+  <svelte:fragment slot="additional-actions">
+    <Button on:click="{importModel}">Import</Button>
+  </svelte:fragment>
   <svelte:fragment slot="content">
     <div slot="content" class="flex flex-col min-w-full min-h-full">
       <div class="min-w-full min-h-full flex-1">

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -99,7 +99,7 @@ async function importModel() {
     <Tab title="Available" url="models/available" />
   </svelte:fragment>
   <svelte:fragment slot="additional-actions">
-    <Button on:click="{importModel}">Import</Button>
+    <Button on:click="{importModel}" aria-label="Import Models">Import</Button>
   </svelte:fragment>
   <svelte:fragment slot="content">
     <div slot="content" class="flex flex-col min-w-full min-h-full">

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -18,7 +18,7 @@
 
 import type { ModelInfo } from './models/IModelInfo';
 import type { ApplicationCatalog } from './models/IApplicationCatalog';
-import type { TelemetryTrustedValue } from '@podman-desktop/api';
+import type { OpenDialogOptions, TelemetryTrustedValue, Uri } from '@podman-desktop/api';
 import type { ApplicationState } from './models/IApplicationState';
 import type { Task } from './models/ITask';
 import type { LocalRepository } from './models/ILocalRepository';
@@ -28,6 +28,7 @@ import type { Language } from 'postman-code-generators';
 import type { CreationInferenceServerOptions } from './models/InferenceServerConfig';
 import type { ModelOptions } from './models/IModelOptions';
 import type { Conversation } from './models/IPlaygroundMessage';
+import type { LocalModelImportInfo } from './models/ILocalModelInfo';
 
 export abstract class StudioAPI {
   abstract ping(): Promise<string>;
@@ -35,6 +36,7 @@ export abstract class StudioAPI {
   abstract pullApplication(recipeId: string, modelId: string): Promise<void>;
   abstract openURL(url: string): Promise<boolean>;
   abstract openFile(file: string): Promise<boolean>;
+  abstract openDialog(options?: OpenDialogOptions): Promise<Uri[]>;
   /**
    * Get the information of models saved locally into the user's directory
    */
@@ -164,4 +166,10 @@ export abstract class StudioAPI {
    * @param tokenId the id of the CancellationToken to cancel
    */
   abstract requestCancelToken(tokenId: number): Promise<void>;
+
+  /**
+   * Import local models selected by user
+   * @param models list of local models to import
+   */
+  abstract importModels(models: LocalModelImportInfo[]): Promise<void>;
 }

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -172,4 +172,11 @@ export abstract class StudioAPI {
    * @param models list of local models to import
    */
   abstract importModels(models: LocalModelImportInfo[]): Promise<void>;
+
+  /**
+   * Check if there is some invalid model from the list of paths
+   * @param models list of local models path to import
+   * @returns the list of invalid models
+   */
+  abstract checkInvalidModels(models: string[]): Promise<string[]>;
 }

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -125,6 +125,7 @@ export class RpcBrowser {
   counter: number = 0;
   promises: Map<number, { resolve: (value: unknown) => unknown; reject: (value: unknown) => void }> = new Map();
   subscribers: Map<string, (msg: any) => void> = new Map();
+  noTimeoutChannels: string[] = ['openDialog'];
 
   getUniqueId(): number {
     return ++this.counter;
@@ -198,12 +199,14 @@ export class RpcBrowser {
     } as IMessageRequest);
 
     // Add some timeout
-    setTimeout(() => {
-      const { reject } = this.promises.get(requestId) || {};
-      if (!reject) return;
-      reject(new Error('Timeout'));
-      this.promises.delete(requestId);
-    }, 5000);
+    if (!this.noTimeoutChannels.includes(channel)) {
+      setTimeout(() => {
+        const { reject } = this.promises.get(requestId) || {};
+        if (!reject) return;
+        reject(new Error('Timeout'));
+        this.promises.delete(requestId);
+      }, 5000);
+    }
 
     // Create a Promise
     return promise;

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -18,6 +18,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Webview } from '@podman-desktop/api';
+import { noTimeoutChannels } from './NoTimeoutChannels';
 
 export interface IMessage {
   id: number;
@@ -125,7 +126,6 @@ export class RpcBrowser {
   counter: number = 0;
   promises: Map<number, { resolve: (value: unknown) => unknown; reject: (value: unknown) => void }> = new Map();
   subscribers: Map<string, (msg: any) => void> = new Map();
-  noTimeoutChannels: string[] = ['openDialog'];
 
   getUniqueId(): number {
     return ++this.counter;
@@ -199,7 +199,7 @@ export class RpcBrowser {
     } as IMessageRequest);
 
     // Add some timeout
-    if (!this.noTimeoutChannels.includes(channel)) {
+    if (!noTimeoutChannels.includes(channel)) {
       setTimeout(() => {
         const { reject } = this.promises.get(requestId) || {};
         if (!reject) return;

--- a/packages/shared/src/messages/NoTimeoutChannels.ts
+++ b/packages/shared/src/messages/NoTimeoutChannels.ts
@@ -16,17 +16,4 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { LocalModelInfo } from './ILocalModelInfo';
-
-export interface ModelInfo {
-  id: string;
-  name: string;
-  description: string;
-  hw: string;
-  registry?: string;
-  license?: string;
-  url?: string;
-  file?: LocalModelInfo;
-  state?: 'deleting';
-  memory?: number;
-}
+export const noTimeoutChannels: string[] = ['openDialog'];

--- a/packages/shared/src/models/ILocalModelInfo.ts
+++ b/packages/shared/src/models/ILocalModelInfo.ts
@@ -22,3 +22,8 @@ export interface LocalModelInfo {
   size?: number;
   creation?: Date;
 }
+
+export interface LocalModelImportInfo {
+  path: string;
+  name: string;
+}

--- a/packages/shared/src/models/IModelInfo.ts
+++ b/packages/shared/src/models/IModelInfo.ts
@@ -23,9 +23,9 @@ export interface ModelInfo {
   name: string;
   description: string;
   hw: string;
-  registry: string;
-  license: string;
-  url: string;
+  registry?: string;
+  license?: string;
+  url?: string;
   file?: LocalModelInfo;
   state?: 'deleting';
   memory: number;

--- a/packages/shared/src/uri/Uri.spec.ts
+++ b/packages/shared/src/uri/Uri.spec.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Uri as APIUri } from '@podman-desktop/api';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { Uri } from './Uri';
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect revive to return revived Uri object', () => {
+  const uriSerialized = {
+    _scheme: 'scheme',
+    _authority: 'authority',
+    _path: 'path',
+    _query: 'query',
+    _fragment: 'fragment',
+  } as unknown as APIUri;
+
+  const revived = Uri.revive(uriSerialized);
+  expect(revived.authority).equals('authority');
+  expect(revived.scheme).equals('scheme');
+  expect(revived.path).equals('path');
+  expect(revived.fsPath).equals('path');
+  expect(revived.query).equals('query');
+  expect(revived.fragment).equals('fragment');
+});

--- a/packages/shared/src/uri/Uri.ts
+++ b/packages/shared/src/uri/Uri.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Uri as APIUri } from '@podman-desktop/api';
+
+export class Uri {
+  private constructor(
+    private _scheme: string,
+    private _authority: string,
+    private _path: string,
+    private _query: string,
+    private _fragment: string,
+  ) {}
+
+  get fsPath(): string {
+    return this._path;
+  }
+  get scheme(): string {
+    return this._scheme;
+  }
+
+  get authority(): string {
+    return this._authority;
+  }
+
+  get path(): string {
+    return this._path;
+  }
+
+  get query(): string {
+    return this._query;
+  }
+
+  get fragment(): string {
+    return this._fragment;
+  }
+
+  with(_change?: { scheme?: string; authority?: string; path?: string; query?: string; fragment?: string }): Uri {
+    throw new Error('unsupported');
+  }
+
+  toString(): string {
+    throw new Error('unsupported');
+  }
+
+  static revive(serialized: APIUri): Uri {
+    if (serialized instanceof Uri) {
+      return serialized;
+    }
+    const serializedProps: Map<string, string> = Object.entries(serialized)
+      .map(([key, value]) => [key.startsWith('_') ? key.substring(1) : key, value])
+      .reduce((map, [key, value]) => {
+        map.set(key, value);
+        return map;
+      }, new Map());
+    return new Uri(
+      serializedProps.get('scheme') ?? '',
+      serializedProps.get('authority') ?? '',
+      serializedProps.get('path') ?? '',
+      serializedProps.get('query') ?? '',
+      serializedProps.get('fragment') ?? '',
+    );
+  }
+}


### PR DESCRIPTION
### What does this PR do?

It allows to import .gguf models that have already been downloaded by the user and that are on his machine.
After imported, the user can start a service, open its folder and delete it

### Screenshot / video of UI

![import_model](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/689c15b2-94f7-4529-b2f5-982b663e9dfe)


### What issues does this PR fix or reference?

it resolves #173 

Fixes #814 


### How to test this PR?

1. download a gguf model which is not listed in the catalog (e.g. take the first ones from here https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/tree/main 
2. go to models, import, select the gguf file
3. once imported, try to play with it (inference server + playground)
4. then delete it (it will be removed from catalog and disk)