### PR TITLE
fix: check modified/created/deleted files when detached repository

### DIFF
--- a/packages/backend/src/managers/gitManager.spec.ts
+++ b/packages/backend/src/managers/gitManager.spec.ts
@@ -290,10 +290,100 @@ describe('isRepositoryUpToDate', () => {
     ]);
     mocks.statusMock.mockResolvedValue({
       detached: true,
+      modified: [],
+      deleted: [],
+      created: [],
     });
 
     const result = await gitmanager.isRepositoryUpToDate('target', 'repo', 'dummyCommit');
     expect(result.ok).toBeTruthy();
     expect(result.error).toBeUndefined();
+  });
+
+  test('detached with expected ref and modified files', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(statSync).mockReturnValue({
+      isDirectory: () => true,
+    } as unknown as Stats);
+
+    const gitmanager = new GitManager();
+
+    vi.spyOn(gitmanager, 'getRepositoryRemotes').mockResolvedValue([
+      {
+        name: 'origin',
+        refs: {
+          fetch: 'repo',
+          push: 'repo',
+        },
+      },
+    ]);
+    mocks.statusMock.mockResolvedValue({
+      detached: true,
+      modified: ['a_file.txt'],
+      deleted: [],
+      created: [],
+    });
+
+    const result = await gitmanager.isRepositoryUpToDate('target', 'repo', 'dummyCommit');
+    expect(result.ok).toBeFalsy();
+    expect(result.error).toBe('The local repository has modified files.');
+  });
+
+  test('detached with expected ref and deleted files', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(statSync).mockReturnValue({
+      isDirectory: () => true,
+    } as unknown as Stats);
+
+    const gitmanager = new GitManager();
+
+    vi.spyOn(gitmanager, 'getRepositoryRemotes').mockResolvedValue([
+      {
+        name: 'origin',
+        refs: {
+          fetch: 'repo',
+          push: 'repo',
+        },
+      },
+    ]);
+    mocks.statusMock.mockResolvedValue({
+      detached: true,
+      deleted: ['a_file.txt'],
+      modified: [],
+      created: [],
+    });
+
+    const result = await gitmanager.isRepositoryUpToDate('target', 'repo', 'dummyCommit');
+    expect(result.ok).toBeFalsy();
+    expect(result.error).toBe('The local repository has deleted files.');
+  });
+
+  test('detached with expected ref and created files', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(statSync).mockReturnValue({
+      isDirectory: () => true,
+    } as unknown as Stats);
+
+    const gitmanager = new GitManager();
+
+    vi.spyOn(gitmanager, 'getRepositoryRemotes').mockResolvedValue([
+      {
+        name: 'origin',
+        refs: {
+          fetch: 'repo',
+          push: 'repo',
+        },
+      },
+    ]);
+    mocks.statusMock.mockResolvedValue({
+      detached: true,
+      created: ['a_file.txt'],
+      deleted: [],
+      modified: [],
+    });
+
+    const result = await gitmanager.isRepositoryUpToDate('target', 'repo', 'dummyCommit');
+    expect(result.ok).toBeFalsy();
+    expect(result.error).toBe('The local repository has created files.');
   });
 });

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -143,12 +143,6 @@ export class GitManager {
         const commit = await this.getCurrentCommit(directory);
         if (!commit.startsWith(ref)) error = `The local repository is detached. HEAD is ${commit} expected ${ref}.`;
       }
-    } else if (status.modified.length > 0) {
-      error = 'The local repository has modified files.';
-    } else if (status.created.length > 0) {
-      error = 'The local repository has created files.';
-    } else if (status.deleted.length > 0) {
-      error = 'The local repository has created files.';
     } else if (status.ahead !== 0) {
       error = `The local repository has ${status.ahead} commit(s) ahead.`;
     } else if (ref !== undefined && status.tracking !== ref) {
@@ -157,6 +151,18 @@ export class GitManager {
       error = 'The local repository is not clean.';
     } else if (status.behind !== 0) {
       return { ok: true, updatable: true };
+    }
+
+    if (error) {
+      return { error };
+    }
+
+    if (status.modified.length > 0) {
+      error = 'The local repository has modified files.';
+    } else if (status.created.length > 0) {
+      error = 'The local repository has created files.';
+    } else if (status.deleted.length > 0) {
+      error = 'The local repository has deleted files.';
     }
 
     if (error) {


### PR DESCRIPTION
### What does this PR do?

When starting a recipe, check that no file is modified/created/deleted when the repository is detached

### What issues does this PR fix or reference?

Fixes #773 

### How to test this PR?

Run a recipe from the catalog (the repository should be detached, see `git status`), stop it, then modify, delete or create a file (stage the changes or not), and verify that there is an alert when starting the recipe.
