### PR TITLE
fix: nighties version are not subject to version verification

### DIFF
--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -131,11 +131,39 @@ test('check activate', async () => {
 describe('version checker', () => {
   test('check activate incompatible', async () => {
     (version as string) = '0.7.0';
-    await expect(studio.activate()).rejects.toThrowError('Extension is not compatible with Podman Desktop version below 1.0.0. Current 0.7.0');
+    await expect(studio.activate()).rejects.toThrowError(
+      'Extension is not compatible with Podman Desktop version below 1.0.0. Current 0.7.0',
+    );
 
     // expect the activate method to be called on the studio class
     expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {
       version: '0.7.0',
+      message: 'error activating extension on version below 1.0.0',
+    });
+  });
+
+  test('version null', async () => {
+    (version as string) = null;
+    await expect(studio.activate()).rejects.toThrowError(
+      'Extension is not compatible with Podman Desktop version below 1.0.0. Current unknown',
+    );
+
+    // expect the activate method to be called on the studio class
+    expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {
+      version: 'unknown',
+      message: 'error activating extension on version below 1.0.0',
+    });
+  });
+
+  test('version undefined', async () => {
+    (version as string) = null;
+    await expect(studio.activate()).rejects.toThrowError(
+      'Extension is not compatible with Podman Desktop version below 1.0.0. Current unknown',
+    );
+
+    // expect the activate method to be called on the studio class
+    expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {
+      version: 'unknown',
       message: 'error activating extension on version below 1.0.0',
     });
   });
@@ -154,7 +182,6 @@ describe('version checker', () => {
     expect(mocks.logErrorMock).not.toHaveBeenCalled();
     expect(mocks.consoleWarnMock).toHaveBeenCalledWith('nighties version are not subject to version verification.');
   });
-
 });
 
 test('check deactivate ', async () => {

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -142,21 +142,8 @@ describe('version checker', () => {
     });
   });
 
-  test('version null', async () => {
-    (version as string) = null;
-    await expect(studio.activate()).rejects.toThrowError(
-      'Extension is not compatible with Podman Desktop version below 1.0.0. Current unknown',
-    );
-
-    // expect the activate method to be called on the studio class
-    expect(mocks.logErrorMock).toBeCalledWith('start.incompatible', {
-      version: 'unknown',
-      message: 'error activating extension on version below 1.0.0',
-    });
-  });
-
   test('version undefined', async () => {
-    (version as string) = null;
+    (version as string) = undefined;
     await expect(studio.activate()).rejects.toThrowError(
       'Extension is not compatible with Podman Desktop version below 1.0.0. Current unknown',
     );

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -167,7 +167,7 @@ describe('version checker', () => {
     await studio.activate();
 
     expect(mocks.logErrorMock).not.toHaveBeenCalled();
-    expect(mocks.consoleWarnMock).toHaveBeenCalledWith('nighties version are not subject to version verification.');
+    expect(mocks.consoleWarnMock).toHaveBeenCalledWith('nightlies version are not subject to version verification.');
   });
 });
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -73,7 +73,7 @@ export class Studio {
     if (!current) return false;
 
     if (current.major === 0 && current.minor === 0) {
-      console.warn('nighties version are not subject to version verification.');
+      console.warn('nightlies version are not subject to version verification.');
       return true;
     }
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -66,18 +66,32 @@ export class Studio {
     this.#extensionContext = extensionContext;
   }
 
+  private checkVersion(): boolean {
+    if(!version) return false;
+
+    const current = coerce(version);
+    if(!current) return false;
+
+    if(current.major === 0 && current.minor === 0) {
+      console.warn('nighties version are not subject to version verification.');
+      return true;
+    }
+
+    return satisfies(current, engines['podman-desktop']);
+  }
+
   public async activate(): Promise<void> {
     console.log('starting AI Lab extension');
     this.telemetry = env.createTelemetryLogger();
 
-    // Ensure version is above minimum podman desktop version supported
-    if (!version || !satisfies(coerce(version), engines['podman-desktop'])) {
+    if(!this.checkVersion()) {
       const min = minVersion(engines['podman-desktop']);
+      const current = version ?? 'unknown';
       this.telemetry.logError('start.incompatible', {
-        version: version,
+        version: current,
         message: `error activating extension on version below ${min.version}`,
       });
-      throw new Error(`Extension is not compatible with Podman Desktop version below ${min.version}.`);
+      throw new Error(`Extension is not compatible with Podman Desktop version below ${min.version}. Current ${current}`);
     }
 
     this.telemetry.logUsage('start');

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -67,12 +67,12 @@ export class Studio {
   }
 
   private checkVersion(): boolean {
-    if(!version) return false;
+    if (!version) return false;
 
     const current = coerce(version);
-    if(!current) return false;
+    if (!current) return false;
 
-    if(current.major === 0 && current.minor === 0) {
+    if (current.major === 0 && current.minor === 0) {
       console.warn('nighties version are not subject to version verification.');
       return true;
     }
@@ -84,14 +84,16 @@ export class Studio {
     console.log('starting AI Lab extension');
     this.telemetry = env.createTelemetryLogger();
 
-    if(!this.checkVersion()) {
+    if (!this.checkVersion()) {
       const min = minVersion(engines['podman-desktop']);
       const current = version ?? 'unknown';
       this.telemetry.logError('start.incompatible', {
         version: current,
         message: `error activating extension on version below ${min.version}`,
       });
-      throw new Error(`Extension is not compatible with Podman Desktop version below ${min.version}. Current ${current}`);
+      throw new Error(
+        `Extension is not compatible with Podman Desktop version below ${min.version}. Current ${current}`,
+      );
     }
 
     this.telemetry.logUsage('start');


### PR DESCRIPTION
### What does this PR do?

The special case of nighties are handled with an ignore warning. We are checking if `major` and `minor` are zeroes, if it does, we ignore the version check.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/787

### How to test this PR?

- [x] unit tests ensure no regression