### PR TITLE
fix: wrong alignment in playground table header

### DIFF
--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -13,7 +13,7 @@ import { conversations } from '/@/stores/conversations';
 const columns: Column<PlaygroundV2>[] = [
   new Column<PlaygroundV2>('Name', { width: '1fr', renderer: PlaygroundColumnName }),
   new Column<PlaygroundV2>('Model', { width: '1fr', renderer: PlaygroundColumnModel }),
-  new Column<PlaygroundV2>('Actions', { width: '40px', renderer: ConversationColumnAction }),
+  new Column<PlaygroundV2>('Actions', { width: '40px', renderer: ConversationColumnAction, align: 'center' }),
 ];
 const row = new Row<PlaygroundV2>({});
 


### PR DESCRIPTION
### What does this PR do?

fix alignment.
instead of keeping the left alignment and move the action icon a bit more away from the right-end. I think it's nicer to have it centered. Maybe when having more icon we can think about switching back to left

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/9f801b2e-c844-42ed-a2cc-e0327ba3e8a9)

### What issues does this PR fix or reference?

it resolves #786 

### How to test this PR?

1. go to the playgrounds page