### PR TITLE
fix: adding chatformat to use for inference servers

### DIFF
--- a/packages/backend/src/assets/ai.json
+++ b/packages/backend/src/assets/ai.json
@@ -105,7 +105,9 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/ibm/merlinite-7b-GGUF/resolve/main/merlinite-7b-Q4_K_M.gguf",
       "memory": 4370129224,
-      "chatformat": "openchat"
+      "properties": {
+        "chat_format": "openchat"
+      }
     },
     {
       "id": "hf.TheBloke.mistral-7b-codealpaca-lora.Q4_K_M",
@@ -136,7 +138,9 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/froggeric/Cerebrum-1.0-7b-GGUF/resolve/main/Cerebrum-1.0-7b-Q4_KS.gguf",
       "memory": 4144643441,
-      "chatformat": "openchat"
+      "properties": {
+        "chat_format": "openchat"
+      }
     },
     {
       "id": "hf.TheBloke.openchat-3.5-0106.Q4_K_M",
@@ -177,7 +181,9 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/llmware/dragon-mistral-7b-v0/resolve/main/dragon-mistral-7b-q4_k_m.gguf",
       "memory": 4370129224,
-      "chatformat": "openchat"
+      "properties": {
+        "chat_format": "openchat"
+      }
     },
     {
       "id": "hf.MaziyarPanahi.MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M",

--- a/packages/backend/src/assets/ai.json
+++ b/packages/backend/src/assets/ai.json
@@ -104,7 +104,8 @@
       "registry": "Hugging Face",
       "license": "Apache-2.0",
       "url": "https://huggingface.co/ibm/merlinite-7b-GGUF/resolve/main/merlinite-7b-Q4_K_M.gguf",
-      "memory": 4370129224
+      "memory": 4370129224,
+      "chatformat": "openchat"
     },
     {
       "id": "hf.TheBloke.mistral-7b-codealpaca-lora.Q4_K_M",
@@ -134,7 +135,8 @@
       "registry": "Hugging Face",
       "license": "Apache-2.0",
       "url": "https://huggingface.co/froggeric/Cerebrum-1.0-7b-GGUF/resolve/main/Cerebrum-1.0-7b-Q4_KS.gguf",
-      "memory": 4144643441
+      "memory": 4144643441,
+      "chatformat": "openchat"
     },
     {
       "id": "hf.TheBloke.openchat-3.5-0106.Q4_K_M",
@@ -174,7 +176,8 @@
       "registry": "Hugging Face",
       "license": "Apache-2.0",
       "url": "https://huggingface.co/llmware/dragon-mistral-7b-v0/resolve/main/dragon-mistral-7b-q4_k_m.gguf",
-      "memory": 4370129224
+      "memory": 4370129224,
+      "chatformat": "openchat"
     },
     {
       "id": "hf.MaziyarPanahi.MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M",

--- a/packages/backend/src/assets/ai.json
+++ b/packages/backend/src/assets/ai.json
@@ -106,7 +106,7 @@
       "url": "https://huggingface.co/ibm/merlinite-7b-GGUF/resolve/main/merlinite-7b-Q4_K_M.gguf",
       "memory": 4370129224,
       "properties": {
-        "chat_format": "openchat"
+        "chatFormat": "openchat"
       }
     },
     {
@@ -139,7 +139,7 @@
       "url": "https://huggingface.co/froggeric/Cerebrum-1.0-7b-GGUF/resolve/main/Cerebrum-1.0-7b-Q4_KS.gguf",
       "memory": 4144643441,
       "properties": {
-        "chat_format": "openchat"
+        "chatFormat": "openchat"
       }
     },
     {
@@ -182,7 +182,7 @@
       "url": "https://huggingface.co/llmware/dragon-mistral-7b-v0/resolve/main/dragon-mistral-7b-q4_k_m.gguf",
       "memory": 4370129224,
       "properties": {
-        "chat_format": "openchat"
+        "chatFormat": "openchat"
       }
     },
     {

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -309,7 +309,7 @@ describe('Create Inference Server', () => {
     );
     expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(
       1,
-      'Pulling ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:0.2.0.',
+      expect.stringContaining('Pulling ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:'),
       'loading',
       {
         trackingId: 'dummyTrackingId',

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -309,7 +309,9 @@ describe('Create Inference Server', () => {
     );
     expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining('Pulling ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:'),
+      expect.stringContaining(
+        'Pulling ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:',
+      ),
       'loading',
       {
         trackingId: 'dummyTrackingId',

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -96,6 +96,33 @@ describe('generateContainerCreateOptions', () => {
       },
     });
   });
+
+  test('model info with chatformat', () => {
+    const result = generateContainerCreateOptions(
+      {
+        port: 8888,
+        providerId: 'test@providerId',
+        image: INFERENCE_SERVER_IMAGE,
+        modelsInfo: [
+          {
+            id: 'dummyModelId',
+            file: {
+              file: 'dummyFile',
+              path: 'dummyPath',
+            },
+            chatformat: 'dummyChatFormat',
+          },
+        ],
+      } as unknown as InferenceServerConfig,
+      {
+        Id: 'dummyImageId',
+        engineId: 'dummyEngineId',
+        RepoTags: [INFERENCE_SERVER_IMAGE],
+      } as unknown as ImageInfo,
+    );
+
+    expect(result.Env).toContain('CHAT_FORMAT=dummyChatFormat');
+  });
 });
 
 describe('withDefaultConfiguration', () => {

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -111,7 +111,7 @@ describe('generateContainerCreateOptions', () => {
               path: 'dummyPath',
             },
             properties: {
-              chat_format: 'dummyChatFormat',
+              chatFormat: 'dummyChatFormat',
             },
           },
         ],

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -97,7 +97,7 @@ describe('generateContainerCreateOptions', () => {
     });
   });
 
