### PR TITLE
fix: disable delete local clone when building ai app

### DIFF
--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -182,7 +182,11 @@ const deleteLocalClone = () => {
               <span>Local clone</span>
             </div>
           </button>
-          <Button title="Delete local clone" on:click="{deleteLocalClone}" icon="{faTrash}" />
+          <Button
+            title="Delete local clone"
+            on:click="{deleteLocalClone}"
+            icon="{faTrash}"
+            disabled="{runningTask !== undefined}" />
         </div>
       {/if}
     </div>


### PR DESCRIPTION
### What does this PR do?

it disables the delete local clone button when the ai app is building 

### Screenshot / video of UI

![delete_button](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/58207330-a07d-49fa-9aa5-67ef9f2911c1)

### What issues does this PR fix or reference?

it resolves #745 

### How to test this PR?

1. run recipe and check that while it is building the images the button is disabled