### PR TITLE
refactor(ApplicationManager): extract build image logic

### DIFF
--- a/packages/backend/src/managers/recipes/BuilderManager.spec.ts
+++ b/packages/backend/src/managers/recipes/BuilderManager.spec.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Recipe } from '@shared/src/models/IRecipe';
+import type { ContainerConfig } from '../../models/AIConfig';
+import fs from 'node:fs';
+import { BuilderManager } from './BuilderManager';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import type { ImageInfo } from '@podman-desktop/api';
+import { containerEngine } from '@podman-desktop/api';
+
+const taskRegistry = {
+  getTask: vi.fn(),
+  createTask: vi.fn(),
+  updateTask: vi.fn(),
+  delete: vi.fn(),
+  deleteAll: vi.fn(),
+  getTasks: vi.fn(),
+  getTasksByLabels: vi.fn(),
+  deleteByLabels: vi.fn(),
+} as unknown as TaskRegistry;
+
+vi.mock('@podman-desktop/api', () => ({
+  containerEngine: {
+    buildImage: vi.fn(),
+    listImages: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(taskRegistry.createTask).mockImplementation((name, state, labels) => ({
+    id: 'random',
+    name: name,
+    state: state,
+    labels: labels ?? {},
+    error: undefined,
+  }));
+});
+
+describe('buildImages', () => {
+  const recipe = {
+    id: 'recipe1',
+  } as Recipe;
+  const containers: ContainerConfig[] = [
+    {
+      name: 'container1',
+      contextdir: 'contextdir1',
+      containerfile: 'Containerfile',
+      arch: ['amd64'],
+      modelService: false,
+      gpu_env: [],
+      ports: [8080],
+    },
+  ];
+  const manager = new BuilderManager(taskRegistry);
+
+  test('setTaskState should be called with error if context does not exist', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.mocked(containerEngine.listImages).mockRejectedValue([]);
+    await expect(manager.build(recipe, containers, 'config')).rejects.toThrow('Context configured does not exist.');
+  });
+  test('setTaskState should be called with error if buildImage executon fails', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.mocked(containerEngine.buildImage).mockRejectedValue('error');
+    vi.mocked(containerEngine.listImages).mockRejectedValue([]);
+
+    await expect(manager.build(recipe, containers, 'config')).rejects.toThrow(
+      'Something went wrong while building the image: error',
+    );
+    expect(taskRegistry.updateTask).toBeCalledWith({
+      error: 'Something went wrong while building the image: error',
+      name: 'Building container1',
+      id: expect.any(String),
+      state: expect.any(String),
+      labels: {},
+    });
+  });
+  test('setTaskState should be called with error if unable to find the image after built', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.mocked(containerEngine.buildImage).mockResolvedValue({});
+    vi.mocked(containerEngine.listImages).mockResolvedValue([]);
+
+    await expect(manager.build(recipe, containers, 'config')).rejects.toThrow('no image found for container1:latest');
+    expect(taskRegistry.updateTask).toBeCalledWith({
+      error: 'no image found for container1:latest',
+      name: 'Building container1',
+      id: expect.any(String),
+      state: expect.any(String),
+      labels: {},
+    });
+  });
+  test('succeed if building image do not fail', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.mocked(containerEngine.buildImage).mockResolvedValue({});
+    vi.mocked(containerEngine.listImages).mockResolvedValue([
+      {
+        RepoTags: ['recipe1-container1:latest'],
+        engineId: 'engine',
+        Id: 'id1',
+      } as unknown as ImageInfo,
+    ]);
+
+    const imageInfoList = await manager.build(recipe, containers, 'config');
+    expect(taskRegistry.updateTask).toBeCalledWith({
+      name: 'Building container1',
+      id: expect.any(String),
+      state: 'success',
+      labels: {},
+    });
+    expect(imageInfoList.length).toBe(1);
+    expect(imageInfoList[0].ports.length).toBe(1);
+    expect(imageInfoList[0].ports[0]).equals('8080');
+  });
+});

