### PR TITLE
resolve tag before to compare with current commit

### DIFF
--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -195,6 +195,10 @@ export class GitManager {
       if (ref === undefined) {
         return { error: 'The local repository is detached.' };
       } else {
+        const tag = await this.getTagCommitId(directory, ref);
+        if (tag) {
+          ref = tag;
+        }
         const commit = await this.getCurrentCommit(directory);
         if (!commit.startsWith(ref)) {
           return { error: `The local repository is detached. HEAD is ${commit} expected ${ref}.` };
@@ -293,5 +297,17 @@ export class GitManager {
       behind: behind + remoteCommits.length,
       ahead: ahead + localCommits.length,
     };
+  }
+
+  async getTagCommitId(directory: string, tagName: string): Promise<string | undefined> {
+    try {
+      return await git.resolveRef({
+        fs,
+        dir: directory,
+        ref: tagName,
+      });
+    } catch {
+      return undefined;
+    }
   }
 }


### PR DESCRIPTION
### What does this PR do?

When starting a recipe, resolve tag (if a tag) before to compare with current commit

### What issues does this PR fix or reference?

Fix #1038 

### How to test this PR?

- Start a recipe, stop it, and start it again. No error should be raised.
- Change sources, then restart recipe. A message should indicate the repository is not clean 