### PR TITLE
fix(ServiceDetails): items center

### DIFF
--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -98,7 +98,7 @@ onMount(() => {
                   {#key service.health?.Status}
                     <ServiceStatus object="{service}" />
                   {/key}
-                  <div class="flex flex-col text-xs ml-2">
+                  <div class="flex flex-col text-xs ml-2 items-center">
                     <span>{service.container.containerId}</span>
                   </div>
                 </div>

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -98,7 +98,7 @@ onMount(() => {
                   {#key service.health?.Status}
                     <ServiceStatus object="{service}" />
                   {/key}
-                  <div class="flex flex-col text-xs ml-2 items-center">
+                  <div class="flex flex-col text-xs ml-2 items-center justify-center">
                     <span>{service.container.containerId}</span>
                   </div>
                 </div>
@@ -110,7 +110,7 @@ onMount(() => {
                 <span class="text-sm">Models</span>
                 <div class="w-full bg-charcoal-600 rounded-md p-2 flex flex-col gap-y-4">
                   {#each service.models as model}
-                    <div class="flex flex-row gap-2 items-center">
+                    <div class="flex flex-row gap-2">
                       <div class="grow text-sm">{model.name}</div>
                       <div>
                         <div

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -110,7 +110,7 @@ onMount(() => {
                 <span class="text-sm">Models</span>
                 <div class="w-full bg-charcoal-600 rounded-md p-2 flex flex-col gap-y-4">
                   {#each service.models as model}
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row gap-2 items-center">
                       <div class="grow text-sm">{model.name}</div>
                       <div>
                         <div


### PR DESCRIPTION
### What does this PR do?

Ensure the container id is centered properly

### Screenshot / video of UI

**Before**
![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/5fd00de0-4940-4c58-85b3-67042c0c419a)

**After**

<img width="635" alt="image" src="https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/6e654e4c-c25f-4fda-bca6-0a0b4adc4fc8">

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/572

### How to test this PR?

<!-- Please explain steps to reproduce -->