### PR TITLE
fix: forbid creating several playgrounds with the same name

### DIFF
--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -428,6 +428,31 @@ test('delete conversation should delete the conversation', async () => {
   expect(webviewMock.postMessage).toHaveBeenCalled();
 });
 
+test('creating a new playground with an existing name shoud fail', async () => {
+  vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
+  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  await manager.createPlayground(
+    'a name',
+    {
+      id: 'model-1',
+      name: 'Model 1',
+    } as unknown as ModelInfo,
+    '',
+    'tracking-1',
+  );
+  await expect(
+    manager.createPlayground(
+      'a name',
+      {
+        id: 'model-2',
+        name: 'Model 2',
+      } as unknown as ModelInfo,
+      '',
+      'tracking-2',
+    ),
+  ).rejects.toThrowError('a playground with the name a name already exists');
+});
+
 test('requestCreatePlayground should call createPlayground and createTask, then updateTask', async () => {
   vi.useRealTimers();
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -109,7 +109,7 @@ export class PlaygroundV2Manager implements Disposable {
     if (!name) {
       name = this.getFreeName();
     }
-    if (!this.isFreeName(name)) {
+    if (!this.isNameFree(name)) {
       throw new Error(`a playground with the name ${name} already exists`);
     }
 
@@ -315,8 +315,8 @@ export class PlaygroundV2Manager implements Disposable {
     return name;
   }
 
-  private isFreeName(name: string): boolean {
-    return !this.getConversations().some(c => c.name === name)
+  private isNameFree(name: string): boolean {
+    return !this.getConversations().some(c => c.name === name);
   }
 
   dispose(): void {

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -316,8 +316,7 @@ export class PlaygroundV2Manager implements Disposable {
   }
 
   private isFreeName(name: string): boolean {
-    const names = new Set(this.getConversations().map(c => c.name));
-    return !names.has(name);
+    return !this.getConversations().some(c => c.name === name)
   }
 
   dispose(): void {

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -109,6 +109,9 @@ export class PlaygroundV2Manager implements Disposable {
     if (!name) {
       name = this.getFreeName();
     }
+    if (!this.isFreeName(name)) {
+      throw new Error(`a playground with the name ${name} already exists`);
+    }
 
     // Create conversation
     const conversationId = this.#conversationRegistry.createConversation(name, model.id);
@@ -310,6 +313,11 @@ export class PlaygroundV2Manager implements Disposable {
       name = `playground ${++i}`;
     } while (names.has(name));
     return name;
+  }
+
+  private isFreeName(name: string): boolean {
+    const names = new Set(this.getConversations().map(c => c.name));
+    return !names.has(name);
   }
 
   dispose(): void {

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -31,8 +31,6 @@ let trackingId: string | undefined = undefined;
 // The trackedTasks are the tasks linked to the trackingId
 let trackedTasks: Task[] = [];
 
-let error: boolean = false;
-
 $: {
   if (!modelId && localModels.length > 0) {
     modelId = localModels[0].id;
@@ -82,7 +80,10 @@ const processTasks = (tasks: Task[]) => {
 
   // Check for errors
   // hint: we do not need to display them as the TasksProgress component will
-  error = trackedTasks.find(task => task.error)?.error !== undefined;
+  const error = trackedTasks.find(task => task.error)?.error !== undefined;
+  if (error) {
+    submitted = false;
+  }
 
   const task: Task | undefined = trackedTasks.find(task => 'playgroundId' in (task.labels ?? {}));
   if (task === undefined) return;


### PR DESCRIPTION
### What does this PR do?

Raise an error when the user creates a playground with a name already used by another playground.

### Screenshot / video of UI


https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/1133d8b7-ce81-4e61-a96a-e6752e9a956f


### What issues does this PR fix or reference?

Fix #782 

### How to test this PR?

- Create a first playground
- try to create a second playground with the same name