### PR TITLE
feat: show warning if no machine is running or there are not enough resources (#227)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -54,7 +54,7 @@
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
-    "@podman-desktop/api": "^1.9.0",
+    "@podman-desktop/api": "0.0.202404101645-5d46ba5",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/postman-collection": "^3.5.10",

--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -33,7 +33,7 @@ import { LocalRepositoryRegistry } from './registries/LocalRepositoryRegistry';
 import type { Recipe } from '@shared/src/models/IRecipe';
 import type { PlaygroundV2Manager } from './managers/playgroundV2Manager';
 import type { SnippetManager } from './managers/SnippetManager';
-import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import type { ModelCheckerInfo, ModelInfo } from '@shared/src/models/IModelInfo';
 import type { CancellationTokenRegistry } from './registries/CancellationTokenRegistry';
 import path from 'node:path';
 import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
@@ -348,7 +348,11 @@ test('navigateToEditConnectionProvider should call navigation.navigateToEditProv
 
 test('checkContainerConnectionStatusAndResources should call podman.checkContainerConnectionStatusAndResources', async () => {
   const checkContainerSpy = vi.spyOn(podman, 'checkContainerConnectionStatusAndResources');
-  await studioApiImpl.checkContainerConnectionStatusAndResources(1000);
+  const modelInfo: ModelCheckerInfo = {
+    memoryNeeded: 1000,
+    context: 'inference',
+  };
+  await studioApiImpl.checkContainerConnectionStatusAndResources(modelInfo);
   await timeout(0);
-  expect(checkContainerSpy).toHaveBeenCalledWith(1000);
+  expect(checkContainerSpy).toHaveBeenCalledWith(modelInfo);
 });

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -43,6 +43,8 @@ import type { Language } from 'postman-code-generators';
 import type { ModelOptions } from '@shared/src/models/IModelOptions';
 import type { CancellationTokenRegistry } from './registries/CancellationTokenRegistry';
 import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
+import { checkContainerConnectionStatusAndResources, getPodmanConnection } from './utils/podman';
+import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 
 interface PortQuickPickItem extends podmanDesktopApi.QuickPickItem {
   port: number;
@@ -248,6 +250,15 @@ export class StudioApiImpl implements StudioAPI {
     const pod = pods.find(pod => pod.Id === podId);
     if (pod === undefined) throw new Error(`Pod with id ${podId} not found.`);
     return podmanDesktopApi.navigation.navigateToPod(pod.kind, pod.Name, pod.engineId);
+  }
+
+  async navigateToResources(): Promise<void> {
+    return podmanDesktopApi.navigation.navigateToResources();
+  }
+
+  async navigateToEditConnectionProvider(connectionName: string): Promise<void> {
+    const connection = getPodmanConnection(connectionName);
+    return podmanDesktopApi.navigation.navigateToEditProviderContainerConnection(connection);
   }
 
   async getApplicationsState(): Promise<ApplicationState[]> {
@@ -466,5 +477,9 @@ export class StudioApiImpl implements StudioAPI {
 
   copyToClipboard(content: string): Promise<void> {
     return podmanDesktopApi.env.clipboard.writeText(content);
+  }
+  
+  async checkContainerConnectionStatusAndResources(memory: number): Promise<ContainerConnectionInfo> {
+    return checkContainerConnectionStatusAndResources(memory);
   }
 }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -18,7 +18,7 @@
 
 import type { StudioAPI } from '@shared/src/StudioAPI';
 import type { ApplicationManager } from './managers/applicationManager';
-import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import type { ModelCheckerInfo, ModelInfo } from '@shared/src/models/IModelInfo';
 import * as podmanDesktopApi from '@podman-desktop/api';
 
 import type { CatalogManager } from './managers/catalogManager';
@@ -485,7 +485,7 @@ export class StudioApiImpl implements StudioAPI {
     return podmanDesktopApi.env.clipboard.writeText(content);
   }
   
-  async checkContainerConnectionStatusAndResources(memory: number): Promise<ContainerConnectionInfo> {
-    return checkContainerConnectionStatusAndResources(memory);
+  async checkContainerConnectionStatusAndResources(modelInfo: ModelCheckerInfo): Promise<ContainerConnectionInfo> {
+    return checkContainerConnectionStatusAndResources(modelInfo);
   }
 }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -484,7 +484,7 @@ export class StudioApiImpl implements StudioAPI {
   copyToClipboard(content: string): Promise<void> {
     return podmanDesktopApi.env.clipboard.writeText(content);
   }
-  
+
   async checkContainerConnectionStatusAndResources(modelInfo: ModelCheckerInfo): Promise<ContainerConnectionInfo> {
     return checkContainerConnectionStatusAndResources(modelInfo);
   }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -253,12 +253,18 @@ export class StudioApiImpl implements StudioAPI {
   }
 
   async navigateToResources(): Promise<void> {
-    return podmanDesktopApi.navigation.navigateToResources();
+    // navigateToResources is only vailable from desktop 1.10
+    if (podmanDesktopApi.navigation.navigateToResources) {
+      return podmanDesktopApi.navigation.navigateToResources();
+    }
   }
 
   async navigateToEditConnectionProvider(connectionName: string): Promise<void> {
-    const connection = getPodmanConnection(connectionName);
-    return podmanDesktopApi.navigation.navigateToEditProviderContainerConnection(connection);
+    // navigateToEditProviderContainerConnection is only vailable from desktop 1.10
+    if (podmanDesktopApi.navigation.navigateToEditProviderContainerConnection) {
+      const connection = getPodmanConnection(connectionName);
+      return podmanDesktopApi.navigation.navigateToEditProviderContainerConnection(connection);
+    }
   }
 
   async getApplicationsState(): Promise<ApplicationState[]> {

--- a/packages/backend/src/utils/podman.spec.ts
+++ b/packages/backend/src/utils/podman.spec.ts
@@ -331,7 +331,10 @@ describe('checkContainerConnectionStatusAndResources', () => {
   };
   test('return noMachineInfo if there is no running podman connection', async () => {
     vi.spyOn(utils, 'getFirstRunningPodmanConnection').mockReturnValue(undefined);
-    const result = await utils.checkContainerConnectionStatusAndResources(10);
+    const result = await utils.checkContainerConnectionStatusAndResources({
+      memoryNeeded: 10,
+      context: 'inference',
+    });
     expect(result).toStrictEqual({
       status: 'no-machine',
       canRedirect: true,
@@ -352,14 +355,17 @@ describe('checkContainerConnectionStatusAndResources', () => {
       },
     ]);
     vi.mocked(podmanDesktopApi.containerEngine.info).mockResolvedValue(undefined);
-    const result = await utils.checkContainerConnectionStatusAndResources(10);
+    const result = await utils.checkContainerConnectionStatusAndResources({
+      memoryNeeded: 10,
+      context: 'inference',
+    });
     expect(result).toStrictEqual({
       status: 'no-machine',
       canRedirect: true,
     });
   });
   test('return lowResourceMachineInfo if the podman connection has not enough cpus', async () => {
-    engineInfo.cpus = 4;
+    engineInfo.cpus = 3;
     engineInfo.memory = 20;
     engineInfo.memoryUsed = 0;
     mocks.getContainerConnectionsMock.mockReturnValue([
@@ -376,13 +382,16 @@ describe('checkContainerConnectionStatusAndResources', () => {
       },
     ]);
     vi.mocked(podmanDesktopApi.containerEngine.info).mockResolvedValue(engineInfo);
-    const result = await utils.checkContainerConnectionStatusAndResources(10);
+    const result = await utils.checkContainerConnectionStatusAndResources({
+      memoryNeeded: 10,
+      context: 'inference',
+    });
     expect(result).toStrictEqual({
       name: 'Podman Machine',
-      cpus: 4,
+      cpus: 3,
       memoryIdle: 20,
-      cpusExpected: 10,
-      memoryExpected: 10,
+      cpusExpected: 4,
+      memoryExpected: 11,
       status: 'low-resources',
       canEdit: false,
       canRedirect: true,
@@ -406,13 +415,16 @@ describe('checkContainerConnectionStatusAndResources', () => {
       },
     ]);
     vi.mocked(podmanDesktopApi.containerEngine.info).mockResolvedValue(engineInfo);
-    const result = await utils.checkContainerConnectionStatusAndResources(10);
+    const result = await utils.checkContainerConnectionStatusAndResources({
+      memoryNeeded: 10,
+      context: 'inference',
+    });
     expect(result).toStrictEqual({
       name: 'Podman Machine',
       cpus: 12,
       memoryIdle: 5,
-      cpusExpected: 10,
-      memoryExpected: 10,
+      cpusExpected: 4,
+      memoryExpected: 11,
       status: 'low-resources',
       canEdit: false,
       canRedirect: true,
@@ -436,7 +448,10 @@ describe('checkContainerConnectionStatusAndResources', () => {
       },
     ]);
     vi.spyOn(podmanDesktopApi.containerEngine, 'info').mockResolvedValue(engineInfo);
-    const result = await utils.checkContainerConnectionStatusAndResources(10);
+    const result = await utils.checkContainerConnectionStatusAndResources({
+      memoryNeeded: 10,
+      context: 'inference',
+    });
     expect(result).toStrictEqual({
       name: 'Podman Machine',
       status: 'running',

--- a/packages/backend/src/utils/podman.ts
+++ b/packages/backend/src/utils/podman.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { ProviderContainerConnection } from '@podman-desktop/api';
-import { configuration, containerEngine, env, process, provider } from '@podman-desktop/api';
+import { configuration, containerEngine, env, navigation, process, provider } from '@podman-desktop/api';
 import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 
 export const MIN_CPUS_VALUE = 10;
@@ -143,9 +143,13 @@ export async function checkContainerConnectionStatusAndResources(
     console.log(String(e));
   }
 
+  // starting from podman desktop 1.10 we have the navigate functions
+  const hasNavigateFunction = !!navigation.navigateToResources;
+
   if (!connection) {
     return {
       status: 'no-machine',
+      canRedirect: hasNavigateFunction,
     };
   }
 
@@ -153,6 +157,7 @@ export async function checkContainerConnectionStatusAndResources(
   if (!engineInfo) {
     return {
       status: 'no-machine',
+      canRedirect: hasNavigateFunction,
     };
   }
 
@@ -167,13 +172,15 @@ export async function checkContainerConnectionStatusAndResources(
       memoryIdle: engineInfo.memory - engineInfo.memoryUsed,
       cpusExpected: MIN_CPUS_VALUE,
       memoryExpected: memoryNeeded,
-      status: 'not-enough-resources',
+      status: 'low-resources',
       canEdit: !!connection.connection.lifecycle?.edit,
+      canRedirect: hasNavigateFunction,
     };
   }
 
   return {
     name: engineInfo.engineName,
     status: 'running',
+    canRedirect: hasNavigateFunction,
   };
 }

--- a/packages/backend/src/utils/podman.ts
+++ b/packages/backend/src/utils/podman.ts
@@ -161,9 +161,11 @@ export async function checkContainerConnectionStatusAndResources(
     };
   }
 
-  const hasCpus = engineInfo.cpus && engineInfo.cpus >= MIN_CPUS_VALUE;
+  const hasCpus = engineInfo.cpus !== undefined && engineInfo.cpus >= MIN_CPUS_VALUE;
   const hasMemory =
-    engineInfo.memory && engineInfo.memoryUsed && engineInfo.memory - engineInfo.memoryUsed >= memoryNeeded;
+    engineInfo.memory !== undefined &&
+    engineInfo.memoryUsed !== undefined &&
+    engineInfo.memory - engineInfo.memoryUsed >= memoryNeeded;
 
   if (!hasCpus || !hasMemory) {
     return {
@@ -179,7 +181,7 @@ export async function checkContainerConnectionStatusAndResources(
   }
 
   return {
-    name: engineInfo.engineName,
+    name: connection.connection.name,
     status: 'running',
     canRedirect: hasNavigateFunction,
   };

--- a/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.spec.ts
+++ b/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.spec.ts
@@ -1,0 +1,258 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ContainerConnectionStatusInfo from './ContainerConnectionStatusInfo.svelte';
+import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+import { studioClient } from '/@/utils/client';
+import { filesize } from 'filesize';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('/@/utils/client', async () => {
+  return {
+    studioClient: {
+      navigateToResources: vi.fn(),
+      navigateToEditConnectionProvider: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('should not show anything if there is no title or description', async () => {
+  const connectionInfo: ContainerConnectionInfo = {
+    name: 'Podman machine',
+    status: 'running',
+    canRedirect: true,
+  };
+  render(ContainerConnectionStatusInfo, { connectionInfo });
+
+  const banner = screen.queryByLabelText('Container connection info banner');
+  expect(banner).not.toBeInTheDocument();
+});
+
+test('should show no running machine banner if there is no running machine', async () => {
+  const navigateMock = vi.spyOn(studioClient, 'navigateToResources');
+  const noMachineInfo: ContainerConnectionInfo = {
+    status: 'no-machine',
+    canRedirect: true,
+  };
+
+  render(ContainerConnectionStatusInfo, { connectionInfo: noMachineInfo });
+
+  const banner = screen.getByLabelText('Container connection info banner');
+  expect(banner).toBeInTheDocument();
+  const titleDiv = screen.getByLabelText('title');
+  expect(titleDiv).toBeInTheDocument();
+  expect(titleDiv.textContent).equals('No Podman machine is running');
+  const descriptionDiv = screen.getByLabelText('description');
+  expect(descriptionDiv).toBeInTheDocument();
+  expect(descriptionDiv.textContent).equals('Please start a Podman Machine before proceeding further.');
+
+  const btnStart = screen.getByRole('button', { name: 'Start now' });
+  expect(btnStart).toBeInTheDocument();
+
+  await userEvent.click(btnStart);
+
+  expect(navigateMock).toBeCalled();
+});
+
+test('should show no running machine banner if there is no running machine and no action if canRedirect is disabled', async () => {
+  const noMachineInfo: ContainerConnectionInfo = {
+    status: 'no-machine',
+    canRedirect: false,
+  };
+
+  render(ContainerConnectionStatusInfo, { connectionInfo: noMachineInfo });
+
+  const banner = screen.getByLabelText('Container connection info banner');
+  expect(banner).toBeInTheDocument();
+  const titleDiv = screen.getByLabelText('title');
+  expect(titleDiv).toBeInTheDocument();
+  expect(titleDiv.textContent).equals('No Podman machine is running');
+  const descriptionDiv = screen.getByLabelText('description');
+  expect(descriptionDiv).toBeInTheDocument();
+  expect(descriptionDiv.textContent).equals('Please start a Podman Machine before proceeding further.');
+
+  const btnStart = screen.queryByRole('button', { name: 'Start now' });
+  expect(btnStart).not.toBeInTheDocument();
+});
+
+test('should show lowResourcesMachine banner if the running machine has not enough resources and both canEdit and canRedirect are true', async () => {
+  const navigateMock = vi.spyOn(studioClient, 'navigateToEditConnectionProvider');
+  const connectionInfo: ContainerConnectionInfo = {
+    name: 'Podman Machine',
+    canEdit: true,
+    canRedirect: true,
+    cpus: 4,
+    cpusExpected: 10,
+    memoryExpected: 10,
+    memoryIdle: 5,
+    status: 'low-resources',
+  };
+
+  render(ContainerConnectionStatusInfo, { connectionInfo });
+
+  const banner = screen.getByLabelText('Container connection info banner');
+  expect(banner).toBeInTheDocument();
+  const titleDiv = screen.getByLabelText('title');
+  expect(titleDiv).toBeInTheDocument();
+  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  const descriptionDiv = screen.getByLabelText('description');
+  expect(descriptionDiv).toBeInTheDocument();
+  expect(descriptionDiv.textContent).equals(
+    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend upgrading your Podman machine with at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
+  );
+
+  const btnUpgrade = screen.getByRole('button', { name: 'Upgrade now' });
+  expect(btnUpgrade).toBeInTheDocument();
+
+  await userEvent.click(btnUpgrade);
+
+  expect(navigateMock).toBeCalledWith('Podman Machine');
+});
+
+test('should show lowResourcesMachine banner if the running machine has not enough cpus and both canEdit and canRedirect are true', async () => {
+  const navigateMock = vi.spyOn(studioClient, 'navigateToEditConnectionProvider');
+  const connectionInfo: ContainerConnectionInfo = {
+    name: 'Podman Machine',
+    canEdit: true,
+    canRedirect: true,
+    cpus: 4,
+    cpusExpected: 10,
+    memoryExpected: 4,
+    memoryIdle: 5,
+    status: 'low-resources',
+  };
+
+  render(ContainerConnectionStatusInfo, { connectionInfo });
+
+  const banner = screen.getByLabelText('Container connection info banner');
+  expect(banner).toBeInTheDocument();
+  const titleDiv = screen.getByLabelText('title');
+  expect(titleDiv).toBeInTheDocument();
+  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  const descriptionDiv = screen.getByLabelText('description');
+  expect(descriptionDiv).toBeInTheDocument();
+  expect(descriptionDiv.textContent).equals(
+    `Your Podman Machine has ${connectionInfo.cpus} vCPUs. We recommend upgrading your Podman machine with at least ${connectionInfo.cpusExpected} vCPUs for better AI performance.`,
+  );
+
+  const btnUpgrade = screen.getByRole('button', { name: 'Upgrade now' });
+  expect(btnUpgrade).toBeInTheDocument();
+
+  await userEvent.click(btnUpgrade);
+
+  expect(navigateMock).toBeCalledWith('Podman Machine');
+});
+
+test('should show lowResourcesMachine banner if the running machine has not enough memory and both canEdit and canRedirect are true', async () => {
+  const navigateMock = vi.spyOn(studioClient, 'navigateToEditConnectionProvider');
+  const connectionInfo: ContainerConnectionInfo = {
+    name: 'Podman Machine',
+    canEdit: true,
+    canRedirect: true,
+    cpus: 12,
+    cpusExpected: 10,
+    memoryExpected: 10,
+    memoryIdle: 5,
+    status: 'low-resources',
+  };
+
+  render(ContainerConnectionStatusInfo, { connectionInfo });
+
+  const banner = screen.getByLabelText('Container connection info banner');
+  expect(banner).toBeInTheDocument();
+  const titleDiv = screen.getByLabelText('title');
+  expect(titleDiv).toBeInTheDocument();
+  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  const descriptionDiv = screen.getByLabelText('description');
+  expect(descriptionDiv).toBeInTheDocument();
+  expect(descriptionDiv.textContent).equals(
+    `Your Podman Machine has ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend upgrading your Podman machine with at least ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
+  );
+
+  const btnUpgrade = screen.getByRole('button', { name: 'Upgrade now' });
+  expect(btnUpgrade).toBeInTheDocument();
+
+  await userEvent.click(btnUpgrade);
+
+  expect(navigateMock).toBeCalledWith('Podman Machine');
+});
+
+test('should show lowResourcesMachine banner without action if the running machine has not enough resources but canEdit is false', async () => {
+  const connectionInfo: ContainerConnectionInfo = {
+    name: 'Podman Machine',
+    canEdit: false,
+    canRedirect: true,
+    cpus: 4,
+    cpusExpected: 10,
+    memoryExpected: 10,
+    memoryIdle: 5,
+    status: 'low-resources',
+  };
+
+  render(ContainerConnectionStatusInfo, { connectionInfo });
+
+  const banner = screen.getByLabelText('Container connection info banner');
+  expect(banner).toBeInTheDocument();
+  const titleDiv = screen.getByLabelText('title');
+  expect(titleDiv).toBeInTheDocument();
+  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  const descriptionDiv = screen.getByLabelText('description');
+  expect(descriptionDiv).toBeInTheDocument();
+  expect(descriptionDiv.textContent).equals(
+    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend freeing some resources on your Podman machine to have at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
+  );
+
+  const btnUpgrade = screen.queryByRole('button', { name: 'Upgrade now' });
+  expect(btnUpgrade).not.toBeInTheDocument();
+});
+
+test('should show lowResourcesMachine banner without action if the running machine has not enough resources but canRedirect is false', async () => {
+  const connectionInfo: ContainerConnectionInfo = {
+    name: 'Podman Machine',
+    canEdit: true,
+    canRedirect: false,
+    cpus: 4,
+    cpusExpected: 10,
+    memoryExpected: 10,
+    memoryIdle: 5,
+    status: 'low-resources',
+  };
+
+  render(ContainerConnectionStatusInfo, { connectionInfo });
+
+  const banner = screen.getByLabelText('Container connection info banner');
+  expect(banner).toBeInTheDocument();
+  const titleDiv = screen.getByLabelText('title');
+  expect(titleDiv).toBeInTheDocument();
+  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  const descriptionDiv = screen.getByLabelText('description');
+  expect(descriptionDiv).toBeInTheDocument();
+  expect(descriptionDiv.textContent).equals(
+    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend upgrading your Podman machine with at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
+  );
+
+  const btnUpgrade = screen.queryByRole('button', { name: 'Upgrade now' });
+  expect(btnUpgrade).not.toBeInTheDocument();
+});

--- a/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.spec.ts
+++ b/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.spec.ts
@@ -63,7 +63,7 @@ test('should show no running machine banner if there is no running machine', asy
   expect(banner).toBeInTheDocument();
   const titleDiv = screen.getByLabelText('title');
   expect(titleDiv).toBeInTheDocument();
-  expect(titleDiv.textContent).equals('No Podman machine is running');
+  expect(titleDiv.textContent).equals('No Podman Machine is running');
   const descriptionDiv = screen.getByLabelText('description');
   expect(descriptionDiv).toBeInTheDocument();
   expect(descriptionDiv.textContent).equals('Please start a Podman Machine before proceeding further.');
@@ -88,7 +88,7 @@ test('should show no running machine banner if there is no running machine and n
   expect(banner).toBeInTheDocument();
   const titleDiv = screen.getByLabelText('title');
   expect(titleDiv).toBeInTheDocument();
-  expect(titleDiv.textContent).equals('No Podman machine is running');
+  expect(titleDiv.textContent).equals('No Podman Machine is running');
   const descriptionDiv = screen.getByLabelText('description');
   expect(descriptionDiv).toBeInTheDocument();
   expect(descriptionDiv.textContent).equals('Please start a Podman Machine before proceeding further.');
@@ -116,17 +116,17 @@ test('should show lowResourcesMachine banner if the running machine has not enou
   expect(banner).toBeInTheDocument();
   const titleDiv = screen.getByLabelText('title');
   expect(titleDiv).toBeInTheDocument();
-  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  expect(titleDiv.textContent).equals('Update your Podman Machine to improve performance');
   const descriptionDiv = screen.getByLabelText('description');
   expect(descriptionDiv).toBeInTheDocument();
   expect(descriptionDiv.textContent).equals(
-    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend upgrading your Podman machine with at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
+    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend updating your Podman Machine to at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
   );
 
-  const btnUpgrade = screen.getByRole('button', { name: 'Upgrade now' });
-  expect(btnUpgrade).toBeInTheDocument();
+  const btnUpdate = screen.getByRole('button', { name: 'Update now' });
+  expect(btnUpdate).toBeInTheDocument();
 
-  await userEvent.click(btnUpgrade);
+  await userEvent.click(btnUpdate);
 
   expect(navigateMock).toBeCalledWith('Podman Machine');
 });
@@ -150,17 +150,17 @@ test('should show lowResourcesMachine banner if the running machine has not enou
   expect(banner).toBeInTheDocument();
   const titleDiv = screen.getByLabelText('title');
   expect(titleDiv).toBeInTheDocument();
-  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  expect(titleDiv.textContent).equals('Update your Podman Machine to improve performance');
   const descriptionDiv = screen.getByLabelText('description');
   expect(descriptionDiv).toBeInTheDocument();
   expect(descriptionDiv.textContent).equals(
-    `Your Podman Machine has ${connectionInfo.cpus} vCPUs. We recommend upgrading your Podman machine with at least ${connectionInfo.cpusExpected} vCPUs for better AI performance.`,
+    `Your Podman Machine has ${connectionInfo.cpus} vCPUs. We recommend updating your Podman Machine to at least ${connectionInfo.cpusExpected} vCPUs for better AI performance.`,
   );
 
-  const btnUpgrade = screen.getByRole('button', { name: 'Upgrade now' });
-  expect(btnUpgrade).toBeInTheDocument();
+  const btnUpdate = screen.getByRole('button', { name: 'Update now' });
+  expect(btnUpdate).toBeInTheDocument();
 
-  await userEvent.click(btnUpgrade);
+  await userEvent.click(btnUpdate);
 
   expect(navigateMock).toBeCalledWith('Podman Machine');
 });
@@ -184,17 +184,17 @@ test('should show lowResourcesMachine banner if the running machine has not enou
   expect(banner).toBeInTheDocument();
   const titleDiv = screen.getByLabelText('title');
   expect(titleDiv).toBeInTheDocument();
-  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  expect(titleDiv.textContent).equals('Update your Podman Machine to improve performance');
   const descriptionDiv = screen.getByLabelText('description');
   expect(descriptionDiv).toBeInTheDocument();
   expect(descriptionDiv.textContent).equals(
-    `Your Podman Machine has ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend upgrading your Podman machine with at least ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
+    `Your Podman Machine has ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend updating your Podman Machine to at least ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
   );
 
-  const btnUpgrade = screen.getByRole('button', { name: 'Upgrade now' });
-  expect(btnUpgrade).toBeInTheDocument();
+  const btnUpdate = screen.getByRole('button', { name: 'Update now' });
+  expect(btnUpdate).toBeInTheDocument();
 
-  await userEvent.click(btnUpgrade);
+  await userEvent.click(btnUpdate);
 
   expect(navigateMock).toBeCalledWith('Podman Machine');
 });
@@ -217,15 +217,15 @@ test('should show lowResourcesMachine banner without action if the running machi
   expect(banner).toBeInTheDocument();
   const titleDiv = screen.getByLabelText('title');
   expect(titleDiv).toBeInTheDocument();
-  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  expect(titleDiv.textContent).equals('Update your Podman Machine to improve performance');
   const descriptionDiv = screen.getByLabelText('description');
   expect(descriptionDiv).toBeInTheDocument();
   expect(descriptionDiv.textContent).equals(
-    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend freeing some resources on your Podman machine to have at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
+    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend freeing some resources on your Podman Machine to have at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
   );
 
-  const btnUpgrade = screen.queryByRole('button', { name: 'Upgrade now' });
-  expect(btnUpgrade).not.toBeInTheDocument();
+  const btnUpdate = screen.queryByRole('button', { name: 'Update now' });
+  expect(btnUpdate).not.toBeInTheDocument();
 });
 
 test('should show lowResourcesMachine banner without action if the running machine has not enough resources but canRedirect is false', async () => {
@@ -246,13 +246,13 @@ test('should show lowResourcesMachine banner without action if the running machi
   expect(banner).toBeInTheDocument();
   const titleDiv = screen.getByLabelText('title');
   expect(titleDiv).toBeInTheDocument();
-  expect(titleDiv.textContent).equals('Upgrade your Podman machine for best AI performance');
+  expect(titleDiv.textContent).equals('Update your Podman Machine to improve performance');
   const descriptionDiv = screen.getByLabelText('description');
   expect(descriptionDiv).toBeInTheDocument();
   expect(descriptionDiv.textContent).equals(
-    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend upgrading your Podman machine with at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
+    `Your Podman Machine has ${connectionInfo.cpus} vCPUs and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available. We recommend updating your Podman Machine to at least ${connectionInfo.cpusExpected} vCPUs and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory for better AI performance.`,
   );
 
-  const btnUpgrade = screen.queryByRole('button', { name: 'Upgrade now' });
-  expect(btnUpgrade).not.toBeInTheDocument();
+  const btnUpdate = screen.queryByRole('button', { name: 'Update now' });
+  expect(btnUpdate).not.toBeInTheDocument();
 });

--- a/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
+++ b/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
@@ -17,14 +17,14 @@ $: updateTitleDescription(connectionInfo);
 
 function updateTitleDescription(connectionInfo: ContainerConnectionInfo) {
   if (connectionInfo.status === 'no-machine') {
-    title = 'No Podman machine is running';
+    title = 'No Podman Machine is running';
     description = 'Please start a Podman Machine before proceeding further.';
     actionName = connectionInfo.canRedirect ? 'Start now' : undefined;
     return;
   }
 
   if (connectionInfo.status === 'low-resources') {
-    title = 'Upgrade your Podman machine for best AI performance';
+    title = 'Update your Podman Machine to improve performance';
 
     const hasEnoughCPU = connectionInfo.cpus >= connectionInfo.cpusExpected;
     const hasEnoughMemory = connectionInfo.memoryIdle > connectionInfo.memoryExpected;
@@ -47,10 +47,10 @@ function updateTitleDescription(connectionInfo: ContainerConnectionInfo) {
     description = `Your ${machineName} has ${machineCurrentStateDescription}. `;
 
     if (connectionInfo?.canEdit) {
-      description += `We recommend upgrading your Podman machine with at least ${machinePreferredStateDescription} for better AI performance.`;
-      actionName = connectionInfo.canRedirect ? 'Upgrade now' : undefined;
+      description += `We recommend updating your Podman Machine to at least ${machinePreferredStateDescription} for better AI performance.`;
+      actionName = connectionInfo.canRedirect ? 'Update now' : undefined;
     } else {
-      description += `We recommend freeing some resources on your Podman machine to have at least ${machinePreferredStateDescription} for better AI performance.`;
+      description += `We recommend freeing some resources on your Podman Machine to have at least ${machinePreferredStateDescription} for better AI performance.`;
     }
     return;
   }

--- a/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
+++ b/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+import Fa from 'svelte-fa';
+import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
+import Button from '../button/Button.svelte';
+import { filesize } from 'filesize';
+import { studioClient } from '/@/utils/client';
+import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+
+export let connectionInfo: ContainerConnectionInfo;
+type BannerBackgroundColor = 'light' | 'dark';
+export let background: BannerBackgroundColor = 'light';
+
+let title: string | undefined = '';
+let description: string | undefined = '';
+let actionName: string | undefined = '';
+$: updateTitleDescription(connectionInfo);
+
+function updateTitleDescription(connectionInfo: ContainerConnectionInfo) {
+  if (connectionInfo.status === 'no-machine') {
+    title = 'No Podman machine is running';
+    description = 'Please start a Podman Machine before proceeding further.';
+    actionName = 'Start now';
+    return;
+  }
+
+  if (connectionInfo.status === 'not-enough-resources') {
+    title = 'Upgrade your Podman machine for best AI performance';
+
+    const hasEnoughCPU = connectionInfo.cpus >= connectionInfo.cpusExpected;
+    const hasEnoughMemory = connectionInfo.memoryIdle > connectionInfo.memoryExpected;
+
+    let machineCurrentStateDescription = '';
+    let machinePreferredStateDescription = '';
+    if (hasEnoughCPU) {
+      machineCurrentStateDescription += `${connectionInfo.cpus} vCPUs`;
+      machinePreferredStateDescription += `${connectionInfo.cpusExpected} vCPUs`;
+      if (!hasEnoughMemory) {
+        machineCurrentStateDescription += ` and ${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available`;
+        machinePreferredStateDescription += ` and ${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory`;
+      }
+    } else {
+      machineCurrentStateDescription += `${filesize(connectionInfo.memoryIdle, { base: 2 })} of memory available`;
+      machinePreferredStateDescription += `${filesize(connectionInfo.memoryExpected, { base: 2 })} of memory`;
+    }
+
+    const machineName = `${connectionInfo.name.includes('Podman Machine') ? connectionInfo.name : `Podman Machine ${connectionInfo.name}`}`;
+    description = `Your ${machineName} has ${machineCurrentStateDescription}.`;
+
+    if (connectionInfo?.canEdit) {
+      description += `We recommend upgrading your Podman machine with at least ${machinePreferredStateDescription} for better AI performance.`;
+      actionName = 'Upgrade now';
+    } else {
+      description += `We recommend freeing some resources on your Podman machine to have at least ${machinePreferredStateDescription} for better AI performance.`;
+    }
+    return;
+  }
+
+  title = undefined;
+  description = undefined;
+  actionName = undefined;
+}
+
+function executeCommand() {
+  if (connectionInfo.status === 'not-enough-resources' && connectionInfo.canEdit) {
+    studioClient.navigateToEditConnectionProvider(connectionInfo.name);
+    return;
+  }
+  if (connectionInfo.status == 'no-machine') {
+    studioClient.navigateToResources();
+  }
+}
+</script>
+
+{#if title && description}
+  <div
+    class="w-full {background === 'light'
+      ? 'bg-charcoal-500'
+      : 'bg-charcoal-800'} border-t-[3px] border-red-700 p-4 mt-5 shadow-inner">
+    <div class="flex flex-row space-x-3">
+      <div class="flex">
+        <Fa icon="{faCircleExclamation}" class="text-red-600" />
+      </div>
+      <div class="flex flex-col grow">
+        <span class="font-medium text-sm">{title}</span>
+        <span class="text-sm">{description}</span>
+      </div>
+      {#if actionName}
+        <div class="flex items-center">
+          <Button class="grow text-gray-500" on:click="{executeCommand}">{actionName}</Button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
+++ b/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import Fa from 'svelte-fa';
-import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import Button from '../button/Button.svelte';
 import { filesize } from 'filesize';
 import { studioClient } from '/@/utils/client';
@@ -77,11 +77,11 @@ function executeCommand() {
   <div
     class="w-full {background === 'light'
       ? 'bg-charcoal-500'
-      : 'bg-charcoal-800'} border-t-[3px] border-red-700 p-4 mt-5 shadow-inner"
+      : 'bg-charcoal-800'} border-t-[3px] border-amber-500 p-4 mt-5 shadow-inner"
     aria-label="Container connection info banner">
     <div class="flex flex-row space-x-3">
       <div class="flex">
-        <Fa icon="{faCircleExclamation}" class="text-red-600" />
+        <Fa icon="{faTriangleExclamation}" class="text-amber-400" />
       </div>
       <div class="flex flex-col grow">
         <span class="font-medium text-sm" aria-label="title">{title}</span>

--- a/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
+++ b/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
@@ -31,7 +31,7 @@ function updateTitleDescription(connectionInfo: ContainerConnectionInfo) {
 
     let machineCurrentStateDescription = '';
     let machinePreferredStateDescription = '';
-    if (hasEnoughCPU) {
+    if (!hasEnoughCPU) {
       machineCurrentStateDescription += `${connectionInfo.cpus} vCPUs`;
       machinePreferredStateDescription += `${connectionInfo.cpusExpected} vCPUs`;
       if (!hasEnoughMemory) {
@@ -77,18 +77,19 @@ function executeCommand() {
   <div
     class="w-full {background === 'light'
       ? 'bg-charcoal-500'
-      : 'bg-charcoal-800'} border-t-[3px] border-red-700 p-4 mt-5 shadow-inner">
+      : 'bg-charcoal-800'} border-t-[3px] border-red-700 p-4 mt-5 shadow-inner"
+    aria-label="Container connection info banner">
     <div class="flex flex-row space-x-3">
       <div class="flex">
         <Fa icon="{faCircleExclamation}" class="text-red-600" />
       </div>
       <div class="flex flex-col grow">
-        <span class="font-medium text-sm">{title}</span>
-        <span class="text-sm">{description}</span>
+        <span class="font-medium text-sm" aria-label="title">{title}</span>
+        <span class="text-sm" aria-label="description">{description}</span>
       </div>
       {#if actionName}
         <div class="flex items-center">
-          <Button class="grow text-gray-500" on:click="{executeCommand}">{actionName}</Button>
+          <Button class="grow text-gray-500" on:click="{executeCommand}" aria-label="{actionName}">{actionName}</Button>
         </div>
       {/if}
     </div>

--- a/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
+++ b/packages/frontend/src/lib/notification/ContainerConnectionStatusInfo.svelte
@@ -19,11 +19,11 @@ function updateTitleDescription(connectionInfo: ContainerConnectionInfo) {
   if (connectionInfo.status === 'no-machine') {
     title = 'No Podman machine is running';
     description = 'Please start a Podman Machine before proceeding further.';
-    actionName = 'Start now';
+    actionName = connectionInfo.canRedirect ? 'Start now' : undefined;
     return;
   }
 
-  if (connectionInfo.status === 'not-enough-resources') {
+  if (connectionInfo.status === 'low-resources') {
     title = 'Upgrade your Podman machine for best AI performance';
 
     const hasEnoughCPU = connectionInfo.cpus >= connectionInfo.cpusExpected;
@@ -44,11 +44,11 @@ function updateTitleDescription(connectionInfo: ContainerConnectionInfo) {
     }
 
     const machineName = `${connectionInfo.name.includes('Podman Machine') ? connectionInfo.name : `Podman Machine ${connectionInfo.name}`}`;
-    description = `Your ${machineName} has ${machineCurrentStateDescription}.`;
+    description = `Your ${machineName} has ${machineCurrentStateDescription}. `;
 
     if (connectionInfo?.canEdit) {
       description += `We recommend upgrading your Podman machine with at least ${machinePreferredStateDescription} for better AI performance.`;
-      actionName = 'Upgrade now';
+      actionName = connectionInfo.canRedirect ? 'Upgrade now' : undefined;
     } else {
       description += `We recommend freeing some resources on your Podman machine to have at least ${machinePreferredStateDescription} for better AI performance.`;
     }
@@ -61,12 +61,14 @@ function updateTitleDescription(connectionInfo: ContainerConnectionInfo) {
 }
 
 function executeCommand() {
-  if (connectionInfo.status === 'not-enough-resources' && connectionInfo.canEdit) {
-    studioClient.navigateToEditConnectionProvider(connectionInfo.name);
-    return;
-  }
-  if (connectionInfo.status == 'no-machine') {
-    studioClient.navigateToResources();
+  if (connectionInfo.canRedirect) {
+    if (connectionInfo.status === 'low-resources' && connectionInfo.canEdit) {
+      studioClient.navigateToEditConnectionProvider(connectionInfo.name);
+      return;
+    }
+    if (connectionInfo.status == 'no-machine') {
+      studioClient.navigateToResources();
+    }
   }
 }
 </script>

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -45,7 +45,7 @@ $: available = containerId && $inferenceServers.some(server => server.container.
 
 let connectionInfo: ContainerConnectionInfo | undefined;
 $: if (localModels && modelId) {
-  checkContainerConnectionStatus(localModels, modelId)
+  checkContainerConnectionStatus(localModels, modelId, 'inference')
     .then(value => (connectionInfo = value))
     .catch((e: unknown) => console.log(String(e)));
 }

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -141,7 +141,7 @@ onMount(async () => {
       {/if}
 
       <!-- tasks tracked -->
-      {#if trackedTasks.length > 0}
+      {#if trackedTasks?.length > 0}
         <div class="mx-5 mt-5" role="status">
           <TasksProgress tasks="{trackedTasks}" />
         </div>

--- a/packages/frontend/src/utils/connectionUtils.spec.ts
+++ b/packages/frontend/src/utils/connectionUtils.spec.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { checkContainerConnectionStatus } from './connectionUtils';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { studioClient } from './client';
+import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+
+vi.mock('./client', async () => {
+  return {
+    studioClient: {
+      checkContainerConnectionStatusAndResources: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const localModels = [{ id: 'model-id' } as ModelInfo, { id: 'model-id-2' } as ModelInfo];
+
+test('checkContainerConnectionStatus should return undefined if checkContainerConnectionStatusAndResources fails', async () => {
+  vi.spyOn(studioClient, 'checkContainerConnectionStatusAndResources').mockRejectedValue('');
+  const result = await checkContainerConnectionStatus(localModels, 'model-id');
+  expect(result).toBeUndefined();
+});
+
+test('checkContainerConnectionStatus should return undefined if model is not in localModels', async () => {
+  vi.spyOn(studioClient, 'checkContainerConnectionStatusAndResources').mockRejectedValue('');
+  const result = await checkContainerConnectionStatus(localModels, 'unknown-model');
+  expect(result).toBeUndefined();
+});
+
+test('checkContainerConnectionStatus should return checkContainerConnectionStatusAndResources result', async () => {
+  const connectionInfo: ContainerConnectionInfo = {
+    status: 'no-machine',
+    canRedirect: true,
+  };
+  vi.spyOn(studioClient, 'checkContainerConnectionStatusAndResources').mockResolvedValue(connectionInfo);
+  const result = await checkContainerConnectionStatus(localModels, 'model-id');
+  expect(result).toStrictEqual(connectionInfo);
+});

--- a/packages/frontend/src/utils/connectionUtils.spec.ts
+++ b/packages/frontend/src/utils/connectionUtils.spec.ts
@@ -34,17 +34,17 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-const localModels = [{ id: 'model-id' } as ModelInfo, { id: 'model-id-2' } as ModelInfo];
+const localModels = [{ id: 'model-id', memory: 10 } as ModelInfo, { id: 'model-id-2', memory: 10 } as ModelInfo];
 
 test('checkContainerConnectionStatus should return undefined if checkContainerConnectionStatusAndResources fails', async () => {
   vi.spyOn(studioClient, 'checkContainerConnectionStatusAndResources').mockRejectedValue('');
-  const result = await checkContainerConnectionStatus(localModels, 'model-id');
+  const result = await checkContainerConnectionStatus(localModels, 'model-id', 'inference');
   expect(result).toBeUndefined();
 });
 
 test('checkContainerConnectionStatus should return undefined if model is not in localModels', async () => {
   vi.spyOn(studioClient, 'checkContainerConnectionStatusAndResources').mockRejectedValue('');
-  const result = await checkContainerConnectionStatus(localModels, 'unknown-model');
+  const result = await checkContainerConnectionStatus(localModels, 'unknown-model', 'inference');
   expect(result).toBeUndefined();
 });
 
@@ -54,6 +54,6 @@ test('checkContainerConnectionStatus should return checkContainerConnectionStatu
     canRedirect: true,
   };
   vi.spyOn(studioClient, 'checkContainerConnectionStatusAndResources').mockResolvedValue(connectionInfo);
-  const result = await checkContainerConnectionStatus(localModels, 'model-id');
+  const result = await checkContainerConnectionStatus(localModels, 'model-id', 'inference');
   expect(result).toStrictEqual(connectionInfo);
 });

--- a/packages/frontend/src/utils/connectionUtils.ts
+++ b/packages/frontend/src/utils/connectionUtils.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { studioClient } from './client';
+import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+
+export async function checkContainerConnectionStatus(
+  localModels: ModelInfo[],
+  modelId: string,
+): Promise<ContainerConnectionInfo | undefined> {
+  const model: ModelInfo | undefined = localModels.find(model => model.id === modelId);
+  let connection: ContainerConnectionInfo | undefined;
+  if (model) {
+    try {
+      connection = await studioClient.checkContainerConnectionStatusAndResources(model.memory);
+    } catch (e) {
+      console.log(e);
+    }
+  }
+  return connection;
+}

--- a/packages/frontend/src/utils/connectionUtils.ts
+++ b/packages/frontend/src/utils/connectionUtils.ts
@@ -16,19 +16,23 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import type { ModelCheckerContext, ModelInfo } from '@shared/src/models/IModelInfo';
 import { studioClient } from './client';
 import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 
 export async function checkContainerConnectionStatus(
   localModels: ModelInfo[],
   modelId: string,
+  context: ModelCheckerContext,
 ): Promise<ContainerConnectionInfo | undefined> {
   const model: ModelInfo | undefined = localModels.find(model => model.id === modelId);
   let connection: ContainerConnectionInfo | undefined;
-  if (model) {
+  if (model?.memory) {
     try {
-      connection = await studioClient.checkContainerConnectionStatusAndResources(model.memory);
+      connection = await studioClient.checkContainerConnectionStatusAndResources({
+        memoryNeeded: model.memory,
+        context,
+      });
     } catch (e) {
       console.log(e);
     }

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -29,6 +29,7 @@ import type { CreationInferenceServerOptions } from './models/InferenceServerCon
 import type { ModelOptions } from './models/IModelOptions';
 import type { Conversation } from './models/IPlaygroundMessage';
 import type { LocalModelImportInfo } from './models/ILocalModelInfo';
+import type { ContainerConnectionInfo } from './models/IContainerConnectionInfo';
 
 export abstract class StudioAPI {
   abstract ping(): Promise<string>;
@@ -51,6 +52,8 @@ export abstract class StudioAPI {
 
   abstract navigateToContainer(containerId: string): Promise<void>;
   abstract navigateToPod(podId: string): Promise<void>;
+  abstract navigateToResources(): Promise<void>;
+  abstract navigateToEditConnectionProvider(connectionName: string): Promise<void>;
 
   abstract getApplicationsState(): Promise<ApplicationState[]>;
   abstract requestRemoveApplication(recipeId: string, modelId: string): Promise<void>;
@@ -186,4 +189,10 @@ export abstract class StudioAPI {
    * @param content
    */
   abstract copyToClipboard(content: string): Promise<void>;
+  
+  /**
+   * Check if the running podman machine is running and has enough resources to execute task
+   * @param memory amount of memory that must be idle
+   */
+  abstract checkContainerConnectionStatusAndResources(memory: number): Promise<ContainerConnectionInfo>;
 }

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ModelInfo } from './models/IModelInfo';
+import type { ModelCheckerInfo, ModelInfo } from './models/IModelInfo';
 import type { ApplicationCatalog } from './models/IApplicationCatalog';
 import type { OpenDialogOptions, TelemetryTrustedValue, Uri } from '@podman-desktop/api';
 import type { ApplicationState } from './models/IApplicationState';
@@ -192,7 +192,7 @@ export abstract class StudioAPI {
   
   /**
    * Check if the running podman machine is running and has enough resources to execute task
-   * @param memory amount of memory that must be idle
+   * @param modelInfo object containing info about the model to check
    */
-  abstract checkContainerConnectionStatusAndResources(memory: number): Promise<ContainerConnectionInfo>;
+  abstract checkContainerConnectionStatusAndResources(modelInfo: ModelCheckerInfo): Promise<ContainerConnectionInfo>;
 }

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -189,7 +189,7 @@ export abstract class StudioAPI {
    * @param content
    */
   abstract copyToClipboard(content: string): Promise<void>;
-  
+
   /**
    * Check if the running podman machine is running and has enough resources to execute task
    * @param modelInfo object containing info about the model to check

--- a/packages/shared/src/models/IContainerConnectionInfo.ts
+++ b/packages/shared/src/models/IContainerConnectionInfo.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export type ContainerConnectionInfo =
+  | RunningContainerConnection
+  | NotEnoughResourcesContainerConnection
+  | NoContainerConnection;
+
+export type ContainerConnectionInfoStatus = 'running' | 'no-machine' | 'not-enough-resources';
+
+export interface RunningContainerConnection {
+  name: string;
+  status: 'running';
+}
+
+export interface NotEnoughResourcesContainerConnection {
+  name: string;
+  cpus: number;
+  memoryIdle: number;
+  cpusExpected: number;
+  memoryExpected: number;
+  status: 'not-enough-resources';
+  canEdit: boolean;
+}
+
+export interface NoContainerConnection {
+  status: 'no-machine';
+}

--- a/packages/shared/src/models/IContainerConnectionInfo.ts
+++ b/packages/shared/src/models/IContainerConnectionInfo.ts
@@ -18,26 +18,29 @@
 
 export type ContainerConnectionInfo =
   | RunningContainerConnection
-  | NotEnoughResourcesContainerConnection
+  | LowResourcesContainerConnection
   | NoContainerConnection;
 
-export type ContainerConnectionInfoStatus = 'running' | 'no-machine' | 'not-enough-resources';
+export type ContainerConnectionInfoStatus = 'running' | 'no-machine' | 'low-resources';
 
 export interface RunningContainerConnection {
   name: string;
   status: 'running';
+  canRedirect: boolean;
 }
 
-export interface NotEnoughResourcesContainerConnection {
+export interface LowResourcesContainerConnection {
   name: string;
   cpus: number;
   memoryIdle: number;
   cpusExpected: number;
   memoryExpected: number;
-  status: 'not-enough-resources';
+  status: 'low-resources';
   canEdit: boolean;
+  canRedirect: boolean;
 }
 
 export interface NoContainerConnection {
   status: 'no-machine';
+  canRedirect: boolean;
 }

--- a/packages/shared/src/models/IModelInfo.ts
+++ b/packages/shared/src/models/IModelInfo.ts
@@ -30,3 +30,10 @@ export interface ModelInfo {
   state?: 'deleting';
   memory?: number;
 }
+
+export type ModelCheckerContext = 'inference' | 'recipe';
+
+export interface ModelCheckerInfo {
+  memoryNeeded: number;
+  context: ModelCheckerContext;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,10 +391,10 @@
   dependencies:
     playwright "1.42.1"
 
-"@podman-desktop/api@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.9.0.tgz#5520b719da555f999c4d42184549a054d680c852"
-  integrity sha512-QFPnl+kYxWdAqoKDRplyqBDNoQj15FLtqCbYW1sq19U4OJP/BXZ9r4SNF8ndvQnBXXvATjUeCC/VAjUuwf5lqQ==
+"@podman-desktop/api@0.0.202404101645-5d46ba5":
+  version "0.0.202404101645-5d46ba5"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-0.0.202404101645-5d46ba5.tgz#562aa4470057bfc7869b576d9691da2ffe49fa18"
+  integrity sha512-5FwFhBrOGb2Nhd0buGZCigAewnio8xlkenmIKW0Ew2jqeoKffgW6e4bpvRTsl9JeGiQqrEa5jkZP6cft+xlGfA==
 
 "@podman-desktop/tests-playwright@^1.9.1":
   version "1.9.1"


### PR DESCRIPTION
### What does this PR do?

It shows a warning banner if the running podman machine does not have enough resources for the model selected by the user or if there is no running machine.

This needs https://github.com/containers/podman-desktop/pull/6733 to work

This PR only covers the inference server page to make the review easier. Going to open a new PR for the recipe page once it is merged

### Screenshot / video of UI

This gif shows if you can edit the machine and if there is no running machine
![warning_banner_1](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/61024d8d-5475-4144-8d01-fb5d964c5192)


This is the message if the edit action is not enabled for the system (like WSL)
![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/147886f5-a29b-4e74-9784-1b5a4bfc0e53)


### What issues does this PR fix or reference?

Fixes #873 

### How to test this PR?

1. if you are on WSL you need to hack the result received from the system as it takes the resources from the host so you have to load the machine a lot to see the warning message
2. on MAC by creating a machine with few resources you should see the banner