### PR TITLE
refactor: cleanup application manager

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -1381,4 +1381,3 @@ describe('pod detection', async () => {
     expect(state[0].health).toEqual('healthy');
   });
 });
-

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -40,7 +40,7 @@ import { getPortsFromLabel, getPortsInfo } from '../utils/ports';
 import { goarch } from '../utils/arch';
 import { getDurationSecondsSince, timeout } from '../utils/utils';
 import type { LocalRepositoryRegistry } from '../registries/LocalRepositoryRegistry';
-import type { ApplicationState, PodHealth } from '@shared/src/models/IApplicationState';
+import type { ApplicationState } from '@shared/src/models/IApplicationState';
 import type { PodmanConnection } from './podmanConnection';
 import { Messages } from '@shared/Messages';
 import type { CatalogManager } from './catalogManager';

--- a/packages/backend/src/utils/imagesUtils.spec.ts
+++ b/packages/backend/src/utils/imagesUtils.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest';
+import type { Recipe } from '@shared/src/models/IRecipe';
+import type { ContainerConfig } from '../models/AIConfig';
+import { getImageTag } from './imagesUtils';
+
+test('return recipe-container tag if container image prop is not defined', () => {
+  const recipe = {
+    id: 'recipe1',
+  } as Recipe;
+  const container = {
+    name: 'name',
+  } as ContainerConfig;
+  const imageTag = getImageTag(recipe, container);
+  expect(imageTag).equals('recipe1-name:latest');
+});
+test('return container image prop is defined', () => {
+  const recipe = {
+    id: 'recipe1',
+  } as Recipe;
+  const container = {
+    name: 'name',
+    image: 'quay.io/repo/image:v1',
+  } as ContainerConfig;
+  const imageTag = getImageTag(recipe, container);
+  expect(imageTag).equals('quay.io/repo/image:v1');
+});
+test('append latest tag to container image prop if it has no tag', () => {
+  const recipe = {
+    id: 'recipe1',
+  } as Recipe;
+  const container = {
+    name: 'name',
+    image: 'quay.io/repo/image',
+  } as ContainerConfig;
+  const imageTag = getImageTag(recipe, container);
+  expect(imageTag).equals('quay.io/repo/image:latest');
+});

--- a/packages/backend/src/utils/imagesUtils.ts
+++ b/packages/backend/src/utils/imagesUtils.ts
@@ -16,10 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const getRandomString = (): string => {
-  return (Math.random() + 1).toString(36).substring(7);
-};
+import type { Recipe } from '@shared/src/models/IRecipe';
+import type { ContainerConfig } from '../models/AIConfig';
 
-export function getRandomName(prefix: string): string {
-  return `${prefix ?? ''}-${new Date().getTime()}`;
+export function getImageTag(recipe: Recipe, container: ContainerConfig) {
+  let tag = container.image ?? `${recipe.id}-${container.name}`;
+  if (!tag.includes(':')) {
+    tag += ':latest';
+  }
+  return tag;
 }

--- a/packages/backend/src/utils/podsUtils.ts
+++ b/packages/backend/src/utils/podsUtils.ts
@@ -15,11 +15,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { PodHealth } from '@shared/src/models/IApplicationState';
 
-export const getRandomString = (): string => {
-  return (Math.random() + 1).toString(36).substring(7);
-};
-
-export function getRandomName(prefix: string): string {
-  return `${prefix ?? ''}-${new Date().getTime()}`;
+export function getPodHealth(infos: (string | undefined)[]): PodHealth {
+  const checked = infos.filter(info => !!info && info !== 'none' && info !== '');
+  if (!checked.length) {
+    return 'none';
+  }
+  if (infos.some(info => info === 'unhealthy')) {
+    return 'unhealthy';
+  }
+  if (infos.some(info => info === 'starting')) {
+    return 'starting';
+  }
+  return 'healthy';
 }


### PR DESCRIPTION
### What does this PR do?

The `ApplicationManager` is too big, and doing too much stuff. We **need** to simply it. 

This PR move the static functions to dedicated utils file, to remove some noise from the ApplicationManager.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1102

### How to test this PR?

- [x] unit tests has been provided