### PR TITLE
fix: models table columns

### DIFF
--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -23,12 +23,12 @@ const columns: Column<ModelInfo>[] = [
   new Column<ModelInfo>('Name', {
     width: '3fr',
     renderer: ModelColumnName,
-    comparator: (a, b) => (a.file?.size ?? Number.MAX_SAFE_INTEGER) - (b.name.localeCompare(a.name)),
+    comparator: (a, b) => b.name.localeCompare(a.name),
   }),
   new Column<ModelInfo>('Size', {
     width: '50px',
     renderer: ModelColumnSize,
-    comparator: (a, b) => (a.file?.size ?? Number.MAX_SAFE_INTEGER) - (b.file?.size ?? Number.MAX_SAFE_INTEGER),
+    comparator: (a, b) => (a.file?.size ?? 0) - (b.file?.size ?? 0),
   }),
   new Column<ModelInfo>('Age', {
     width: '70px',

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -20,9 +20,21 @@ import ModelColumnIcon from '../lib/table/model/ModelColumnIcon.svelte';
 
 const columns: Column<ModelInfo>[] = [
   new Column<ModelInfo>('', { width: '40px', renderer: ModelColumnIcon }),
-  new Column<ModelInfo>('Name', { width: '3fr', renderer: ModelColumnName }),
-  new Column<ModelInfo>('Size', { width: '50px', renderer: ModelColumnSize }),
-  new Column<ModelInfo>('Age', { width: '60px', renderer: ModelColumnAge }),
+  new Column<ModelInfo>('Name', {
+    width: '3fr',
+    renderer: ModelColumnName,
+    comparator: (a, b) => (a.file?.size ?? Number.MAX_SAFE_INTEGER) - (b.name.localeCompare(a.name)),
+  }),
+  new Column<ModelInfo>('Size', {
+    width: '50px',
+    renderer: ModelColumnSize,
+    comparator: (a, b) => (a.file?.size ?? Number.MAX_SAFE_INTEGER) - (b.file?.size ?? Number.MAX_SAFE_INTEGER),
+  }),
+  new Column<ModelInfo>('Age', {
+    width: '70px',
+    renderer: ModelColumnAge,
+    comparator: (a, b) => (a.file?.creation?.getTime() ?? 0) - (b.file?.creation?.getTime() ?? 0),
+  }),
   new Column<ModelInfo>('', { width: '225px', align: 'right', renderer: ModelColumnLabels }),
   new Column<ModelInfo>('Actions', { align: 'right', width: '120px', renderer: ModelColumnActions }),
 ];


### PR DESCRIPTION
### What does this PR do?

This PR improve slightly the catalog models table, by increasing the size of the age column, and adding comparators to sort the column.

### Screenshot / video of UI

**seconds**

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/c315de56-7458-4061-8904-bf4c03e65f4b)

** minutes **

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/a9091fd5-a6cb-47b9-9e97-c87011b4937c)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/840

### How to test this PR?

<!-- Please explain steps to reproduce -->