### PR TITLE
service page: update empty message

### DIFF
--- a/packages/frontend/src/pages/InferenceServers.spec.ts
+++ b/packages/frontend/src/pages/InferenceServers.spec.ts
@@ -56,7 +56,7 @@ test('no inference servers should display a status message', async () => {
   render(InferenceServers);
   const status = screen.getByRole('status');
   expect(status).toBeInTheDocument();
-  expect(status.textContent).toBe('There is no services running for now.');
+  expect(status.textContent).toContain('There is no model service. ');
 
   const table = screen.queryByRole('table');
   expect(table).toBeNull();

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -67,7 +67,21 @@ function createNewService() {
               row="{row}"
               bind:selectedItemsNumber="{selectedItemsNumber}" />
           {:else}
-            <div role="status">There is no services running for now.</div>
+            <div role="status">
+              There is no model service. You can <a
+                href="{'javascript:void(0);'}"
+                class="underline"
+                role="button"
+                title="Create a new Model Service"
+                on:click="{createNewService}">create one now</a
+              >.
+            </div>
+            <p>
+              A model service offers a configurable endpoint via an OpenAI-compatible web server, facilitating a
+              seamless integration of AI capabilities into existing applications. Upon initialization, effortlessly
+              access detailed service information and generate code snippets in multiple programming languages to ease
+              application integration.
+            </p>
           {/if}
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?
Update the message when there is no service running.  We did the same for playgrounds already.

### Screenshot / video of UI

Before:
![Screenshot 2024-04-15 at 13 10 34](https://github.com/containers/podman-desktop-extension-ai-lab/assets/11679875/85f0777b-55ed-49c6-af6d-cd3d4ac92743)


After:
![Screenshot 2024-04-15 at 13 12 58](https://github.com/containers/podman-desktop-extension-ai-lab/assets/11679875/fee8bbbd-41de-4bf1-9aa8-2e33112f525e)