### PR TITLE
fix: add telemetry for snippets

### DIFF
--- a/packages/backend/src/managers/SnippetManager.spec.ts
+++ b/packages/backend/src/managers/SnippetManager.spec.ts
@@ -18,12 +18,17 @@
 
 import { beforeEach, expect, test, vi } from 'vitest';
 import { SnippetManager } from './SnippetManager';
-import type { Webview } from '@podman-desktop/api';
+import type { TelemetryLogger, Webview } from '@podman-desktop/api';
 import { Messages } from '@shared/Messages';
 
 const webviewMock = {
   postMessage: vi.fn(),
 } as unknown as Webview;
+
+const telemetryMock = {
+  logUsage: vi.fn(),
+  logError: vi.fn(),
+} as unknown as TelemetryLogger;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -31,7 +36,7 @@ beforeEach(() => {
 });
 
 test('expect init to notify webview', () => {
-  const manager = new SnippetManager(webviewMock);
+  const manager = new SnippetManager(webviewMock, telemetryMock);
   manager.init();
 
   expect(webviewMock.postMessage).toHaveBeenCalledWith({
@@ -41,14 +46,14 @@ test('expect init to notify webview', () => {
 });
 
 test('expect postman-code-generators to have many languages available.', () => {
-  const manager = new SnippetManager(webviewMock);
+  const manager = new SnippetManager(webviewMock, telemetryMock);
   manager.init();
 
   expect(manager.getLanguageList().length).toBeGreaterThan(0);
 });
 
 test('expect postman-code-generators to have nodejs supported.', () => {
-  const manager = new SnippetManager(webviewMock);
+  const manager = new SnippetManager(webviewMock, telemetryMock);
   manager.init();
 
   const languages = manager.getLanguageList();
@@ -61,7 +66,7 @@ test('expect postman-code-generators to have nodejs supported.', () => {
 });
 
 test('expect postman-code-generators to generate proper nodejs native code', async () => {
-  const manager = new SnippetManager(webviewMock);
+  const manager = new SnippetManager(webviewMock, telemetryMock);
   manager.init();
 
   const snippet = await manager.generate(
@@ -86,7 +91,7 @@ request(options, function (error, response) {
 });
 
 test('expect snippet manager to have Quarkus Langchain4J supported.', () => {
-  const manager = new SnippetManager(webviewMock);
+  const manager = new SnippetManager(webviewMock, telemetryMock);
   manager.init();
 
   const languages = manager.getLanguageList();
@@ -99,7 +104,7 @@ test('expect snippet manager to have Quarkus Langchain4J supported.', () => {
 });
 
 test('expect new variant to replace existing one if same name', () => {
-  const manager = new SnippetManager(webviewMock);
+  const manager = new SnippetManager(webviewMock, telemetryMock);
   manager.init();
 
   const languages = manager.getLanguageList();

--- a/packages/backend/src/managers/SnippetManager.ts
+++ b/packages/backend/src/managers/SnippetManager.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { Disposable, Webview } from '@podman-desktop/api';
+import type { Disposable, TelemetryLogger, Webview } from '@podman-desktop/api';
 import { getLanguageList, convert, type Language } from 'postman-code-generators';
 import { Request } from 'postman-collection';
 import { Publisher } from '../utils/Publisher';
@@ -31,7 +31,10 @@ export class SnippetManager extends Publisher<Language[]> implements Disposable 
   #languages: Language[];
   #additionalGenerators: Map<string, Generator>;
 
-  constructor(webview: Webview) {
+  constructor(
+    webview: Webview,
+    private telemetry: TelemetryLogger,
+  ) {
     super(webview, Messages.MSG_SUPPORTED_LANGUAGES_UPDATE, () => this.getLanguageList());
   }
 
@@ -51,6 +54,7 @@ export class SnippetManager extends Publisher<Language[]> implements Disposable 
   }
 
   async generate(requestOptions: RequestOptions, language: string, variant: string): Promise<string> {
+    this.telemetry.logUsage('snippet.generate', { language: language, variant: variant });
     const generator = this.#additionalGenerators.get(`${language}/${variant}`);
     if (generator) {
       return generator(requestOptions);

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -203,7 +203,7 @@ export class Studio {
       this.telemetry,
     );
 
-    const snippetManager = new SnippetManager(this.#panel.webview);
+    const snippetManager = new SnippetManager(this.#panel.webview, this.telemetry);
     snippetManager.init();
 
     // Creating StudioApiImpl

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -25,6 +25,8 @@ $: variants = $snippetLanguages.find(language => language.key === selectedLangua
 let selectedVariant: string = 'cURL';
 $: selectedVariant;
 
+let code: HTMLElement;
+
 const onLanguageChange = (): void => {
   if (variants.length > 0) {
     selectedVariant = variants[0].key;
@@ -70,6 +72,14 @@ const generate = async (language: string, variant: string) => {
 $: {
   if (!snippet && service) {
     generate('curl', 'cURL');
+  }
+}
+
+$: {
+  if (code) {
+    code.addEventListener('copy', event => {
+      studioClient.telemetryLogUsage('snippet.copy', { language: selectedLanguage, variant: selectedVariant });
+    });
   }
 }
 
@@ -184,7 +194,7 @@ onMount(() => {
 
               {#if snippet !== undefined}
                 <div class="bg-charcoal-900 rounded-md w-full p-4 mt-2">
-                  <code class="whitespace-break-spaces text-sm">
+                  <code class="whitespace-break-spaces text-sm" bind:this="{code}">
                     {snippet}
                   </code>
                 </div>


### PR DESCRIPTION
Fixes #835

### What does this PR do?

Add telemetry events for snippets:
- `snippet.create`: when a snippet is generated
- `snippet.copy`: when code is copied into clipboard

Both have `language` and `variant` as properties

### Screenshot / video of UI

<N/A

### What issues does this PR fix or reference?

#835 

### How to test this PR?

N/A