### PR TITLE
feat(models): adding update mechanism

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -269,7 +269,7 @@ describe('pullApplication', () => {
     vi.spyOn(podman, 'isQEMUMachine').mockResolvedValue(false);
     vi.spyOn(modelsManager, 'isModelOnDisk').mockReturnValue(false);
     vi.spyOn(modelsManager, 'uploadModelToPodmanMachine').mockResolvedValue('path');
-    mocks.performDownloadMock.mockResolvedValue('path');
+    mocks.performDownloadMock.mockResolvedValue(false);
     const recipe: Recipe = {
       id: 'recipe1',
       name: 'Recipe 1',
@@ -336,7 +336,7 @@ describe('pullApplication', () => {
     vi.spyOn(podman, 'isQEMUMachine').mockResolvedValue(false);
     vi.spyOn(modelsManager, 'isModelOnDisk').mockReturnValue(false);
     vi.spyOn(modelsManager, 'uploadModelToPodmanMachine').mockResolvedValue('path');
-    mocks.performDownloadMock.mockResolvedValue('path');
+    mocks.performDownloadMock.mockResolvedValue(false);
     const recipe: Recipe = {
       id: 'recipe1',
       name: 'Recipe 1',

--- a/packages/backend/src/managers/models/UpdateManager.spec.ts
+++ b/packages/backend/src/managers/models/UpdateManager.spec.ts
@@ -1,0 +1,248 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { UpdateManager } from './UpdateManager';
+import type { Webview } from '@podman-desktop/api';
+import type { ModelsManager } from '../modelsManager';
+import https from 'node:https';
+import type { ClientRequest, IncomingMessage } from 'node:http';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import fs, { promises } from 'node:fs';
+
+const webviewMock = {
+  postMessage: vi.fn(),
+} as unknown as Webview;
+
+const modelsManagerMock = {
+  getModelsInfo: vi.fn(),
+} as unknown as ModelsManager;
+
+vi.mock('node:https', () => {
+  return {
+    default: {
+      get: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('non-initialized should not have any update available', () => {
+  const updater = new UpdateManager(webviewMock, modelsManagerMock);
+  expect(updater.getAll().length).toBe(0);
+});
+
+test('init call should get all the models from models manager', async () => {
+  vi.mocked(modelsManagerMock.getModelsInfo).mockReturnValue([]);
+  const updater = new UpdateManager(webviewMock, modelsManagerMock);
+  updater.init();
+
+  return vi.waitFor(() => {
+    expect(modelsManagerMock.getModelsInfo).toHaveBeenCalledOnce();
+  });
+});
+
+test('init call should HEAD model url to get ETag', async () => {
+  // state that the etag file exists
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+  // mock read etag
+  vi.spyOn(promises, 'readFile').mockResolvedValue('old-etag');
+
+  // mock models info
+  vi.mocked(modelsManagerMock.getModelsInfo).mockReturnValue([
+    {
+      url: 'dummy-url',
+      file: {
+        path: 'dummy-path',
+        file: 'dummy-file',
+      },
+      id: 'dummy-model-id',
+    } as unknown as ModelInfo,
+  ]);
+
+  // Get the https callback
+  let onResponse: ((msg: IncomingMessage) => void) | undefined;
+  vi.mocked(https.get).mockImplementation((url, options, callback) => {
+    onResponse = callback;
+    expect(url).toBe('dummy-url');
+    expect(options.method).toBe('HEAD');
+    return {} as unknown as ClientRequest;
+  });
+
+  // create & initialize the update manager
+  const updater = new UpdateManager(webviewMock, modelsManagerMock);
+  updater.init();
+
+  // wait for the callback to be defined
+  await vi.waitFor(() => {
+    expect(onResponse).toBeDefined();
+  });
+
+  // let typescript know it is defined
+  if (!onResponse) throw new Error('undefined onResponse');
+
+  onResponse({ headers: { etag: 'new-etag' } } as unknown as IncomingMessage);
+
+  await vi.waitFor(() => {
+    expect(updater.getAll().length).toBe(1);
+  });
+});
+
+test('init call should ignore request without etag header', async () => {
+  // state that the etag file exists
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+  // mock read etag
+  vi.spyOn(promises, 'readFile').mockResolvedValue('old-etag');
+
+  // mock models info
+  vi.mocked(modelsManagerMock.getModelsInfo).mockReturnValue([
+    {
+      url: 'dummy-url-without-etag',
+      file: {
+        path: 'dummy-path',
+        file: 'dummy-file',
+      },
+      id: 'dummy-model-id-1',
+    } as unknown as ModelInfo,
+    {
+      url: 'dummy-url-with-etag',
+      file: {
+        path: 'dummy-path',
+        file: 'dummy-file',
+      },
+      id: 'dummy-model-id-2',
+    } as unknown as ModelInfo,
+  ]);
+
+  // Mock the https callback
+  vi.mocked(https.get).mockImplementation((url, options, callback) => {
+    if (url === 'dummy-url-with-etag') {
+      callback?.({ headers: { etag: 'new-etag' } } as unknown as IncomingMessage);
+    } else {
+      callback?.({ headers: {} } as unknown as IncomingMessage);
+    }
+    return {} as unknown as ClientRequest;
+  });
+
+  // create & initialize the update manager
+  const updater = new UpdateManager(webviewMock, modelsManagerMock);
+  updater.init();
+
+  await vi.waitFor(() => {
+    const updates = updater.getAll();
+    expect(updates.length).toBe(1);
+    expect(updates[0].modelsId).toBe('dummy-model-id-2');
+  });
+});
+
+test('models info without file should not be checked', async () => {
+  // state that the etag file exists
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+  // mock read etag
+  vi.spyOn(promises, 'readFile').mockResolvedValue('old-etag');
+
+  // mock models info
+  vi.mocked(modelsManagerMock.getModelsInfo).mockReturnValue([
+    {
+      url: 'dummy-url-without-file',
+      id: 'dummy-model-id-1',
+    } as unknown as ModelInfo,
+    {
+      url: 'dummy-url-with-etag',
+      file: {
+        path: 'dummy-path',
+        file: 'dummy-file',
+      },
+      id: 'dummy-model-id-2',
+    } as unknown as ModelInfo,
+  ]);
+
+  // Mock the https callback
+  vi.mocked(https.get).mockImplementation((url, options, callback) => {
+    expect(url).not.toBe('dummy-url-without-file');
+    if (url === 'dummy-url-with-etag') {
+      callback?.({ headers: { etag: 'new-etag' } } as unknown as IncomingMessage);
+    }
+    return {} as unknown as ClientRequest;
+  });
+
+  // create & initialize the update manager
+  const updater = new UpdateManager(webviewMock, modelsManagerMock);
+  updater.init();
+
+  await vi.waitFor(() => {
+    const updates = updater.getAll();
+    expect(updates.length).toBe(1);
+    expect(updates[0].modelsId).toBe('dummy-model-id-2');
+  });
+});
+
+test('models info without local etag should not be checked', async () => {
+  // state that the etag file exists
+  vi.spyOn(fs, 'existsSync').mockImplementation(path => {
+    return path.toString().includes('dummy-path-with-etag');
+  });
+
+  // mock read etag
+  vi.spyOn(promises, 'readFile').mockResolvedValue('old-etag');
+
+  // mock models info
+  vi.mocked(modelsManagerMock.getModelsInfo).mockReturnValue([
+    {
+      url: 'dummy-url-without-local-etag',
+      file: {
+        path: 'dummy-path-without-etag',
+        file: 'dummy-file',
+      },
+      id: 'dummy-model-id-1',
+    } as unknown as ModelInfo,
+    {
+      url: 'dummy-url-with-local-etag',
+      file: {
+        path: 'dummy-path-with-etag',
+        file: 'dummy-file',
+      },
+      id: 'dummy-model-id-2',
+    } as unknown as ModelInfo,
+  ]);
+
+  // Mock the https callback
+  vi.mocked(https.get).mockImplementation((url, options, callback) => {
+    expect(url).not.toBe('dummy-url-without-local-etag');
+    if (url === 'dummy-url-with-local-etag') {
+      callback?.({ headers: { etag: 'new-etag' } } as unknown as IncomingMessage);
+    }
+    return {} as unknown as ClientRequest;
+  });
+
+  // create & initialize the update manager
+  const updater = new UpdateManager(webviewMock, modelsManagerMock);
+  updater.init();
+
+  await vi.waitFor(() => {
+    const updates = updater.getAll();
+    expect(updates.length).toBe(1);
+    expect(updates[0].modelsId).toBe('dummy-model-id-2');
+  });
+});

--- a/packages/backend/src/managers/models/UpdateManager.spec.ts
+++ b/packages/backend/src/managers/models/UpdateManager.spec.ts
@@ -151,7 +151,7 @@ test('init call should ignore request without etag header', async () => {
   await vi.waitFor(() => {
     const updates = updater.getAll();
     expect(updates.length).toBe(1);
-    expect(updates[0].modelsId).toBe('dummy-model-id-2');
+    expect(updates[0].modelId).toBe('dummy-model-id-2');
   });
 });
 
@@ -194,7 +194,7 @@ test('models info without file should not be checked', async () => {
   await vi.waitFor(() => {
     const updates = updater.getAll();
     expect(updates.length).toBe(1);
-    expect(updates[0].modelsId).toBe('dummy-model-id-2');
+    expect(updates[0].modelId).toBe('dummy-model-id-2');
   });
 });
 
@@ -243,6 +243,6 @@ test('models info without local etag should not be checked', async () => {
   await vi.waitFor(() => {
     const updates = updater.getAll();
     expect(updates.length).toBe(1);
-    expect(updates[0].modelsId).toBe('dummy-model-id-2');
+    expect(updates[0].modelId).toBe('dummy-model-id-2');
   });
 });

--- a/packages/backend/src/managers/models/UpdateManager.ts
+++ b/packages/backend/src/managers/models/UpdateManager.ts
@@ -76,7 +76,6 @@ export class UpdateManager extends Publisher<UpdateInfo[]> implements Disposable
   }
 
   async requestUpdate(modelId: string): Promise<void> {
-    console.log(`requestUpdate ${modelId}`);
 
     const modelInfo: ModelInfo = this.modelsManager.getModelInfo(modelId);
     if (!modelInfo.url || !modelInfo.file) throw new Error(`model with id ${modelId} cannot be updated.`);
@@ -90,7 +89,6 @@ export class UpdateManager extends Publisher<UpdateInfo[]> implements Disposable
       throw new Error('Something went wrong: undefined etag.');
     }
 
-    console.log(`requestDownloadModel ${modelId}`);
     await this.modelsManager.requestDownloadModel(modelInfo, {
       'is-update': 'true',
     });

--- a/packages/backend/src/managers/models/UpdateManager.ts
+++ b/packages/backend/src/managers/models/UpdateManager.ts
@@ -62,7 +62,7 @@ export class UpdateManager extends Publisher<UpdateInfo[]> implements Disposable
 
       if (localEtag !== remoteEtag) {
         this.#updates.set(model.id, {
-          modelsId: model.id,
+          modelId: model.id,
           message: 'New update is available.',
         });
       }

--- a/packages/backend/src/managers/models/UpdateManager.ts
+++ b/packages/backend/src/managers/models/UpdateManager.ts
@@ -76,7 +76,6 @@ export class UpdateManager extends Publisher<UpdateInfo[]> implements Disposable
   }
 
   async requestUpdate(modelId: string): Promise<void> {
-
     const modelInfo: ModelInfo = this.modelsManager.getModelInfo(modelId);
     if (!modelInfo.url || !modelInfo.file) throw new Error(`model with id ${modelId} cannot be updated.`);
 

--- a/packages/backend/src/managers/models/UpdateManager.ts
+++ b/packages/backend/src/managers/models/UpdateManager.ts
@@ -1,0 +1,172 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Disposable, Webview } from '@podman-desktop/api';
+import type { ModelsManager } from '../modelsManager';
+import { Publisher } from '../../utils/Publisher';
+import type { UpdateInfo } from '@shared/src/models/IUpdate';
+import { Messages } from '@shared/Messages';
+import https from 'node:https';
+import { existsSync, promises } from 'node:fs';
+import path from 'node:path';
+import { ModelInfo } from '@shared/src/models/IModelInfo';
+
+export class UpdateManager extends Publisher<UpdateInfo[]>  implements Disposable {
+  #updates: Map<string, UpdateInfo> = new Map();
+
+  constructor(webview: Webview, private modelsManager: ModelsManager) {
+    super(webview, Messages.MSG_UPDATES_INFO, () => this.getAll());
+  }
+
+  getAll(): UpdateInfo[] {
+    return Array.from(this.#updates.values());
+  }
+
+  dispose(): void {
+    this.#updates.clear();
+  }
+
+  private async checkUpdates(): Promise<void> {
+    const models = this.modelsManager.getModelsInfo();
+    for (const model of models) {
+      if(!model.url || !model.file)
+        continue;
+
+      let etag: string | undefined = undefined;
+      try {
+        etag = await this.getEtag(model.url);
+      } catch (err: unknown) {
+        console.error(`Something went wrong while getting the etag for model ${model.id}:`, err);
+      }
+
+      if(!etag)
+        continue;
+
+      const localEtag = await this.readEtagValue(model.file.path);
+      if(!localEtag)
+        continue;
+
+      if(localEtag !== etag) {
+        this.#updates.set(model.id, {
+          modelsId: model.id,
+          message: 'New update is available.',
+        });
+      }
+    }
+  }
+
+  init(): void {
+    this.checkUpdates().catch((err: unknown) => {
+      console.error('Something went wrong while checking models updates', err);
+    });
+  }
+
+  async requestUpdate(modelId: string): Promise<void> {
+    console.log(`requestUpdate ${modelId}`);
+
+    const modelInfo: ModelInfo = this.modelsManager.getModelInfo(modelId);
+    if(!modelInfo.url || !modelInfo.file)
+      throw new Error(`model with id ${modelId} cannot be updated.`);
+
+    if(!this.#updates.has(modelId))
+      throw new Error(`no update available for the model id ${modelId}`);
+
+    const etag = await this.getEtag(modelInfo.url);
+    if(!etag) {
+      // cleanup
+      this.#updates.delete(modelId);
+      throw new Error('Something went wrong: undefined etag.');
+    }
+
+    console.log(`requestDownloadModel ${modelId}`);
+    await this.modelsManager.requestDownloadModel(modelInfo, {
+      'is-update': 'true',
+    });
+
+    // update the etag file
+    await this.writeEtagValue(modelInfo.file.path, etag);
+
+    this.#updates.delete(modelId);
+  }
+
+  private getEtagPath(directory: string): string {
+    return path.join(directory, 'etag');
+  }
+
+  /**
+   * read the etag value from the `etag` utf-8 file
+   */
+  private async readEtagValue(directory: string): Promise<string | undefined> {
+    const etagPath = this.getEtagPath(directory);
+
+    if(!existsSync(etagPath))
+      return undefined;
+
+    const content = await promises.readFile(etagPath, 'utf-8');
+    return content.trim();
+  }
+
+  /**
+   * write the etag value to the `etag` utf-8 file
+   */
+  private async writeEtagValue(directory: string, value: string): Promise<void> {
+    const etagPath = this.getEtagPath(directory);
+
+    return promises.writeFile(etagPath, value, 'utf-8');
+  }
+
+  /**
+   * wrapper of the fetchETag to transform as a promise the result instead of a callback
+   * @param url
+   */
+  private getEtag(url: string): Promise<string | undefined> {
+    return new Promise((resolve, reject) => {
+      // fetch through a HEAD request the Etag property
+      this.fetchETag(url, (result) => {
+        if(result.error) {
+          reject(new Error(result.error));
+          return;
+        }
+
+        resolve(result.etag);
+      });
+    });
+  }
+
+  /**
+   * given an url, perform a head request to it, and will perform a callback with
+   * the result of the call
+   * @param url the url to perform the head request on
+   * @param callback the function to callback
+   */
+  private fetchETag(url: string, callback: (result: { etag?: string, error?: string}) => void): void {
+    https.get(url, {
+      method: 'HEAD',
+    }, resp => {
+      if (resp.headers.location) {
+        this.fetchETag(resp.headers.location, callback);
+        return;
+      }
+
+      if(!('etag' in resp.headers) || typeof resp.headers['etag'] !== 'string') {
+        callback({ error: `ETag could not be found for ${url}` });
+      } else {
+        callback({ etag: resp.headers['etag'] });
+      }
+    });
+  }
+}

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -774,4 +774,33 @@ describe('downloadModel', () => {
     expect(mocks.performDownloadMock).toHaveBeenCalledTimes(1);
     expect(mocks.onEventDownloadMock).toHaveBeenCalledTimes(2);
   });
+
+  test('using is-update label should force models to be re-downloaded', async () => {
+    const manager = new ModelsManager(
+      'appdir',
+      {} as Webview,
+      {
+        getModels(): ModelInfo[] {
+          return [];
+        },
+      } as CatalogManager,
+      telemetryLogger,
+      taskRegistry,
+      cancellationTokenRegistryMock,
+    );
+    vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(true);
+    await manager.requestDownloadModel(
+      {
+        id: 'id',
+        url: 'url',
+        name: 'name',
+      } as ModelInfo,
+      {
+        'is-update': 'true',
+      },
+    );
+
+    expect(mocks.performDownloadMock).toHaveBeenCalledTimes(1);
+    expect(mocks.onEventDownloadMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -111,7 +111,9 @@ export class ModelsManager implements Disposable {
     const entries = fs.readdirSync(this.#modelsDir, { withFileTypes: true });
     const dirs = entries.filter(dir => dir.isDirectory());
     for (const d of dirs) {
-      const modelEntries = fs.readdirSync(path.resolve(d.path, d.name)).filter((file) => !file.endsWith('tmp') && file !== 'etag');
+      const modelEntries = fs
+        .readdirSync(path.resolve(d.path, d.name))
+        .filter(file => !file.endsWith('tmp') && file !== 'etag');
       if (modelEntries.length !== 1) {
         // we support models with one file only for now
         continue;
@@ -385,8 +387,7 @@ export class ModelsManager implements Disposable {
 
     // perform download
     const aborted = await downloader.perform(model.id);
-    if(aborted)
-      throw new Error('The downloader has been aborted.');
+    if (aborted) throw new Error('The downloader has been aborted.');
 
     return downloader.getTarget();
   }

--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -38,6 +38,7 @@ import type { CancellationTokenRegistry } from './registries/CancellationTokenRe
 import path from 'node:path';
 import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
 import * as podman from './utils/podman';
+import type { UpdateManager } from './managers/models/UpdateManager';
 
 vi.mock('./ai.json', () => {
   return {
@@ -138,6 +139,7 @@ beforeEach(async () => {
     {} as unknown as PlaygroundV2Manager,
     {} as unknown as SnippetManager,
     {} as unknown as CancellationTokenRegistry,
+    {} as unknown as UpdateManager,
   );
   vi.mock('node:fs');
 

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -45,6 +45,8 @@ import type { CancellationTokenRegistry } from './registries/CancellationTokenRe
 import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
 import { checkContainerConnectionStatusAndResources, getPodmanConnection } from './utils/podman';
 import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+import type { UpdateInfo } from '@shared/src/models/IUpdate';
+import type { UpdateManager } from './managers/models/UpdateManager';
 
 interface PortQuickPickItem extends podmanDesktopApi.QuickPickItem {
   port: number;
@@ -62,6 +64,7 @@ export class StudioApiImpl implements StudioAPI {
     private playgroundV2: PlaygroundV2Manager,
     private snippetManager: SnippetManager,
     private cancellationTokenRegistry: CancellationTokenRegistry,
+    private updateManager: UpdateManager,
   ) {}
 
   async requestDeleteConversation(conversationId: string): Promise<void> {
@@ -488,5 +491,15 @@ export class StudioApiImpl implements StudioAPI {
 
   async checkContainerConnectionStatusAndResources(modelInfo: ModelCheckerInfo): Promise<ContainerConnectionInfo> {
     return checkContainerConnectionStatusAndResources(modelInfo);
+  }
+
+  async getModelsUpdateInfo(): Promise<UpdateInfo[]> {
+    return this.updateManager.getAll();
+  }
+
+  async requestModelUpdate(modelId:string): Promise<void> {
+    this.updateManager.requestUpdate(modelId).catch((err: unknown) => {
+      console.error('Something went wrong while trying to request model update', err);
+    });
   }
 }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -497,7 +497,7 @@ export class StudioApiImpl implements StudioAPI {
     return this.updateManager.getAll();
   }
 
-  async requestModelUpdate(modelId:string): Promise<void> {
+  async requestModelUpdate(modelId: string): Promise<void> {
     this.updateManager.requestUpdate(modelId).catch((err: unknown) => {
       console.error('Something went wrong while trying to request model update', err);
     });

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -200,15 +200,15 @@ export class Studio {
     );
 
     this.#panel.onDidChangeViewState((e: WebviewPanelOnDidChangeViewStateEvent) => {
-      if(!this.#lazyInitialized) {
+      if (!this.#lazyInitialized) {
         // init inference manager
-        if(this.#inferenceManager) {
+        if (this.#inferenceManager) {
           this.#inferenceManager.init();
           this.#extensionContext.subscriptions.push(this.#inferenceManager);
         }
 
         // init update manager
-        if(this.#updateManager) {
+        if (this.#updateManager) {
           this.#updateManager.init();
           this.#extensionContext.subscriptions.push(this.#updateManager);
         }

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -39,7 +39,12 @@ export class Downloader {
     return this.target;
   }
 
-  async perform(id: string) {
+  /**
+   * perform the download
+   * @param id
+   * @return true if the downloader has been aborted
+   */
+  async perform(id: string): Promise<boolean> {
     this.requestedIdentifier = id;
     const startTime = performance.now();
 
@@ -69,6 +74,7 @@ export class Downloader {
     } finally {
       this.completed = true;
     }
+    return this.abortSignal?.aborted === true;
   }
 
   private download(url: string): Promise<void> {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,6 +12,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
+    "@podman-desktop/ui-svelte": "^1.9.1",
     "tinro": "^0.6.12"
   },
   "devDependencies": {

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -38,9 +38,9 @@ function createModelService() {
 }
 
 function updateModel() {
-  studioClient.requestModelUpdate(object.id).catch((err) => {
+  studioClient.requestModelUpdate(object.id).catch(err => {
     console.error('Something went wrong while trying to request model update', err);
-  })
+  });
 }
 </script>
 
@@ -60,8 +60,5 @@ function updateModel() {
   <ListItemButtonIcon icon="{faDownload}" onClick="{downloadModel}" title="Download Model" enabled="{!object.state}" />
 {/if}
 {#if updateInfo}
-  <ListItemButtonIcon
-    icon="{faCircleArrowUp}"
-    title="Update model"
-    onClick="{() => updateModel()}" />
+  <ListItemButtonIcon icon="{faCircleArrowUp}" title="Update model" onClick="{() => updateModel()}" />
 {/if}

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
-import { faArrowUp, faCircleArrowUp, faDownload, faRocket, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCircleArrowUp, faDownload, faRocket, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '../../button/ListItemButtonIcon.svelte';
 import { studioClient } from '/@/utils/client';
@@ -10,7 +10,7 @@ import type { UpdateInfo } from '@shared/src/models/IUpdate';
 export let object: ModelInfo;
 
 let updateInfo: UpdateInfo | undefined = undefined;
-$: updateInfo = $modelsUpdateInfo.find(update => update.modelsId === object.id);
+$: updateInfo = $modelsUpdateInfo.find(update => update.modelId === object.id);
 
 function deleteModel() {
   studioClient.requestRemoveLocalModel(object.id).catch(err => {
@@ -60,5 +60,5 @@ function updateModel() {
   <ListItemButtonIcon icon="{faDownload}" onClick="{downloadModel}" title="Download Model" enabled="{!object.state}" />
 {/if}
 {#if updateInfo}
-  <ListItemButtonIcon icon="{faCircleArrowUp}" title="Update model" onClick="{() => updateModel()}" />
+  <ListItemButtonIcon icon="{faCircleArrowUp}" title="{updateInfo.message}" onClick="{() => updateModel()}" />
 {/if}

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
-import { faDownload, faRocket, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faArrowUp, faCircleArrowUp, faDownload, faRocket, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '../../button/ListItemButtonIcon.svelte';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
+import { modelsUpdateInfo } from '/@/stores/modelsUpdateInfo';
+import type { UpdateInfo } from '@shared/src/models/IUpdate';
 export let object: ModelInfo;
+
+let updateInfo: UpdateInfo | undefined = undefined;
+$: updateInfo = $modelsUpdateInfo.find(update => update.modelsId === object.id);
 
 function deleteModel() {
   studioClient.requestRemoveLocalModel(object.id).catch(err => {
@@ -31,6 +36,12 @@ function createModelService() {
   router.goto('/service/create');
   router.location.query.replace({ 'model-id': object.id });
 }
+
+function updateModel() {
+  studioClient.requestModelUpdate(object.id).catch((err) => {
+    console.error('Something went wrong while trying to request model update', err);
+  })
+}
 </script>
 
 {#if object.file !== undefined}
@@ -47,4 +58,10 @@ function createModelService() {
   <ListItemButtonIcon icon="{faTrash}" onClick="{deleteModel}" title="Delete Model" enabled="{!object.state}" />
 {:else}
   <ListItemButtonIcon icon="{faDownload}" onClick="{downloadModel}" title="Download Model" enabled="{!object.state}" />
+{/if}
+{#if updateInfo}
+  <ListItemButtonIcon
+    icon="{faCircleArrowUp}"
+    title="Update model"
+    onClick="{() => updateModel()}" />
 {/if}

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -42,8 +42,18 @@ const mocks = vi.hoisted(() => {
     },
     getModelsInfoMock: vi.fn().mockResolvedValue([]),
     getTasks: vi.fn().mockResolvedValue([]),
+    getModelsUpdateInfoMock: vi.fn().mockReturnValue([]),
   };
 });
+
+vi.mock('/@/stores/modelsUpdateInfo', () => ({
+  modelsUpdateInfo: {
+    subscribe: (f: (msg: any) => void) => {
+      f(mocks.getModelsUpdateInfoMock());
+      return () => {};
+    },
+  },
+}));
 
 vi.mock('/@/utils/client', async () => {
   return {

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { vi, test, expect, describe } from 'vitest';
+import { vi, test, expect } from 'vitest';
 import { screen, render, waitFor, within } from '@testing-library/svelte';
 import Models from './Models.svelte';
 import { router } from 'tinro';

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { vi, test, expect } from 'vitest';
+import { vi, test, expect, describe } from 'vitest';
 import { screen, render, waitFor, within } from '@testing-library/svelte';
 import Models from './Models.svelte';
 import { router } from 'tinro';

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -38,7 +38,7 @@ const columns: Column<ModelInfo>[] = [
     renderer: ModelColumnAge,
     comparator: (a, b) => (a.file?.creation?.getTime() ?? 0) - (b.file?.creation?.getTime() ?? 0),
   }),
-  new Column<ModelInfo>('', { width: '225px', align: 'right', renderer: ModelColumnLabels }),
+  new Column<ModelInfo>('', { width: '240px', align: 'right', renderer: ModelColumnLabels }),
   new Column<ModelInfo>('Actions', { align: 'right', width: '160px', renderer: ModelColumnActions }),
 ];
 const row = new Row<ModelInfo>({});

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -39,7 +39,7 @@ const columns: Column<ModelInfo>[] = [
     comparator: (a, b) => (a.file?.creation?.getTime() ?? 0) - (b.file?.creation?.getTime() ?? 0),
   }),
   new Column<ModelInfo>('', { width: '225px', align: 'right', renderer: ModelColumnLabels }),
-  new Column<ModelInfo>('Actions', { align: 'right', width: '120px', renderer: ModelColumnActions }),
+  new Column<ModelInfo>('Actions', { align: 'right', width: '160px', renderer: ModelColumnActions }),
 ];
 const row = new Row<ModelInfo>({});
 

--- a/packages/frontend/src/stores/modelsUpdateInfo.ts
+++ b/packages/frontend/src/stores/modelsUpdateInfo.ts
@@ -21,4 +21,8 @@ import { Messages } from '@shared/Messages';
 import { RPCReadable } from './rpcReadable';
 import type { UpdateInfo } from '@shared/src/models/IUpdate';
 
-export const modelsUpdateInfo = RPCReadable<UpdateInfo[]>([], [Messages.MSG_UPDATES_INFO], studioClient.getModelsUpdateInfo);
+export const modelsUpdateInfo = RPCReadable<UpdateInfo[]>(
+  [],
+  [Messages.MSG_UPDATES_INFO],
+  studioClient.getModelsUpdateInfo,
+);

--- a/packages/frontend/src/stores/modelsUpdateInfo.ts
+++ b/packages/frontend/src/stores/modelsUpdateInfo.ts
@@ -16,16 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum Messages {
-  MSG_NEW_CATALOG_STATE = 'new-catalog-state',
-  MSG_TASKS_UPDATE = 'tasks-update',
-  MSG_NEW_MODELS_STATE = 'new-models-state',
-  MSG_APPLICATIONS_STATE_UPDATE = 'applications-state-update',
-  MSG_LOCAL_REPOSITORY_UPDATE = 'local-repository-update',
-  MSG_INFERENCE_SERVERS_UPDATE = 'inference-servers-update',
-  MSG_MONITORING_UPDATE = 'monitoring-update',
-  MSG_SUPPORTED_LANGUAGES_UPDATE = 'supported-languages-supported',
-  MSG_CONVERSATIONS_UPDATE = 'conversations-update',
-  MSG_GPUS_UPDATE = 'gpus-update',
-  MSG_UPDATES_INFO = 'updates-info-update',
-}
+import { studioClient } from '/@/utils/client';
+import { Messages } from '@shared/Messages';
+import { RPCReadable } from './rpcReadable';
+import type { UpdateInfo } from '@shared/src/models/IUpdate';
+
+export const modelsUpdateInfo = RPCReadable<UpdateInfo[]>([], [Messages.MSG_UPDATES_INFO], studioClient.getModelsUpdateInfo);

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -30,6 +30,7 @@ import type { ModelOptions } from './models/IModelOptions';
 import type { Conversation } from './models/IPlaygroundMessage';
 import type { LocalModelImportInfo } from './models/ILocalModelInfo';
 import type { ContainerConnectionInfo } from './models/IContainerConnectionInfo';
+import type { UpdateInfo } from './models/IUpdate';
 
 export abstract class StudioAPI {
   abstract ping(): Promise<string>;
@@ -195,4 +196,15 @@ export abstract class StudioAPI {
    * @param modelInfo object containing info about the model to check
    */
   abstract checkContainerConnectionStatusAndResources(modelInfo: ModelCheckerInfo): Promise<ContainerConnectionInfo>;
+
+  /**
+   * Get the current models update info.
+   */
+  abstract getModelsUpdateInfo(): Promise<UpdateInfo[]>;
+
+  /**
+   * Request to update a model
+   * @param modelId the id of the model to update
+   */
+  abstract requestModelUpdate(modelId: string): Promise<void>;
 }

--- a/packages/shared/src/models/IUpdate.ts
+++ b/packages/shared/src/models/IUpdate.ts
@@ -18,5 +18,5 @@
 
 export interface UpdateInfo {
   message: string;
-  modelsId: string;
+  modelId: string;
 }

--- a/packages/shared/src/models/IUpdate.ts
+++ b/packages/shared/src/models/IUpdate.ts
@@ -16,16 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum Messages {
-  MSG_NEW_CATALOG_STATE = 'new-catalog-state',
-  MSG_TASKS_UPDATE = 'tasks-update',
-  MSG_NEW_MODELS_STATE = 'new-models-state',
-  MSG_APPLICATIONS_STATE_UPDATE = 'applications-state-update',
-  MSG_LOCAL_REPOSITORY_UPDATE = 'local-repository-update',
-  MSG_INFERENCE_SERVERS_UPDATE = 'inference-servers-update',
-  MSG_MONITORING_UPDATE = 'monitoring-update',
-  MSG_SUPPORTED_LANGUAGES_UPDATE = 'supported-languages-supported',
-  MSG_CONVERSATIONS_UPDATE = 'conversations-update',
-  MSG_GPUS_UPDATE = 'gpus-update',
-  MSG_UPDATES_INFO = 'updates-info-update',
+export interface UpdateInfo {
+  message: string;
+  modelsId: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,6 +401,17 @@
   resolved "https://registry.yarnpkg.com/@podman-desktop/tests-playwright/-/tests-playwright-1.10.1.tgz#cbee9812d3f84fefb394cc0044fd0e72a574f486"
   integrity sha512-SUIP3+/FV/rumiMGb4GBYRXQoi4F2mVYYw+hWk6XmnRMPrBakVZcS0/TChZ9upV6o7Mhzt8K2zJC/fsyBJVA6Q==
 
+"@podman-desktop/ui-svelte@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/ui-svelte/-/ui-svelte-1.9.1.tgz#aa7550ee6b3310366ce2f7576821b9562912e147"
+  integrity sha512-fAxAjE/mdEOhQt605I5FyFvBDW7PHp/+C8JEVBStP2InBfcLTaBhVFWuSJdYlmZYOOZ4tzmplfgxBi8gg7SOYw==
+  dependencies:
+    "@fortawesome/fontawesome-free" "^6.5.2"
+    "@fortawesome/free-brands-svg-icons" "^6.5.2"
+    "@fortawesome/free-regular-svg-icons" "^6.5.2"
+    "@fortawesome/free-solid-svg-icons" "^6.5.2"
+    svelte-fa "^4.0.2"
+
 "@rollup/rollup-android-arm-eabi@4.13.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz#b98786c1304b4ff8db3a873180b778649b5dff2b"


### PR DESCRIPTION
### What does this PR do?

This PR adds a `UpdateManager` for the models, responsible of keeping track if a models has been updated.

How ? Most CDN provide a `ETag` or Entity Tag, which is globally a resource identifier, we can make a `HEAD` request to the model's url to get the `ETag` value. We save the etag value in a `etag` file next to the models.

Why ? We are mostly using urls which resolve the main branch of a repository, not a fixed commit. Therefore when new commits become available, we might want to download the new version.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/466

### How to test this PR?

- [x] todo write unit tests