--- a/packages/backend/src/managers/recipes/BuilderManager.ts
+++ b/packages/backend/src/managers/recipes/BuilderManager.ts
@@ -1,0 +1,159 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { type BuildImageOptions, type Disposable, containerEngine } from '@podman-desktop/api';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import type { Recipe } from '@shared/src/models/IRecipe';
+import type { ContainerConfig } from '../../models/AIConfig';
+import type { ImageInfo} from '../applicationManager';
+import { LABEL_RECIPE_ID } from '../applicationManager';
+import type { Task } from '@shared/src/models/ITask';
+import path from 'node:path';
+import { getParentDirectory } from '../../utils/pathUtils';
+import fs from 'fs';
+import { getImageTag } from '../../utils/imagesUtils';
+
+export class BuilderManager implements Disposable {
+  private controller: Map<string, AbortController> = new Map();
+
+  constructor(private taskRegistry: TaskRegistry) {}
+
+  /**
+   * On dispose, the builder will abort all current build.
+   */
+  dispose(): void {
+    Array.from(this.controller.values()).every(controller => controller.abort('disposing builder manager'));
+  }
+
+  async build(
+    recipe: Recipe,
+    containers: ContainerConfig[],
+    configPath: string,
+    labels?: { [key: string]: string },
+  ): Promise<ImageInfo[]> {
+    const containerTasks: { [key: string]: Task } = Object.fromEntries(
+      containers.map(container => [
+        container.name,
+        this.taskRegistry.createTask(`Building ${container.name}`, 'loading', labels),
+      ]),
+    );
+
+    const imageInfoList: ImageInfo[] = [];
+
+    // Promise all the build images
+    const abortController = new AbortController();
+
+    // only one build per recipe is supported
+    if (this.controller.has(recipe.id)) {
+      this.controller.get(recipe.id)?.abort('multiple build not supported.');
+    }
+
+    this.controller.set(recipe.id, abortController);
+
+    try {
+      await Promise.all(
+        containers.map(container => {
+          const task = containerTasks[container.name];
+
+          // We use the parent directory of our configFile as the rootdir, then we append the contextDir provided
+          const context = path.join(getParentDirectory(configPath), container.contextdir);
+          console.log(`Application Manager using context ${context} for container ${container.name}`);
+
+          // Ensure the context provided exist otherwise throw an Error
+          if (!fs.existsSync(context)) {
+            task.error = 'The context provided does not exist.';
+            this.taskRegistry.updateTask(task);
+            throw new Error('Context configured does not exist.');
+          }
+
+          const imageTag = getImageTag(recipe, container);
+          const buildOptions: BuildImageOptions = {
+            containerFile: container.containerfile,
+            tag: imageTag,
+            labels: {
+              [LABEL_RECIPE_ID]: labels !== undefined && 'recipe-id' in labels ? labels['recipe-id'] : '',
+            },
+            abortController: abortController,
+          };
+
+          let error = false;
+          return containerEngine
+            .buildImage(
+              context,
+              (event, data) => {
+                // todo: do something with the event
+                if (event === 'error' || (event === 'finish' && data !== '')) {
+                  console.error('Something went wrong while building the image: ', data);
+                  task.error = `Something went wrong while building the image: ${data}`;
+                  this.taskRegistry.updateTask(task);
+                  error = true;
+                }
+              },
+              buildOptions,
+            )
+            .catch((err: unknown) => {
+              task.error = `Something went wrong while building the image: ${String(err)}`;
+              this.taskRegistry.updateTask(task);
+              throw new Error(`Something went wrong while building the image: ${String(err)}`);
+            })
+            .then(() => {
+              if (error) {
+                throw new Error(`Something went wrong while building the image: ${imageTag}`);
+              }
+            });
+        }),
+      );
+    } catch (err: unknown) {
+      abortController.abort();
+      throw err;
+    } finally {
+      // remove abort controller
+      this.controller.delete(recipe.id);
+    }
+
+    // after image are built we return their data
+    const images = await containerEngine.listImages();
+    await Promise.all(
+      containers.map(async container => {
+        const task = containerTasks[container.name];
+        const imageTag = getImageTag(recipe, container);
+
+        const image = images.find(im => {
+          return im.RepoTags?.some(tag => tag.endsWith(imageTag));
+        });
+
+        if (!image) {
+          task.error = `no image found for ${container.name}:latest`;
+          this.taskRegistry.updateTask(task);
+          throw new Error(`no image found for ${container.name}:latest`);
+        }
+
+        imageInfoList.push({
+          id: image.Id,
+          modelService: container.modelService,
+          ports: container.ports?.map(p => `${p}`) ?? [],
+          appName: container.name,
+        });
+
+        task.state = 'success';
+        this.taskRegistry.updateTask(task);
+      }),
+    );
+
+    return imageInfoList;
+  }
+}

--- a/packages/backend/src/managers/recipes/BuilderManager.ts
+++ b/packages/backend/src/managers/recipes/BuilderManager.ts
@@ -19,7 +19,7 @@ import { type BuildImageOptions, type Disposable, containerEngine } from '@podma
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import type { Recipe } from '@shared/src/models/IRecipe';
 import type { ContainerConfig } from '../../models/AIConfig';
-import type { ImageInfo} from '../applicationManager';
+import type { ImageInfo } from '../applicationManager';
 import { LABEL_RECIPE_ID } from '../applicationManager';
 import type { Task } from '@shared/src/models/ITask';
 import path from 'node:path';

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -41,6 +41,7 @@ import { PlaygroundV2Manager } from './managers/playgroundV2Manager';
 import { SnippetManager } from './managers/SnippetManager';
 import { CancellationTokenRegistry } from './registries/CancellationTokenRegistry';
 import { engines } from '../package.json';
+import { BuilderManager } from './managers/recipes/BuilderManager';
 
 export const AI_LAB_COLLECT_GPU_COMMAND = 'ai-lab.gpu.collect';
 
@@ -158,6 +159,9 @@ export class Studio {
     this.catalogManager = new CatalogManager(this.#panel.webview, appUserDirectory);
     this.catalogManager.init();
 
+    const builderManager = new BuilderManager(taskRegistry);
+    this.#extensionContext.subscriptions.push(builderManager);
+
     this.modelsManager = new ModelsManager(
       appUserDirectory,
       this.#panel.webview,
@@ -179,6 +183,7 @@ export class Studio {
       this.modelsManager,
       this.telemetry,
       localRepositoryRegistry,
+      builderManager,
     );
 
     this.#inferenceManager = new InferenceManager(


### PR DESCRIPTION
### What does this PR do?

Simplify the ApplicationManager class by migrating build image logic to a dedicated manager.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1104

### How to test this PR?

- [x] unit tests have been provided

You can start some recipes to ensure there is not regression