### PR TITLE
feat: improve recipes page

### DIFF
--- a/packages/frontend/src/lib/RecipeCard.svelte
+++ b/packages/frontend/src/lib/RecipeCard.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import { getIcon } from '/@/utils/categoriesUtils.js';
+import Card from '/@/lib/Card.svelte';
+import type { Recipe } from '@shared/src/models/IRecipe';
+
+export let background: string = 'bg-charcoal-700';
+
+export let recipe: Recipe;
+export let displayDescription: boolean = true;
+</script>
+
+<Card
+  href="/recipe/{recipe.id}"
+  title="{recipe.name}"
+  description="{displayDescription ? recipe.description : ''}"
+  icon="{getIcon(recipe.icon)}"
+  classes="{background} flex-grow p-4 h-full" />

--- a/packages/frontend/src/lib/RecipesCard.spec.ts
+++ b/packages/frontend/src/lib/RecipesCard.spec.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import RecipesCard from '/@/lib/RecipesCard.svelte';
+
+test('recipes card without recipes should display empty message', async () => {
+  render(RecipesCard, {
+    recipes: [],
+    category: {
+      id: 'dummy-category',
+      name: 'Dummy category',
+    },
+  });
+
+  const message = screen.getByText('There is no recipe in this category for now ! Come back later');
+  expect(message).toBeDefined();
+});
+
+test('recipes card with recipes should display them', async () => {
+  render(RecipesCard, {
+    recipes: [
+      {
+        id: 'recipe1',
+        name: 'Recipe 1',
+        models: ['model1'],
+        categories: [],
+        description: 'Recipe 1',
+        readme: '',
+        repository: 'https://recipe-1',
+      },
+    ],
+    category: {
+      id: 'dummy-category',
+      name: 'Dummy category',
+    },
+  });
+
+  const text = screen.getAllByText('Recipe 1');
+  expect(text.length).toBeGreaterThan(0);
+});

--- a/packages/frontend/src/lib/RecipesCard.svelte
+++ b/packages/frontend/src/lib/RecipesCard.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
 import Card from '/@/lib/Card.svelte';
-import { getIcon } from '/@/utils/categoriesUtils';
 import type { Category } from '@shared/src/models/ICategory';
-import { catalog } from '/@/stores/catalog';
+import RecipeCard from '/@/lib/RecipeCard.svelte';
+import type { Recipe } from '@shared/src/models/IRecipe';
 
 export let category: Category;
-
-$: categories = $catalog.categories;
-$: recipes = $catalog.recipes.filter(r => r.categories.includes(category.id));
+export let recipes: Recipe[];
 
 export let primaryBackground: string = 'bg-charcoal-800';
 export let secondaryBackground: string = 'bg-charcoal-700';
 
-export let displayCategory: boolean = true;
 export let displayDescription: boolean = true;
 </script>
 
