### PR TITLE
refactor: workers by system

### DIFF
--- a/packages/backend/src/utils/uploader.spec.ts
+++ b/packages/backend/src/utils/uploader.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { expect, test, describe, vi } from 'vitest';
-import { WSLUploader } from './WSLUploader';
+import { WSLUploader } from '../workers/uploader/WSLUploader';
 import * as podmanDesktopApi from '@podman-desktop/api';
 import { beforeEach } from 'node:test';
 import { Uploader } from './uploader';
@@ -63,7 +63,7 @@ describe('perform', () => {
     expect(result.startsWith('localpath')).toBeTruthy();
   });
   test('should return remote path if there is a worker for current system', async () => {
-    vi.spyOn(WSLUploader.prototype, 'upload').mockResolvedValue('remote');
+    vi.spyOn(WSLUploader.prototype, 'perform').mockResolvedValue('remote');
     vi.mocked(podmanDesktopApi.env).isWindows = true;
     const result = await uploader.perform('id');
     expect(result).toBe('remote');

--- a/packages/backend/src/workers/IWorker.ts
+++ b/packages/backend/src/workers/IWorker.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface IWorker<T, R> {
+  enabled(): boolean;
+  perform(trackingId: T): Promise<R>;
+}

--- a/packages/backend/src/workers/WindowsWorker.ts
+++ b/packages/backend/src/workers/WindowsWorker.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { env } from '@podman-desktop/api';
+import type { IWorker } from './IWorker';
+
+export abstract class WindowsWorker<T, R> implements IWorker<T, R> {
+  enabled(): boolean {
+    return env.isWindows;
+  }
+
+  abstract perform(content: T): Promise<R>;
+}

--- a/packages/backend/src/workers/uploader/WSLUploader.spec.ts
+++ b/packages/backend/src/workers/uploader/WSLUploader.spec.ts
@@ -19,7 +19,7 @@
 import { expect, test, describe, vi } from 'vitest';
 import { WSLUploader } from './WSLUploader';
 import * as podmanDesktopApi from '@podman-desktop/api';
-import * as utils from './podman';
+import * as utils from '../../utils/podman';
 import { beforeEach } from 'node:test';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
@@ -47,12 +47,12 @@ beforeEach(() => {
 describe('canUpload', () => {
   test('should return false if system is not windows', () => {
     vi.mocked(podmanDesktopApi.env).isWindows = false;
-    const result = wslUploader.canUpload();
+    const result = wslUploader.enabled();
     expect(result).toBeFalsy();
   });
   test('should return true if system is windows', () => {
     vi.mocked(podmanDesktopApi.env).isWindows = true;
-    const result = wslUploader.canUpload();
+    const result = wslUploader.enabled();
     expect(result).toBeTruthy();
   });
 });
@@ -72,7 +72,7 @@ describe('upload', () => {
   });
   test('throw if localpath is not defined', async () => {
     await expect(
-      wslUploader.upload({
+      wslUploader.perform({
         file: undefined,
       } as unknown as ModelInfo),
     ).rejects.toThrowError('model is not available locally.');
@@ -80,7 +80,7 @@ describe('upload', () => {
   test('copy model if not exists on podman machine', async () => {
     mocks.execMock.mockRejectedValueOnce('error');
     vi.spyOn(utils, 'getFirstRunningMachineName').mockReturnValue('machine2');
-    await wslUploader.upload({
+    await wslUploader.perform({
       id: 'dummyId',
       file: { path: 'C:\\Users\\podman\\folder', file: 'dummy.guff' },
     } as unknown as ModelInfo);
@@ -112,7 +112,7 @@ describe('upload', () => {
   test('do not copy model if it exists on podman machine', async () => {
     mocks.execMock.mockResolvedValue('');
     vi.spyOn(utils, 'getFirstRunningMachineName').mockReturnValue('machine2');
-    await wslUploader.upload({
+    await wslUploader.perform({
       id: 'dummyId',
       file: { path: 'C:\\Users\\podman\\folder', file: 'dummy.guff' },
     } as unknown as ModelInfo);

--- a/packages/backend/src/workers/uploader/WSLUploader.ts
+++ b/packages/backend/src/workers/uploader/WSLUploader.ts
@@ -17,17 +17,14 @@
  ***********************************************************************/
 
 import * as podmanDesktopApi from '@podman-desktop/api';
-import { getFirstRunningMachineName, getPodmanCli } from './podman';
-import type { UploadWorker } from './uploader';
-import { getLocalModelFile, getRemoteModelFile, isModelUploaded, MACHINE_BASE_FOLDER } from './modelsUtils';
+import { getFirstRunningMachineName, getPodmanCli } from '../../utils/podman';
+import { getLocalModelFile, getRemoteModelFile, isModelUploaded, MACHINE_BASE_FOLDER } from '../../utils/modelsUtils';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { WindowsWorker } from '../WindowsWorker';
 
-export class WSLUploader implements UploadWorker {
-  canUpload(): boolean {
-    return podmanDesktopApi.env.isWindows;
-  }
+export class WSLUploader extends WindowsWorker<ModelInfo, string> {
 
-  async upload(modelInfo: ModelInfo): Promise<string> {
+  async perform(modelInfo: ModelInfo): Promise<string> {
     const localPath = getLocalModelFile(modelInfo);
 
     const driveLetter = localPath.charAt(0);

--- a/packages/backend/src/workers/uploader/WSLUploader.ts
+++ b/packages/backend/src/workers/uploader/WSLUploader.ts
@@ -23,7 +23,6 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { WindowsWorker } from '../WindowsWorker';
 
 export class WSLUploader extends WindowsWorker<ModelInfo, string> {
-
   async perform(modelInfo: ModelInfo): Promise<string> {
     const localPath = getLocalModelFile(modelInfo);
 


### PR DESCRIPTION
### What does this PR do?

In the future with the GPU, we will have a lot of system specific (win, mac, linux) or hardware specific (NVIDIA, Vulkan) code. @lstocchi introduced the concept of ~workers for the WSL Upload task. This is a pattern we can generify and reuse. 

This PR introduce an interface `IWorker` and an abstract class `WindowsWorker` with basic utilities. The main goals are

- Reducing the quantity of code in the `packages/backend/src/utils` folder, which start to get too big
- Generify the WSL worker and offer reusable component for later usage

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] existing unit tests ensure no regression