### PR TITLE
fix: error when calculating sha256 on big files

### DIFF
--- a/packages/backend/src/utils/sha.spec.ts
+++ b/packages/backend/src/utils/sha.spec.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { beforeEach, expect, test, vi } from 'vitest';
-import { promises } from 'node:fs';
+import * as fs from 'node:fs';
 import { hasValidSha } from './sha';
+import { Readable } from 'node:stream';
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -25,7 +26,12 @@ beforeEach(() => {
 
 test('return true if file has same hash of the expected one', () => {
   vi.mock('node:fs');
-  vi.spyOn(promises, 'readFile').mockImplementation(() => Promise.resolve(Buffer.from('test')));
+
+  const readable = Readable.from('test');
+
+  vi.spyOn(fs, 'createReadStream').mockImplementation(() => {
+    return readable as fs.ReadStream;
+  });
 
   // sha of test => 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
   const isValid = hasValidSha('file', '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08');
@@ -34,7 +40,11 @@ test('return true if file has same hash of the expected one', () => {
 
 test('return false if file has different hash of the expected one', () => {
   vi.mock('node:fs');
-  vi.spyOn(promises, 'readFile').mockImplementation(() => Promise.resolve(Buffer.from('test')));
+  const readable = Readable.from('test');
+
+  vi.spyOn(fs, 'createReadStream').mockImplementation(() => {
+    return readable as fs.ReadStream;
+  });
 
   // sha of test => 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
   const isValid = hasValidSha('file', 'fakeSha');

--- a/packages/backend/src/utils/sha.ts
+++ b/packages/backend/src/utils/sha.ts
@@ -16,13 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import crypto from 'node:crypto';
-import { promises } from 'node:fs';
+import * as fs from 'node:fs';
+import { promises } from 'node:stream';
 
 export async function hasValidSha(filePath: string, expectedSha: string): Promise<boolean> {
   const checkSum = crypto.createHash('sha256');
-  const readStream = await promises.readFile(filePath);
+  const input = fs.createReadStream(filePath);
+  await promises.pipeline(input, checkSum);
 
-  checkSum.update(readStream);
   const actualSha = checkSum.digest('hex');
   return actualSha === expectedSha;
 }


### PR DESCRIPTION
### What does this PR do?

It avoid reading a huge file all at once, resulting in a failure when trying to calculate sha256

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #1093 

### How to test this PR?

1. download a big model (> 2GB) like granite
2. start a recipe with the downloaded model (it must already be on disk, otherwise you won't face the issue/fix)