### PR TITLE
feat: better icon for pod deletion

### DIFF
--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -244,7 +244,7 @@ export class StudioApiImpl implements StudioAPI {
     // Do not wait on the promise as the api would probably timeout before the user answer.
     podmanDesktopApi.window
       .showWarningMessage(
-        `Stop the AI App "${recipe.name}"? This will delete the containers running the application and model.`,
+        `Delete the AI App "${recipe.name}"? This will delete the containers running the application and model.`,
         'Confirm',
         'Cancel',
       )

--- a/packages/frontend/src/lib/ApplicationActions.spec.ts
+++ b/packages/frontend/src/lib/ApplicationActions.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { expect, test, vi, beforeEach } from 'vitest';
+
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { studioClient } from '../utils/client';
+import ApplicationActions from '/@/lib/ApplicationActions.svelte';
+import type { ApplicationState } from '@shared/src/models/IApplicationState';
+
+vi.mock('../utils/client', async () => ({
+  studioClient: {
+    requestRemoveApplication: vi.fn(),
+    requestRestartApplication: vi.fn(),
+    requestOpenApplication: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(studioClient.requestRemoveApplication).mockResolvedValue(undefined);
+  vi.mocked(studioClient.requestRestartApplication).mockResolvedValue(undefined);
+  vi.mocked(studioClient.requestOpenApplication).mockResolvedValue(undefined);
+});
+
+test('deletion action should call requestRemoveApplication', async () => {
+  render(ApplicationActions, {
+    object: {
+      pod: {},
+    } as unknown as ApplicationState,
+    recipeId: 'dummy-recipe-id',
+    modelId: 'dummy-model-id',
+  });
+
+  const deleteBtn = screen.getByTitle('Delete AI App');
+  expect(deleteBtn).toBeVisible();
+
+  await fireEvent.click(deleteBtn);
+  expect(studioClient.requestRemoveApplication).toHaveBeenCalledWith('dummy-recipe-id', 'dummy-model-id');
+});
+
+test('open action should call requestOpenApplication', async () => {
+  render(ApplicationActions, {
+    object: {
+      pod: {},
+    } as unknown as ApplicationState,
+    recipeId: 'dummy-recipe-id',
+    modelId: 'dummy-model-id',
+  });
+
+  const openBtn = screen.getByTitle('Open AI App');
+  expect(openBtn).toBeVisible();
+
+  await fireEvent.click(openBtn);
+  expect(studioClient.requestOpenApplication).toHaveBeenCalledWith('dummy-recipe-id', 'dummy-model-id');
+});
+
+test('restart action should call requestRestartApplication', async () => {
+  render(ApplicationActions, {
+    object: {
+      pod: {},
+    } as unknown as ApplicationState,
+    recipeId: 'dummy-recipe-id',
+    modelId: 'dummy-model-id',
+  });
+
+  const restartBtn = screen.getByTitle('Restart AI App');
+  expect(restartBtn).toBeVisible();
+
+  await fireEvent.click(restartBtn);
+  expect(studioClient.requestRestartApplication).toHaveBeenCalledWith('dummy-recipe-id', 'dummy-model-id');
+});

--- a/packages/frontend/src/lib/ApplicationActions.svelte
+++ b/packages/frontend/src/lib/ApplicationActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faRotateForward, faStop, faArrowUpRightFromSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faRotateForward, faArrowUpRightFromSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '/@/lib/button/ListItemButtonIcon.svelte';
 import { studioClient } from '/@/utils/client';
 import type { ApplicationState } from '@shared/src/models/IApplicationState';

--- a/packages/frontend/src/lib/ApplicationActions.svelte
+++ b/packages/frontend/src/lib/ApplicationActions.svelte
@@ -9,7 +9,7 @@ export let modelId: string;
 
 function deleteApplication() {
   studioClient.requestRemoveApplication(recipeId, modelId).catch(err => {
-    console.error(`Something went wrong while trying to stop AI App: ${String(err)}.`);
+    console.error(`Something went wrong while trying to delete AI App: ${String(err)}.`);
   });
 }
 

--- a/packages/frontend/src/lib/ApplicationActions.svelte
+++ b/packages/frontend/src/lib/ApplicationActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faRotateForward, faStop, faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { faRotateForward, faStop, faArrowUpRightFromSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '/@/lib/button/ListItemButtonIcon.svelte';
 import { studioClient } from '/@/utils/client';
 import type { ApplicationState } from '@shared/src/models/IApplicationState';
@@ -7,7 +7,7 @@ export let object: ApplicationState | undefined;
 export let recipeId: string;
 export let modelId: string;
 
-function stopApplication() {
+function deleteApplication() {
   studioClient.requestRemoveApplication(recipeId, modelId).catch(err => {
     console.error(`Something went wrong while trying to stop AI App: ${String(err)}.`);
   });
@@ -27,7 +27,7 @@ function openApplication() {
 </script>
 
 {#if object?.pod !== undefined}
-  <ListItemButtonIcon icon="{faStop}" onClick="{() => stopApplication()}" title="Stop AI App" />
+  <ListItemButtonIcon icon="{faTrash}" onClick="{() => deleteApplication()}" title="Delete AI App" />
 
   <ListItemButtonIcon icon="{faArrowUpRightFromSquare}" onClick="{() => openApplication()}" title="Open AI App" />
 


### PR DESCRIPTION
### What does this PR do?

After discussing with @slemeur about https://github.com/containers/podman-desktop-extension-ai-lab/issues/469 we understood that the delete icon added in https://github.com/containers/podman-desktop-extension-ai-lab/pull/719 was responsible of the cleanup.

To complete the ticket, this PR is changing the misleading stop icon to the trash icon, to reflect the real action of the button, which is deleting the pod.

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/c7efdb97-50e4-48f7-8755-9fdce6dc1b85)

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/9d5df573-6b1a-4a0a-bb85-7309ee978da9)


### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/469

### How to test this PR?

- [x] unit tests has been provided