-  test('model info with chatformat', () => {
+  test('model info with chat_format properties', () => {
     const result = generateContainerCreateOptions(
       {
         port: 8888,
@@ -110,7 +110,9 @@ describe('generateContainerCreateOptions', () => {
               file: 'dummyFile',
               path: 'dummyPath',
             },
-            chatformat: 'dummyChatFormat',
+            properties: {
+              chat_format: 'dummyChatFormat',
+            },
           },
         ],
       } as unknown as InferenceServerConfig,

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -123,7 +123,40 @@ describe('generateContainerCreateOptions', () => {
       } as unknown as ImageInfo,
     );
 
-    expect(result.Env).toContain('CHAT_FORMAT=dummyChatFormat');
+    expect(result.Env).toContain('MODEL_CHAT_FORMAT=dummyChatFormat');
+  });
+
+  test('model info with multiple properties', () => {
+    const result = generateContainerCreateOptions(
+      {
+        port: 8888,
+        providerId: 'test@providerId',
+        image: INFERENCE_SERVER_IMAGE,
+        modelsInfo: [
+          {
+            id: 'dummyModelId',
+            file: {
+              file: 'dummyFile',
+              path: 'dummyPath',
+            },
+            properties: {
+              basicProp: 'basicProp',
+              lotOfCamelCases: 'lotOfCamelCases',
+              lowercase: 'lowercase',
+            },
+          },
+        ],
+      } as unknown as InferenceServerConfig,
+      {
+        Id: 'dummyImageId',
+        engineId: 'dummyEngineId',
+        RepoTags: [INFERENCE_SERVER_IMAGE],
+      } as unknown as ImageInfo,
+    );
+
+    expect(result.Env).toContain('MODEL_BASIC_PROP=basicProp');
+    expect(result.Env).toContain('MODEL_LOT_OF_CAMEL_CASES=lotOfCamelCases');
+    expect(result.Env).toContain('MODEL_LOWERCASE=lowercase');
   });
 });
 

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -34,7 +34,7 @@ export const SECOND: number = 1_000_000_000;
 export const LABEL_INFERENCE_SERVER: string = 'ai-lab-inference-server';
 
 export const INFERENCE_SERVER_IMAGE =
