### PR TITLE
fix: capture die events for inference servers

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -287,6 +287,10 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     // Subscribe to container status update
     const disposable = this.containerRegistry.subscribe(containerId, (status: string) => {
       switch (status) {
+        case 'die':
+          this.updateServerStatus(engineId, containerId);
+          clearInterval(intervalId);
+          break;
         case 'remove':
           // Update the list of servers
           this.removeInferenceServer(containerId);


### PR DESCRIPTION
### What does this PR do?

After some investigation, we did not have any logic for external stop events, leading to the server still marked as running for a period of time (until the pull update, which can last up to 10 seconds).

This PR is adding proper management of the `die` container event to improve the reactivity of the updates.

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/1f80f7fa-62e6-44b2-a253-7f83c5a10cd1

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/893

### How to test this PR?

- [x] unit tests has been provided