@@ -23,23 +20,7 @@ export let displayDescription: boolean = true;
     {/if}
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
       {#each recipes as recipe}
-        <Card
-          href="/recipe/{recipe.id}"
-          title="{recipe.name}"
-          description="{displayDescription ? recipe.description : ''}"
-          icon="{getIcon(recipe.icon)}"
-          classes="{secondaryBackground} flex-grow p-4 h-full">
-          <div slot="content" class="text-base font-normal mt-2">
-            {#if displayCategory}
-              {#each recipe.categories as categoryId}
-                <Card
-                  title="{categories.find(category => category.id === categoryId)?.name || '?'}"
-                  classes="{primaryBackground} p-1"
-                  primaryBackground="{primaryBackground}" />
-              {/each}
-            {/if}
-          </div>
-        </Card>
+        <RecipeCard recipe="{recipe}" background="{secondaryBackground}" displayDescription="{displayDescription}" />
       {/each}
     </div>
   </div>

--- a/packages/frontend/src/pages/Recipes.spec.ts
+++ b/packages/frontend/src/pages/Recipes.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { ApplicationCatalog } from '@shared/src/models/IApplicationCatalog';
+import * as catalogStore from '/@/stores/catalog';
+import { readable } from 'svelte/store';
+import Recipes from '/@/pages/Recipes.svelte';
+
+vi.mock('/@/stores/catalog', async () => {
+  return {
+    catalog: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  const catalog: ApplicationCatalog = {
+    recipes: [
+      {
+        id: 'recipe1',
+        name: 'Recipe 1',
+        models: ['model1'],
+        categories: [],
+        description: 'Recipe 1',
+        readme: '',
+        repository: 'https://recipe-1',
+      },
+      {
+        id: 'recipe2',
+        name: 'Recipe 2',
+        models: ['model2'],
+        categories: ['dummy-category'],
+        description: 'Recipe 2',
+        readme: '',
+        repository: 'https://recipe-2',
+      },
+    ],
+    models: [],
+    categories: [
+      {
+        id: 'dummy-category',
+        name: 'Dummy category',
+      },
+    ],
+  };
+  vi.mocked(catalogStore).catalog = readable(catalog);
+});
+
+test('recipe without category should be visible', async () => {
+  render(Recipes);
+
+  const text = screen.getAllByText('Recipe 1');
+  expect(text.length).toBeGreaterThan(0);
+});
+
+test('recipe with category should be visible', async () => {
+  render(Recipes);
+
+  const text = screen.getAllByText('Recipe 2');
+  expect(text.length).toBeGreaterThan(0);
+});

--- a/packages/frontend/src/pages/Recipes.svelte
+++ b/packages/frontend/src/pages/Recipes.svelte
@@ -1,24 +1,59 @@
 <script lang="ts">
 import NavPage from '/@/lib/NavPage.svelte';
 import RecipesCard from '/@/lib/RecipesCard.svelte';
-import { RECENT_CATEGORY_ID } from '/@/utils/client';
 import { catalog } from '/@/stores/catalog';
+import type { Recipe } from '@shared/src/models/IRecipe';
+import { onMount } from 'svelte';
+import type { Category } from '@shared/src/models/ICategory';
 
-$: categories = $catalog.categories;
+let groups: Map<Category, Recipe[]> = new Map();
+
+const UNCLASSIFIED: Category = {
+  id: 'unclassified',
+  name: 'Unclassified',
+};
+
+onMount(() => {
+  return catalog.subscribe(({ recipes, categories }) => {
+    const categoryDict = Object.fromEntries(categories.map(category => [category.id, category]));
+
+    const output: Map<Category, Recipe[]> = new Map();
+
+    for (const recipe of recipes) {
+      if (recipe.categories.length === 0) {
+        output.set(UNCLASSIFIED, [...(output.get(UNCLASSIFIED) ?? []), recipe]);
+        continue;
+      }
+
+      // iterate over all categories
+      for (const categoryId of recipe.categories) {
+        let key: Category;
+        if (categoryId in categoryDict) {
+          key = categoryDict[categoryId];
+        } else {
+          key = UNCLASSIFIED;
+        }
+
+        output.set(key, [...(output.get(key) ?? []), recipe]);
+      }
+    }
+
+    groups = output;
+  });
+});
 </script>
 
 <NavPage title="Recipe Catalog" searchEnabled="{false}">
   <div slot="content" class="flex flex-col min-w-full min-h-full">
     <div class="min-w-full min-h-full flex-1">
       <div class="px-5 space-y-5">
-        {#each categories as category}
-          {#if $catalog.recipes.some(r => r.categories.includes(category.id))}
-            <RecipesCard
-              category="{category}"
-              primaryBackground=""
-              secondaryBackground="bg-charcoal-700"
-              displayCategory="{false}" />
-          {/if}
+        {#each groups.entries() as [category, recipes]}
+          <RecipesCard
+            category="{category}"
+            recipes="{recipes}"
+            primaryBackground=""
+            secondaryBackground="bg-charcoal-700"
+            displayCategory="{false}" />
         {/each}
       </div>
     </div>


### PR DESCRIPTION
### What does this PR do?

- Remove the catalog store dependency of the RecipesCard component 
- Create a dedicated RecipeCard component
- Place all recipes without categories in an `unclassified` section (before they were just not displayed)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

This work is required for https://github.com/containers/podman-desktop-extension-ai-lab/issues/1095

https://github.com/containers/podman-desktop-extension-ai-lab/pull/1097 will need to be rebased after this is merged
### How to test this PR?

- [x] unit tests have been provided