### PR TITLE
fix: remove the last recipes from recipes page

### DIFF
--- a/packages/frontend/src/pages/Recipes.svelte
+++ b/packages/frontend/src/pages/Recipes.svelte
@@ -11,12 +11,6 @@ $: categories = $catalog.categories;
   <div slot="content" class="flex flex-col min-w-full min-h-full">
     <div class="min-w-full min-h-full flex-1">
       <div class="px-5 space-y-5">
-        <!-- Recent recipes -->
-        <RecipesCard
-          category="{{ id: RECENT_CATEGORY_ID, name: 'Recently-viewed recipes' }}"
-          class="p-6"
-          displayDescription="{false}" />
-
         {#each categories as category}
           {#if $catalog.recipes.some(r => r.categories.includes(category.id))}
             <RecipesCard


### PR DESCRIPTION
Fixes #779

### What does this PR do?

Remove the recently processed recipes from the recipes catalog pag

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/695993/f5b7b61a-3560-47a8-8b4a-5d66c6bf2ba5)

### What issues does this PR fix or reference?

#779 

### How to test this PR?

Go the recipes catalog page