### PR TITLE
feat: provides model properties to model service while running an AI App

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -48,7 +48,7 @@ import type { TaskRegistry } from '../registries/TaskRegistry';
 import { Publisher } from '../utils/Publisher';
 import { isQEMUMachine } from '../utils/podman';
 import { SECOND } from '../utils/inferenceUtils';
-import { addModelPropertiesToEnvironment } from '../utils/modelsUtils';
+import { getModelPropertiesForEnvironment } from '../utils/modelsUtils';
 
 export const LABEL_MODEL_ID = 'ai-lab-model-id';
 export const LABEL_MODEL_PORTS = 'ai-lab-model-ports';
@@ -301,7 +301,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
           if (modelService && modelService.ports.length > 0) {
             const endPoint = `http://localhost:${modelService.ports[0]}`;
             envs = [`MODEL_ENDPOINT=${endPoint}`];
-            addModelPropertiesToEnvironment(modelInfo, envs);
+            envs.push(...getModelPropertiesForEnvironment(modelInfo));
           }
         }
         if (image.ports.length > 0) {

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -48,6 +48,7 @@ import type { TaskRegistry } from '../registries/TaskRegistry';
 import { Publisher } from '../utils/Publisher';
 import { isQEMUMachine } from '../utils/podman';
 import { SECOND } from '../utils/inferenceUtils';
+import { addModelPropertiesToEnvironment } from '../utils/modelsUtils';
 
 export const LABEL_MODEL_ID = 'ai-lab-model-id';
 export const LABEL_MODEL_PORTS = 'ai-lab-model-ports';
@@ -251,7 +252,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
 
     let attachedContainers: ContainerAttachedInfo[];
     try {
-      attachedContainers = await this.createAndAddContainersToPod(podInfo, images, modelPath);
+      attachedContainers = await this.createAndAddContainersToPod(podInfo, images, model, modelPath);
       task.state = 'success';
     } catch (e) {
       console.error(`error when creating pod ${podInfo.Id}`, e);
@@ -269,6 +270,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
   async createAndAddContainersToPod(
     podInfo: ApplicationPodInfo,
     images: ImageInfo[],
+    modelInfo: ModelInfo,
     modelPath: string,
   ): Promise<ContainerAttachedInfo[]> {
     const containers: ContainerAttachedInfo[] = [];
@@ -299,6 +301,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
           if (modelService && modelService.ports.length > 0) {
             const endPoint = `http://localhost:${modelService.ports[0]}`;
             envs = [`MODEL_ENDPOINT=${endPoint}`];
+            addModelPropertiesToEnvironment(modelInfo, envs);
           }
         }
         if (image.ports.length > 0) {

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -28,7 +28,7 @@ import {
 import type { CreationInferenceServerOptions, InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from './utils';
 import { getFreeRandomPort } from './ports';
-import { addModelPropertiesToEnvironment } from './modelsUtils';
+import { getModelPropertiesForEnvironment } from './modelsUtils';
 
 export const SECOND: number = 1_000_000_000;
 
@@ -117,7 +117,7 @@ export function generateContainerCreateOptions(
   }
 
   const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
-  addModelPropertiesToEnvironment(modelInfo, envs);
+  envs.push(...getModelPropertiesForEnvironment(modelInfo));
 
   return {
     Image: imageInfo.Id,

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -16,18 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import {
-  containerEngine,
-  provider,
   type ContainerCreateOptions,
+  containerEngine,
   type ContainerProviderConnection,
-  type PullEvent,
-  type ProviderContainerConnection,
   type ImageInfo,
   type ListImagesOptions,
+  provider,
+  type ProviderContainerConnection,
+  type PullEvent,
 } from '@podman-desktop/api';
 import type { CreationInferenceServerOptions, InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from './utils';
 import { getFreeRandomPort } from './ports';
+import { addModelPropertiesToEnvironment } from './modelsUtils';
 
 export const SECOND: number = 1_000_000_000;
 
@@ -116,14 +117,7 @@ export function generateContainerCreateOptions(
   }
 
   const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
-  if (modelInfo.properties) {
-    envs.push(
-      ...Object.entries(modelInfo.properties).map(([key, value]) => {
-        const formattedKey = key.replace(/[A-Z]/g, m => `_${m}`).toUpperCase();
-        return `MODEL_${formattedKey}=${value}`;
-      }),
-    );
-  }
+  addModelPropertiesToEnvironment(modelInfo, envs);
 
   return {
     Image: imageInfo.Id,

--- a/packages/backend/src/utils/modelsUtils.ts
+++ b/packages/backend/src/utils/modelsUtils.ts
@@ -71,3 +71,14 @@ export async function deleteRemoteModel(machine: string, modelInfo: ModelInfo): 
     console.error('Something went wrong while trying to stat remote model path', err);
   }
 }
+
+export function addModelPropertiesToEnvironment(modelInfo: ModelInfo, envs: string[]) {
+  if (modelInfo.properties) {
+    envs.push(
+      ...Object.entries(modelInfo.properties).map(([key, value]) => {
+        const formattedKey = key.replace(/[A-Z]/g, m => `_${m}`).toUpperCase();
+        return `MODEL_${formattedKey}=${value}`;
+      }),
+    );
+  }
+}

--- a/packages/backend/src/utils/modelsUtils.ts
+++ b/packages/backend/src/utils/modelsUtils.ts
@@ -72,7 +72,8 @@ export async function deleteRemoteModel(machine: string, modelInfo: ModelInfo): 
   }
 }
 
-export function addModelPropertiesToEnvironment(modelInfo: ModelInfo, envs: string[]) {
+export function getModelPropertiesForEnvironment(modelInfo: ModelInfo): string[] {
+  const envs: string[] = [];
   if (modelInfo.properties) {
     envs.push(
       ...Object.entries(modelInfo.properties).map(([key, value]) => {
@@ -81,4 +82,5 @@ export function addModelPropertiesToEnvironment(modelInfo: ModelInfo, envs: stri
       }),
     );
   }
+  return envs;
 }


### PR DESCRIPTION
Fixes #903

### What does this PR do?

Allow to pass model properties as environment variables when starting an AI App like it is done for an inference server

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#903

### How to test this PR?

1. Start a recipe with a model with properties
2. Enter the model server container
3. Verify the environment variable is set