### PR TITLE
fix: using podman storage path from context

### DIFF
--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -28,6 +28,7 @@ vi.mock('./managers/modelsManager');
 
 const mockedExtensionContext = {
   subscriptions: [],
+  storagePath: 'dummy-storage-path',
 } as unknown as ExtensionContext;
 
 const studio = new Studio(mockedExtensionContext);

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -44,9 +44,6 @@ import { SnippetManager } from './managers/SnippetManager';
 import { CancellationTokenRegistry } from './registries/CancellationTokenRegistry';
 import { engines } from '../package.json';
 
-// TODO: Need to be configured
-export const AI_LAB_FOLDER = path.join('podman-desktop', 'ai-lab');
-
 export const AI_LAB_COLLECT_GPU_COMMAND = 'ai-lab.gpu.collect';
 
 export class Studio {
@@ -148,8 +145,7 @@ export class Studio {
     const containerRegistry = new ContainerRegistry();
     this.#extensionContext.subscriptions.push(containerRegistry.init());
 
-    // Let's create the api that the front will be able to call
-    const appUserDirectory = path.join(os.homedir(), AI_LAB_FOLDER);
+    const appUserDirectory = this.extensionContext.storagePath;
 
     this.rpcExtension = new RpcExtension(this.#panel.webview);
     const gitManager = new GitManager();

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -32,8 +32,6 @@ import { GitManager } from './managers/gitManager';
 import { TaskRegistry } from './registries/TaskRegistry';
 import { CatalogManager } from './managers/catalogManager';
 import { ModelsManager } from './managers/modelsManager';
-import path from 'node:path';
-import os from 'os';
 import fs from 'node:fs';
 import { ContainerRegistry } from './registries/ContainerRegistry';
 import { PodmanConnection } from './managers/podmanConnection';


### PR DESCRIPTION
### What does this PR do?

Use `extensionContext.storagePath` instead of `$HOME/podman-desktop/ai-lab`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/844

### How to test this PR?

- [x] existing unit tests ensure no regression