### PR TITLE
fix: navigation alignment

### DIFF
--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -11,7 +11,7 @@ export let meta: TinroRouteMeta;
   class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-charcoal-800"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
-    <a href="/" title="Navigate to dashboard" class="pt-6 pl-3 px-5 mb-10 flex items-center ml-[4px]">
+    <a href="/" title="Navigate to dashboard" class="pt-4 pl-3 px-5 mb-10 flex items-center ml-[4px]">
       <Fa size="1.5x" class="text-purple-500 cursor-pointer mr-4" icon="{faBrain}" />
       <p class="text-xl first-letter:uppercase">AI Lab</p>
     </a>

--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -11,19 +11,19 @@ export let meta: TinroRouteMeta;
   class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-charcoal-800"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
-    <a href="/" title="Navigate to dashboard" class="pt-4 px-5 mb-10 flex items-center">
+    <a href="/" title="Navigate to dashboard" class="pt-6 pl-3 px-5 mb-10 flex items-center ml-[4px]">
       <Fa size="1.5x" class="text-purple-500 cursor-pointer mr-4" icon="{faBrain}" />
       <p class="text-xl first-letter:uppercase">AI Lab</p>
     </a>
   </div>
   <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
     <!-- AI Apps -->
-    <span class="pl-3 text-sm text-gray-700">AI APPS</span>
+    <span class="pl-3 text-sm text-gray-700 ml-[4px]">AI APPS</span>
     <SettingsNavItem icon="{faBookOpen}" title="Recipes Catalog" href="/recipes" bind:meta="{meta}" />
     <SettingsNavItem icon="{faServer}" title="Running" href="/applications" bind:meta="{meta}" />
 
     <!-- Models -->
-    <div class="pl-3 mt-2">
+    <div class="pl-3 mt-2 ml-[4px]">
       <span class="text-sm text-gray-700">MODELS</span>
     </div>
     <SettingsNavItem icon="{faBookOpen}" title="Catalog" href="/models" bind:meta="{meta}" />


### PR DESCRIPTION
### What does this PR do?

The navigation item have a border of 4px, making them slightly unaligned. This PR is adding this 4px as margin to other items to align item. 

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/86aadacc-c72e-43fc-a097-4a07f3385cd3) | ![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/d4c2d6c1-f4e4-4e08-a498-e5fbfef31ee9) |

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/795

### How to test this PR?

<!-- Please explain steps to reproduce -->