### PR TITLE
feat(inference): adding transition statuses

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -729,6 +729,7 @@ describe('transition statuses', () => {
     const inferenceManager = await getInitializedInferenceManager();
     await inferenceManager.startInferenceServer('dummyId');
 
+    // first status must be set to starting
     expect(webviewMock.postMessage).toHaveBeenCalledWith({
       id: Messages.MSG_INFERENCE_SERVERS_UPDATE,
       body: [
@@ -738,6 +739,20 @@ describe('transition statuses', () => {
           models: expect.anything(),
           health: undefined,
           status: 'starting',
+        },
+      ],
+    });
+
+    // on success it should have been set to running
+    expect(webviewMock.postMessage).toHaveBeenCalledWith({
+      id: Messages.MSG_INFERENCE_SERVERS_UPDATE,
+      body: [
+        {
+          connection: expect.anything(),
+          container: expect.anything(),
+          models: expect.anything(),
+          health: undefined,
+          status: 'running',
         },
       ],
     });

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -33,6 +33,7 @@ import type { ModelsManager } from '../modelsManager';
 import { LABEL_INFERENCE_SERVER, INFERENCE_SERVER_IMAGE } from '../../utils/inferenceUtils';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
+import { Messages } from '@shared/Messages';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
@@ -621,5 +622,124 @@ describe('containerRegistry events', () => {
 
     // we should have disposed the subscriber, as the container is removed
     expect(disposableMock).toHaveBeenCalled();
+  });
+});
+
+describe('transition statuses', () => {
+  test('stopping an inference server should first set status to stopping', async () => {
+    mockListContainers([
+      {
+        Id: 'dummyId',
+        engineId: 'dummyEngineId',
+        Labels: {
+          [LABEL_INFERENCE_SERVER]: '[]',
+        },
+      },
+    ]);
+    vi.mocked(containerEngine.inspectContainer).mockResolvedValue({
+      State: {
+        Status: 'running',
+        Health: undefined,
+      },
+    } as unknown as ContainerInspectInfo);
+
+    const inferenceManager = await getInitializedInferenceManager();
+    await inferenceManager.stopInferenceServer('dummyId');
+
+    // first called with stopping status
+    expect(webviewMock.postMessage).toHaveBeenCalledWith({
+      id: Messages.MSG_INFERENCE_SERVERS_UPDATE,
+      body: [
+        {
+          connection: expect.anything(),
+          container: expect.anything(),
+          models: expect.anything(),
+          health: undefined,
+          status: 'stopping',
+        },
+      ],
+    });
+
+    // finally have been called with status stopped
+    expect(webviewMock.postMessage).toHaveBeenCalledWith({
+      id: Messages.MSG_INFERENCE_SERVERS_UPDATE,
+      body: [
+        {
+          connection: expect.anything(),
+          container: expect.anything(),
+          models: expect.anything(),
+          health: undefined,
+          status: 'stopped',
+        },
+      ],
+    });
+  });
+
+  test('deleting an inference server should first set status to stopping', async () => {
+    mockListContainers([
+      {
+        Id: 'dummyId',
+        engineId: 'dummyEngineId',
+        Labels: {
+          [LABEL_INFERENCE_SERVER]: '[]',
+        },
+      },
+    ]);
+    vi.mocked(containerEngine.inspectContainer).mockResolvedValue({
+      State: {
+        Status: 'running',
+        Health: undefined,
+      },
+    } as unknown as ContainerInspectInfo);
+
+    const inferenceManager = await getInitializedInferenceManager();
+    await inferenceManager.deleteInferenceServer('dummyId');
+
+    expect(webviewMock.postMessage).toHaveBeenCalledWith({
+      id: Messages.MSG_INFERENCE_SERVERS_UPDATE,
+      body: [
+        {
+          connection: expect.anything(),
+          container: expect.anything(),
+          models: expect.anything(),
+          health: undefined,
+          status: 'deleting',
+        },
+      ],
+    });
+  });
+
+  test('starting an inference server should first set status to stopping', async () => {
+    mockListContainers([
+      {
+        Id: 'dummyId',
+        engineId: 'dummyEngineId',
+        Labels: {
+          [LABEL_INFERENCE_SERVER]: '[]',
+        },
+      },
+    ]);
+    vi.mocked(containerEngine.inspectContainer).mockResolvedValue({
+      State: {
+        Status: 'stopped',
+        Health: undefined,
+      },
+    } as unknown as ContainerInspectInfo);
+
+    const inferenceManager = await getInitializedInferenceManager();
+    await inferenceManager.startInferenceServer('dummyId');
+
+    expect(webviewMock.postMessage).toHaveBeenCalledWith({
+      id: Messages.MSG_INFERENCE_SERVERS_UPDATE,
+      body: [
+        {
+          connection: expect.anything(),
+          container: expect.anything(),
+          models: expect.anything(),
+          health: undefined,
+          status: 'starting',
+        },
+      ],
+    });
   });
 });

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -462,7 +462,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
       this.setInferenceServerStatus(server.container.containerId, 'starting');
       await containerEngine.startContainer(server.container.engineId, server.container.containerId);
       // start watch container status
-      this.watchContainerStatus(server.container.engineId, server.container.containerId);
+      this.setInferenceServerStatus(server.container.containerId, 'running');
     } catch (error: unknown) {
       console.error(error);
       this.telemetry.logError('inference.start', {

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -461,8 +461,10 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
       // set status to starting
       this.setInferenceServerStatus(server.container.containerId, 'starting');
       await containerEngine.startContainer(server.container.engineId, server.container.containerId);
-      // start watch container status
+
       this.setInferenceServerStatus(server.container.containerId, 'running');
+      // start watch for container status update
+      this.watchContainerStatus(server.container.engineId, server.container.containerId);
     } catch (error: unknown) {
       console.error(error);
       this.telemetry.logError('inference.start', {

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -27,7 +27,7 @@ import type { InferenceServerConfig } from '@shared/src/models/InferenceServerCo
 import type { ImageInfo } from '@podman-desktop/api';
 import { getFreeRandomPort } from './ports';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
-import type { InferenceServer, type InferenceServerStatus } from '@shared/src/models/IInference';
+import type { InferenceServer, InferenceServerStatus } from '@shared/src/models/IInference';
 
 vi.mock('./ports', () => ({
   getFreeRandomPort: vi.fn(),

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -21,11 +21,13 @@ import {
   withDefaultConfiguration,
   INFERENCE_SERVER_IMAGE,
   SECOND,
+  isTransitioning,
 } from './inferenceUtils';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import type { ImageInfo } from '@podman-desktop/api';
 import { getFreeRandomPort } from './ports';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import type { InferenceServer, type InferenceServerStatus } from '@shared/src/models/IInference';
 
 vi.mock('./ports', () => ({
   getFreeRandomPort: vi.fn(),
@@ -194,4 +196,23 @@ describe('withDefaultConfiguration', () => {
     expect(result.labels).toStrictEqual({ hello: 'world' });
     expect(result.providerId).toBe('dummyProviderId');
   });
+});
+
+test.each(['stopping', 'deleting', 'starting'] as InferenceServerStatus[])(
+  '%s should be a transitioning state',
+  status => {
+    expect(
+      isTransitioning({
+        status: status,
+      } as unknown as InferenceServer),
+    ).toBeTruthy();
+  },
+);
+
+test.each(['running', 'stopped', 'error'] as InferenceServerStatus[])('%s should be a stable state', status => {
+  expect(
+    isTransitioning({
+      status: status,
+    } as unknown as InferenceServer),
+  ).toBeFalsy();
 });

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -29,6 +29,7 @@ import type { CreationInferenceServerOptions, InferenceServerConfig } from '@sha
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from './utils';
 import { getFreeRandomPort } from './ports';
 import { getModelPropertiesForEnvironment } from './modelsUtils';
+import type { InferenceServer } from '@shared/src/models/IInference';
 
 export const SECOND: number = 1_000_000_000;
 
@@ -168,4 +169,17 @@ export async function withDefaultConfiguration(
     modelsInfo: options.modelsInfo,
     providerId: options.providerId,
   };
+}
+
+export function isTransitioning(server: InferenceServer): boolean {
+  switch (server.status) {
+    case 'deleting':
+    case 'stopping':
+    case 'starting':
+      return true;
+    default:
+      break;
+  }
+
+  return false;
 }

--- a/packages/frontend/src/lib/table/service/ServiceAction.spec.ts
+++ b/packages/frontend/src/lib/table/service/ServiceAction.spec.ts
@@ -113,3 +113,21 @@ test('should call deleteInferenceServer when click delete', async () => {
   await fireEvent.click(startBtn);
   expect(studioClient.requestDeleteInferenceServer).toHaveBeenCalledWith('dummyContainerId');
 });
+
+test('should be disabled on transition', async () => {
+  render(ServiceAction, {
+    object: {
+      health: undefined,
+      models: [],
+      connection: { port: 8888 },
+      status: 'stopping',
+      container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+    },
+  });
+
+  const startBtn = screen.getByTitle('Start service');
+  expect(startBtn.classList).toContain('text-gray-900');
+
+  const deleteBtn = screen.getByTitle('Delete service');
+  expect(deleteBtn.classList).toContain('text-gray-900');
+});

--- a/packages/frontend/src/lib/table/service/ServiceAction.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceAction.svelte
@@ -22,11 +22,16 @@ function deleteInferenceServer() {
     console.error('Something went wrong while trying to delete inference server', err);
   });
 }
+
+let loading: boolean;
+$: {
+  loading = ['deleting', 'stopping', 'starting'].includes(object.status);
+}
 </script>
 
 {#if object.status === 'running'}
   <ListItemButtonIcon icon="{faStop}" onClick="{stopInferenceServer}" title="Stop service" />
 {:else}
-  <ListItemButtonIcon icon="{faPlay}" onClick="{startInferenceServer}" title="Start service" />
+  <ListItemButtonIcon enabled="{!loading}" icon="{faPlay}" onClick="{startInferenceServer}" title="Start service" />
 {/if}
-<ListItemButtonIcon icon="{faTrash}" onClick="{deleteInferenceServer}" title="Delete service" />
+<ListItemButtonIcon enabled="{!loading}" icon="{faTrash}" onClick="{deleteInferenceServer}" title="Delete service" />

--- a/packages/frontend/src/lib/table/service/ServiceStatus.spec.ts
+++ b/packages/frontend/src/lib/table/service/ServiceStatus.spec.ts
@@ -118,3 +118,31 @@ test('click on status icon should redirect to container', async () => {
     expect(studioClient.navigateToContainer).toHaveBeenCalledWith('dummyContainerId');
   });
 });
+
+test('error status should show degraded', async () => {
+  render(ServiceStatus, {
+    object: {
+      models: [],
+      connection: { port: 8888 },
+      status: 'error',
+      container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+    },
+  });
+  // Get button and click on it
+  const status = screen.getByRole('status');
+  expect(status.title).toBe('DEGRADED');
+});
+
+test('running status with no healthcheck should show starting', async () => {
+  render(ServiceStatus, {
+    object: {
+      models: [],
+      connection: { port: 8888 },
+      status: 'running',
+      container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+    },
+  });
+  // Get button and click on it
+  const status = screen.getByRole('status');
+  expect(status.title).toBe('STARTING');
+});

--- a/packages/frontend/src/lib/table/service/ServiceStatus.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceStatus.svelte
@@ -14,7 +14,7 @@ let status: string;
 let loading: boolean;
 $: {
   status = getStatus();
-  loading = object.health === undefined && object.status !== 'stopped';
+  loading = ['deleting', 'stopping', 'starting'].includes(object.status);
 }
 
 function getStatus(): 'RUNNING' | 'STARTING' | 'DEGRADED' | '' {
@@ -26,6 +26,7 @@ function getStatus(): 'RUNNING' | 'STARTING' | 'DEGRADED' | '' {
     case 'healthy':
       return 'RUNNING';
     case 'unhealthy':
+    case 'error':
       return 'DEGRADED';
     case 'starting':
       return 'STARTING';

--- a/packages/frontend/src/lib/table/service/ServiceStatus.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceStatus.svelte
@@ -18,8 +18,19 @@ $: {
 }
 
 function getStatus(): 'RUNNING' | 'STARTING' | 'DEGRADED' | '' {
-  if (object.status === 'stopped') {
-    return '';
+  switch (object.status) {
+    case 'stopped':
+      return '';
+    case 'error':
+      return 'DEGRADED';
+    default:
+      break;
+  }
+
+  // Special case: when the health check is undefined, and the container is running
+  // it is not ready, so still showing starting
+  if (object.health === undefined && object.status === 'running') {
+    return 'STARTING';
   }
 
   switch (object.health?.Status) {

--- a/packages/shared/src/models/IInference.ts
+++ b/packages/shared/src/models/IInference.ts
@@ -17,6 +17,8 @@
  ***********************************************************************/
 import type { ModelInfo } from './IModelInfo';
 
+export type InferenceServerStatus = 'stopped' | 'running' | 'deleting' | 'stopping' | 'error' | 'starting';
+
 export interface InferenceServer {
   /**
    * Supported models
@@ -35,7 +37,7 @@ export interface InferenceServer {
   /**
    * Inference server status
    */
-  status: 'stopped' | 'running';
+  status: InferenceServerStatus;
   /**
    * Health check
    */


### PR DESCRIPTION
### What does this PR do?

Adding transition statuses to the Inference Servers. This work has started with https://github.com/containers/podman-desktop-extension-ai-lab/pull/550 but was delayed to other priorities.

This allows to improve the user experience.

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/ef72faa4-737f-4aaa-8c5c-7238123e61b2

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/857 https://github.com/containers/podman-desktop-extension-ai-lab/issues/547 https://github.com/containers/podman-desktop-extension-ai-lab/issues/942

### How to test this PR?

- [x] unit tests has been provided

You can test it manually by reproducing the videos above.