### PR TITLE
feat: add model icon in the list of models for a recipe

### DIFF
--- a/packages/frontend/src/pages/RecipeModels.spec.ts
+++ b/packages/frontend/src/pages/RecipeModels.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor, within } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+import * as catalogStore from '/@/stores/catalog';
+import { readable } from 'svelte/store';
+import type { ApplicationCatalog } from '@shared/src/models/IApplicationCatalog';
+import RecipeModels from '/@/pages/RecipeModels.svelte';
+
+vi.mock('/@/stores/catalog', async () => {
+  return {
+    catalog: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  const catalog: ApplicationCatalog = {
+    recipes: [
+      {
+        id: 'recipe1',
+        name: 'Recipe 1',
+        models: ['model1'],
+        categories: [],
+        description: 'Recipe 1',
+        readme: '',
+        repository: 'https://podman-desktop.io',
+      },
+    ],
+    models: [
+      {
+        id: 'model1',
+        name: 'Model 1',
+        url: 'https://podman-desktop.io',
+        registry: 'Podman Desktop',
+        license: 'Apache 2.0',
+        description: '',
+        hw: 'CPU',
+        memory: 4 * 1024 * 1024 * 1024,
+      },
+    ],
+    categories: [],
+  };
+  vi.mocked(catalogStore).catalog = readable(catalog);
+});
+
+test('should display model icon', async () => {
+  render(RecipeModels, {
+    selectedModelId: 'model1',
+    setSelectedModel: vi.fn(),
+    modelsIds: ['model1'],
+  });
+
+  await waitFor(async () => {
+    const table = screen.getByRole('table');
+    expect(table).toBeInTheDocument();
+    const rows = screen.queryAllByRole('rowgroup');
+    expect(rows.length > 0).toBeTruthy();
+
+    const icon = await within(rows[1]).findByRole('img');
+    expect(icon).toBeDefined();
+  });
+});

--- a/packages/frontend/src/pages/RecipeModels.svelte
+++ b/packages/frontend/src/pages/RecipeModels.svelte
@@ -6,6 +6,7 @@ import { catalog } from '/@/stores/catalog';
 import ModelColumnRecipeSelection from '../lib/table/model/ModelColumnRecipeSelection.svelte';
 import ModelColumnRecipeRecommended from '../lib/table/model/ModelColumnRecipeRecommended.svelte';
 import type { RecipeModelInfo } from '../models/RecipeModelInfo';
+import ModelColumnIcon from '/@/lib/table/model/ModelColumnIcon.svelte';
 
 export let modelsIds: string[] | undefined;
 export let selectedModelId: string;
@@ -24,6 +25,7 @@ $: models = $catalog.models
 const columns: Column<RecipeModelInfo>[] = [
   new Column<RecipeModelInfo>('', { width: '20px', renderer: ModelColumnRecipeSelection }),
   new Column<RecipeModelInfo>('', { width: '20px', renderer: ModelColumnRecipeRecommended }),
+  new Column<RecipeModelInfo>('', { width: '32px', renderer: ModelColumnIcon }),
   new Column<RecipeModelInfo>('Name', { width: '4fr', renderer: ModelColumnName }),
 ];
 const row = new Row<RecipeModelInfo>({});


### PR DESCRIPTION
Fixes #623

### What does this PR do?

Add model icon in the recipe model list

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/695993/8e974687-28ea-4b80-a2f3-bfe0177e3cf6)

### What issues does this PR fix or reference?

#623 

### How to test this PR?

1. Go to a recipe map
2. Switch to the models list