### PR TITLE
feat: allows to set a custom folder where to download models

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,6 +11,17 @@
   },
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "AI Lab",
+      "properties": {
+        "ai-lab.models.path": {
+          "type": "string",
+          "format": "folder",
+          "default": "",
+          "description": "Custom path where to download models. Note: The extension must be restarted for changes to take effect. (Default is blank)"
+        }
+      }
+    },
     "icons": {
       "brain-icon": {
         "description": "Brain icon",


### PR DESCRIPTION
### What does this PR do?

It allows to set a custom folder where to download models.
Right now, the settings it is just a textbox where the user has to copy/paste the path. It will need the PR https://github.com/containers/podman-desktop/pull/7135 to be merged to switch to a file component

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #51 

### How to test this PR?

1. update the models dir by using the new setting. Restart the extension and check it uses the new folder