### PR TITLE
refactor: create PodManager

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -1212,6 +1212,10 @@ describe('pod detection', async () => {
         'ai-lab-model-id': 'model-id-1',
       },
     });
+    expect(podManager.findPodByLabelsValues).toHaveBeenCalledWith({
+      'ai-lab-recipe-id': 'recipe-id-1',
+      'ai-lab-model-id': 'model-id-1',
+    });
   });
 
   test('deleteApplication calls stopPod and removePod', async () => {

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -746,8 +746,8 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
 
   private async findPod(recipeId: string, modelId: string): Promise<PodInfo | undefined> {
     return this.podManager.findPodByLabelsValues({
-      LABEL_RECIPE_ID: recipeId,
-      LABEL_MODEL_ID: modelId,
+      [LABEL_RECIPE_ID]: recipeId,
+      [LABEL_MODEL_ID]: modelId,
     });
   }
 

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -48,9 +48,9 @@ import { Publisher } from '../utils/Publisher';
 import { isQEMUMachine } from '../utils/podman';
 import { SECOND } from '../utils/inferenceUtils';
 import { getModelPropertiesForEnvironment } from '../utils/modelsUtils';
-import { getPodHealth } from '../utils/podsUtils';
 import { getRandomName } from '../utils/randomUtils';
 import type { BuilderManager } from './recipes/BuilderManager';
+import type { PodManager } from './recipes/PodManager';
 
 export const LABEL_MODEL_ID = 'ai-lab-model-id';
 export const LABEL_MODEL_PORTS = 'ai-lab-model-ports';
@@ -101,6 +101,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
     private telemetry: TelemetryLogger,
     private localRepositories: LocalRepositoryRegistry,
     private builderManager: BuilderManager,
+    private podManager: PodManager,
   ) {
     super(webview, Messages.MSG_APPLICATIONS_STATE_UPDATE, () => this.getApplicationsState());
     this.#applications = new ApplicationRegistry<ApplicationState>();
@@ -501,13 +502,10 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
 
   adoptRunningApplications() {
     this.podmanConnection.startupSubscribe(() => {
-      containerEngine
-        .listPods()
+      this.podManager
+        .getPodsWithLabels([LABEL_RECIPE_ID])
         .then(pods => {
-          const appsPods = pods.filter(pod => LABEL_RECIPE_ID in pod.Labels);
-          for (const podToAdopt of appsPods) {
-            this.adoptPod(podToAdopt);
-          }
+          pods.forEach(pod => this.adoptPod(pod));
         })
         .catch((err: unknown) => {
           console.error('error during adoption of existing playground containers', err);
@@ -637,10 +635,9 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
   }
 
   private async checkPodsHealth(): Promise<void> {
-    const pods = await containerEngine
-      .listPods()
-      .then(pods => pods.filter(pod => LABEL_RECIPE_ID in pod.Labels && LABEL_MODEL_ID in pod.Labels));
+    const pods = await this.podManager.getPodsWithLabels([LABEL_RECIPE_ID, LABEL_MODEL_ID]);
     let changes = false;
+
     for (const pod of pods) {
       const recipeId = pod.Labels[LABEL_RECIPE_ID];
       const modelId = pod.Labels[LABEL_MODEL_ID];
@@ -648,12 +645,8 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
         // a fresh pod could not have been added yet, we will handle it at next iteration
         continue;
       }
-      const containerStates: (string | undefined)[] = await Promise.all(
-        pod.Containers.map(container =>
-          containerEngine.inspectContainer(pod.engineId, container.Id).then(data => data.State.Health?.Status),
-        ),
-      );
-      const podHealth = getPodHealth(containerStates);
+
+      const podHealth = await this.podManager.getHealth(pod);
       const state = this.#applications.get({ recipeId, modelId });
       if (state.health !== podHealth) {
         state.health = podHealth;
@@ -736,7 +729,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
   }
 
   async getApplicationPod(recipeId: string, modelId: string): Promise<PodInfo> {
-    const appPod = await this.queryPod(recipeId, modelId);
+    const appPod = await this.findPod(recipeId, modelId);
     if (!appPod) {
       throw new Error(`no pod found with recipe Id ${recipeId} and model Id ${modelId}`);
     }
@@ -744,19 +737,18 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
   }
 
   private async hasApplicationPod(recipeId: string, modelId: string): Promise<boolean> {
-    const appPod = await this.queryPod(recipeId, modelId);
-    return !!appPod;
+    const pod = await this.podManager.findPodByLabelsValues({
+      LABEL_RECIPE_ID: recipeId,
+      LABEL_MODEL_ID: modelId,
+    });
+    return !!pod;
   }
 
-  private async queryPod(recipeId: string, modelId: string): Promise<PodInfo | undefined> {
-    const pods = await containerEngine.listPods();
-    return pods.find(
-      pod =>
-        LABEL_RECIPE_ID in pod.Labels &&
-        pod.Labels[LABEL_RECIPE_ID] === recipeId &&
-        LABEL_MODEL_ID in pod.Labels &&
-        pod.Labels[LABEL_MODEL_ID] === modelId,
-    );
+  private async findPod(recipeId: string, modelId: string): Promise<PodInfo | undefined> {
+    return this.podManager.findPodByLabelsValues({
+      LABEL_RECIPE_ID: recipeId,
+      LABEL_MODEL_ID: modelId,
+    });
   }
 
   dispose(): void {

--- a/packages/backend/src/managers/recipes/BuilderManager.spec.ts
+++ b/packages/backend/src/managers/recipes/BuilderManager.spec.ts
@@ -1,3 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { Recipe } from '@shared/src/models/IRecipe';
 import type { ContainerConfig } from '../../models/AIConfig';

--- a/packages/backend/src/managers/recipes/PodManager.spec.ts
+++ b/packages/backend/src/managers/recipes/PodManager.spec.ts
@@ -1,0 +1,170 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, vi, expect, test } from 'vitest';
+import { PodManager } from './PodManager';
+import type { ContainerInspectInfo, PodInfo } from '@podman-desktop/api';
+import { containerEngine } from '@podman-desktop/api';
+
+vi.mock('@podman-desktop/api', () => ({
+  containerEngine: {
+    listPods: vi.fn(),
+    inspectContainer: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  // we return the id as health status
+  vi.mocked(containerEngine.inspectContainer).mockImplementation(async (engineId: string, id: string) => {
+    return {
+      State: {
+        Health: {
+          Status: id,
+        },
+      },
+    } as unknown as ContainerInspectInfo;
+  });
+});
+
+test('getAllPods should use container engine list pods method', async () => {
+  await new PodManager().getAllPods();
+
+  expect(containerEngine.listPods).toHaveBeenCalledOnce();
+});
+
+test('findPodByLabelsValues should only return pods with labels matching values', async () => {
+  vi.mocked(containerEngine.listPods).mockResolvedValue([
+    {
+      Id: 'pod-id-1',
+      Labels: {
+        'dummy-key': 'dummy-invalid',
+        hello: 'eggs',
+      },
+    },
+    {
+      Id: 'pod-id-2',
+      Labels: {
+        hello: 'world',
+        'dummy-key': 'dummy-valid',
+      },
+    },
+    {
+      Id: 'pod-id-2',
+      Labels: {
+        hello: 'world',
+        'dummy-key': 'invalid',
+      },
+    },
+    {
+      Id: 'pod-id-3',
+    },
+  ] as unknown as PodInfo[]);
+
+  const pod = await new PodManager().findPodByLabelsValues({
+    'dummy-key': 'dummy-valid',
+    hello: 'world',
+  });
+  expect(pod).toBeDefined();
+  expect(pod?.Id).toBe('pod-id-2');
+});
+
+test('getPodsWithLabels should only return pods with proper labels', async () => {
+  vi.mocked(containerEngine.listPods).mockResolvedValue([
+    {
+      Id: 'pod-id-1',
+      Labels: {
+        'dummy-key': 'dummy-value',
+        hello: 'world',
+      },
+    },
+    {
+      Id: 'pod-id-2',
+      Labels: {
+        hello: 'world',
+        'dummy-key': 'dummy-value',
+      },
+    },
+    {
+      Id: 'pod-id-3',
+    },
+  ] as unknown as PodInfo[]);
+  const pods = await new PodManager().getPodsWithLabels(['dummy-key']);
+  expect(pods.length).toBe(2);
+  expect(pods.find(pod => pod.Id === 'pod-id-1')).toBeDefined();
+  expect(pods.find(pod => pod.Id === 'pod-id-2')).toBeDefined();
+  expect(pods.find(pod => pod.Id === 'pod-id-3')).toBeUndefined();
+});
+
+describe('getHealth', () => {
+  test('getHealth with no container should be none', async () => {
+    const health = await new PodManager().getHealth({
+      Containers: [],
+    } as unknown as PodInfo);
+    expect(health).toBe('none');
+  });
+
+  test('getHealth with one healthy should be healthy', async () => {
+    const health = await new PodManager().getHealth({
+      Containers: [
+        {
+          Id: 'healthy',
+        },
+      ],
+    } as unknown as PodInfo);
+    expect(health).toBe('healthy');
+  });
+
+  test('getHealth with many healthy and one unhealthy should be unhealthy', async () => {
+    const health = await new PodManager().getHealth({
+      Containers: [
+        {
+          Id: 'healthy',
+        },
+        {
+          Id: 'unhealthy',
+        },
+        {
+          Id: 'healthy',
+        },
+        {
+          Id: 'starting',
+        },
+      ],
+    } as unknown as PodInfo);
+    expect(health).toBe('unhealthy');
+  });
+
+  test('getHealth with many healthy and one starting should be starting', async () => {
+    const health = await new PodManager().getHealth({
+      Containers: [
+        {
+          Id: 'healthy',
+        },
+        {
+          Id: 'healthy',
+        },
+        {
+          Id: 'starting',
+        },
+      ],
+    } as unknown as PodInfo);
+    expect(health).toBe('starting');
+  });
+});

--- a/packages/backend/src/managers/recipes/PodManager.ts
+++ b/packages/backend/src/managers/recipes/PodManager.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Disposable, PodInfo } from '@podman-desktop/api';
+import { containerEngine } from '@podman-desktop/api';
+import type { PodHealth } from '@shared/src/models/IApplicationState';
+import { getPodHealth } from '../../utils/podsUtils';
+
+export class PodManager implements Disposable {
+  dispose(): void {}
+
+  /**
+   * Utility method to get all the pods
+   */
+  getAllPods(): Promise<PodInfo[]> {
+    return containerEngine.listPods();
+  }
+
+  /**
+   * return the first pod matching the provided labels and their associated value
+   * @param requestedLabels the labels the pod must be matching
+   */
+  async findPodByLabelsValues(requestedLabels: Record<string, string>): Promise<PodInfo | undefined> {
+    const pods = await this.getAllPods();
+
+    return pods.find(pod => {
+      const labels = pod.Labels;
+      if (labels === undefined) return false;
+
+      for (const [key, value] of Object.entries(requestedLabels)) {
+        if (!(key in labels) || labels[key] !== value) return false;
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * return pods containing all the labels provided
+   * This method does not check for the values, only existence
+   * @param labels
+   */
+  async getPodsWithLabels(labels: string[]): Promise<PodInfo[]> {
+    const pods = await this.getAllPods();
+
+    return pods.filter(pod => labels.every(label => !!pod.Labels && label in pod.Labels));
+  }
+
+  /**
+   * Given a pod Info, will fetch the health status of each containing composing it, and
+   * will return a PodHealth
+   * @param pod the pod to inspect
+   */
+  async getHealth(pod: PodInfo): Promise<PodHealth> {
+    const containerStates: (string | undefined)[] = await Promise.all(
+      pod.Containers.map(container =>
+        containerEngine.inspectContainer(pod.engineId, container.Id).then(data => data.State.Health?.Status),
+      ),
+    );
+
+    return getPodHealth(containerStates);
+  }
+}

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -42,6 +42,7 @@ import { SnippetManager } from './managers/SnippetManager';
 import { CancellationTokenRegistry } from './registries/CancellationTokenRegistry';
 import { engines } from '../package.json';
 import { BuilderManager } from './managers/recipes/BuilderManager';
+import { PodManager } from './managers/recipes/PodManager';
 
 export const AI_LAB_COLLECT_GPU_COMMAND = 'ai-lab.gpu.collect';
 
@@ -162,6 +163,9 @@ export class Studio {
     const builderManager = new BuilderManager(taskRegistry);
     this.#extensionContext.subscriptions.push(builderManager);
 
+    const podManager = new PodManager();
+    this.#extensionContext.subscriptions.push(podManager);
+
     this.modelsManager = new ModelsManager(
       appUserDirectory,
       this.#panel.webview,
@@ -184,6 +188,7 @@ export class Studio {
       this.telemetry,
       localRepositoryRegistry,
       builderManager,
+      podManager,
     );
 
     this.#inferenceManager = new InferenceManager(


### PR DESCRIPTION
### What does this PR do?

Following the work on simplifying the ApplicationManager, this PR extract some methods related to pods. This ease the testing process, as we do not need to mock tons of containerEngine function inside the ApplicationManager.spec.ts file.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] unit tests has been provided

Start a recipe, restart ai-lab, check recipe is shown in the running page