-  'ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:0.2.0';
+  'ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:0.3.0';
 
 /**
  * Return container connection provider

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -116,7 +116,7 @@ export function generateContainerCreateOptions(
   }
 
   const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
-  if(modelInfo.chatformat) {
+  if (modelInfo.chatformat) {
     envs.push(`CHAT_FORMAT=${modelInfo.chatformat}`);
   }
 

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -117,10 +117,12 @@ export function generateContainerCreateOptions(
 
   const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
   if (modelInfo.properties) {
-    envs.push(...Object.entries(modelInfo.properties).map(([key, value]) => {
-      const formattedKey = key.replace(/[A-Z]/g, m => `_${m}`).toUpperCase();
-      return `MODEL_${formattedKey}=${value}`;
-    }));
+    envs.push(
+      ...Object.entries(modelInfo.properties).map(([key, value]) => {
+        const formattedKey = key.replace(/[A-Z]/g, m => `_${m}`).toUpperCase();
+        return `MODEL_${formattedKey}=${value}`;
+      }),
+    );
   }
 
   return {

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -118,7 +118,8 @@ export function generateContainerCreateOptions(
   const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
   if (modelInfo.properties) {
     Object.entries(modelInfo.properties).forEach(([key, value]) => {
-      envs.push(`${key.toUpperCase()}=${value}`);
+      const formatedKey = key.replace(/[A-Z]/g, m => `_${m}`);
+      envs.push(`${formatedKey}=${value}`);
     });
   }
 

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -115,6 +115,11 @@ export function generateContainerCreateOptions(
     throw new Error('The model info file provided is undefined');
   }
 
+  const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
+  if(modelInfo.chatformat) {
+    envs.push(`CHAT_FORMAT=${modelInfo.chatformat}`);
+  }
+
   return {
     Image: imageInfo.Id,
     Detach: true,
@@ -147,7 +152,7 @@ export function generateContainerCreateOptions(
       ...config.labels,
       [LABEL_INFERENCE_SERVER]: JSON.stringify(config.modelsInfo.map(model => model.id)),
     },
-    Env: [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'],
+    Env: envs,
     Cmd: ['--models-path', '/models', '--context-size', '700', '--threads', '4'],
   };
 }

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -116,8 +116,10 @@ export function generateContainerCreateOptions(
   }
 
   const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
-  if (modelInfo.chatformat) {
-    envs.push(`CHAT_FORMAT=${modelInfo.chatformat}`);
+  if (modelInfo.properties) {
+    Object.entries(modelInfo.properties).forEach(([key, value]) => {
+      envs.push(`${key.toUpperCase()}=${value}`);
+    });
   }
 
   return {

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -117,10 +117,10 @@ export function generateContainerCreateOptions(
 
   const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
   if (modelInfo.properties) {
-    Object.entries(modelInfo.properties).forEach(([key, value]) => {
-      const formatedKey = key.replace(/[A-Z]/g, m => `_${m}`);
-      envs.push(`${formatedKey}=${value}`);
-    });
+    envs.push(...Object.entries(modelInfo.properties).map(([key, value]) => {
+      const formattedKey = key.replace(/[A-Z]/g, m => `_${m}`).toUpperCase();
+      return `MODEL_${formattedKey}=${value}`;
+    }));
   }
 
   return {

--- a/packages/shared/src/models/IModelInfo.ts
+++ b/packages/shared/src/models/IModelInfo.ts
@@ -29,9 +29,7 @@ export interface ModelInfo {
   file?: LocalModelInfo;
   state?: 'deleting';
   memory?: number;
-  /**
-   * the chat format to use
-   * @example llama-2
-   */
-  chatformat?: 'openchat' | 'llama-2' | string;
+  properties?: {
+    [key: string]: string;
+  };
 }

--- a/packages/shared/src/models/IModelInfo.ts
+++ b/packages/shared/src/models/IModelInfo.ts
@@ -33,5 +33,5 @@ export interface ModelInfo {
    * the chat format to use
    * @example llama-2
    */
-  chatformat?: 'openchat' | 'llama-2' | string
+  chatformat?: 'openchat' | 'llama-2' | string;
 }

--- a/packages/shared/src/models/IModelInfo.ts
+++ b/packages/shared/src/models/IModelInfo.ts
@@ -29,4 +29,9 @@ export interface ModelInfo {
   file?: LocalModelInfo;
   state?: 'deleting';
   memory?: number;
+  /**
+   * the chat format to use
+   * @example llama-2
+   */
+  chatformat?: 'openchat' | 'llama-2' | string
 }


### PR DESCRIPTION
### What does this PR do?

This PR is adding the optional `chatformat` to the model object.

Need https://github.com/containers/podman-desktop-extension-ai-lab-playground-images/pull/11 to be merged, and a new version published of the image to be working.

Fixing the playgrounds for the following models
- Merlinite
- Cerebrum
- dragon-mistral

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/4abac94d-9080-4740-89b2-972d90905c89)

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/4a072315-7b27-48fc-816e-c6e06983cb1e)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/825

### How to test this PR?

- [x] unit tests has been provided