### PR TITLE
fix: open in VScode URL format is broken on Windows

### DIFF
--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -367,7 +367,7 @@ export class StudioApiImpl implements StudioAPI {
     const unixPath: string = path.normalize(directory).replace(/[\\/]+/g, '/');
 
     podmanDesktopApi.env
-      .openExternal(podmanDesktopApi.Uri.file(unixPath).with({ scheme: 'vscode', authority: 'file' }))
+      .openExternal(podmanDesktopApi.Uri.file(unixPath).with({ scheme: 'vscode', authority: 'file/' }))
       .catch((err: unknown) => {
         console.error('Something went wrong while trying to open VSCode', err);
       });


### PR DESCRIPTION
Fixes #832

### What does this PR do?

Fix the VSCode URL which is not valid for Windows

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#832

### How to test this PR?

1. Pull a recipe
2. Open it in VSCode