### PR TITLE
fix: bump inference server image to 0.3.2

### DIFF
--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -36,7 +36,7 @@ export const SECOND: number = 1_000_000_000;
 export const LABEL_INFERENCE_SERVER: string = 'ai-lab-inference-server';
 
 export const INFERENCE_SERVER_IMAGE =
-  'ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:0.3.1';
+  'ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:0.3.2';
 
 /**
  * Return container connection provider


### PR DESCRIPTION
Fixes #1103

### What does this PR do?

Bump inference server to 0.3.2

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#1103 

### How to test this PR?

1. Create an inference server
2. Create and use a playground