### PR TITLE
refactor(ApplicationManager): remove unused interfaces 

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -28,7 +28,8 @@ import type {
   Webview,
   HostConfig,
   HealthConfig,
- PodContainerInfo } from '@podman-desktop/api';
+  PodContainerInfo,
+} from '@podman-desktop/api';
 import type { AIConfig, AIConfigFile, ContainerConfig } from '../models/AIConfig';
 import { parseYamlFile } from '../models/AIConfig';
 import type { Task } from '@shared/src/models/ITask';
@@ -713,7 +714,15 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
     await this.deleteApplication(recipeId, modelId);
     const recipe = this.catalogManager.getRecipeById(recipeId);
     const model = this.catalogManager.getModelById(appPod.Labels[LABEL_MODEL_ID]);
-    await this.initApplication(recipe, model);
+
+    // init the recipe
+    const podInfo = await this.initApplication(recipe, model);
+
+    // start the pod
+    return this.runApplication(podInfo, {
+      'recipe-id': recipe.id,
+      'model-id': model.id,
+    });
   }
 
   async getApplicationPorts(recipeId: string, modelId: string): Promise<number[]> {

--- a/packages/backend/src/managers/recipes/PodManager.spec.ts
+++ b/packages/backend/src/managers/recipes/PodManager.spec.ts
@@ -168,3 +168,41 @@ describe('getHealth', () => {
     expect(health).toBe('starting');
   });
 });
+
+describe('getPod', () => {
+  test('getPod should throw an error if none is matching', async () => {
+    vi.mocked(containerEngine.listPods).mockResolvedValue([]);
+    await expect(async () => {
+      await new PodManager().getPod('fakeEngineId', 'fakePodId');
+    }).rejects.toThrowError('pod with engineId fakeEngineId and Id fakePodId cannot be found.');
+  });
+
+  test('getPod should return matching pod', async () => {
+    vi.mocked(containerEngine.listPods).mockResolvedValue([
+      {
+        engineId: 'engine-1',
+        Id: 'pod-id-1',
+        Labels: {
+          'dummy-key': 'dummy-value',
+          hello: 'world',
+        },
+      },
+      {
+        engineId: 'engine-2',
+        Id: 'pod-id-2',
+        Labels: {
+          hello: 'world',
+          'dummy-key': 'dummy-value',
+        },
+      },
+      {
+        engineId: 'engine-3',
+        Id: 'pod-id-3',
+      },
+    ] as unknown as PodInfo[]);
+    const pod = await new PodManager().getPod('engine-3', 'pod-id-3');
+    expect(pod).toBeDefined();
+    expect(pod.engineId).toBe('engine-3');
+    expect(pod.Id).toBe('pod-id-3');
+  });
+});

--- a/packages/backend/src/managers/recipes/PodManager.ts
+++ b/packages/backend/src/managers/recipes/PodManager.ts
@@ -74,4 +74,11 @@ export class PodManager implements Disposable {
 
     return getPodHealth(containerStates);
   }
+
+  async getPod(engineId: string, Id: string): Promise<PodInfo> {
+    const pods = await this.getAllPods();
+    const result = pods.find(pod => pod.engineId === engineId && pod.Id === Id);
+    if (!result) throw new Error(`pod with engineId ${engineId} and Id ${Id} cannot be found.`);
+    return result;
+  }
 }


### PR DESCRIPTION
### What does this PR do?

- The custom interface ContainerAttachedInfo is replaced with PodContainerInfo (from api)
- The custom interface ApplicationPodInfo is replaced with PodInfo (from api)
- Renaming `runApplication` to `initApplication` to better match what it is doing (see code comment added)
- createAndAddContainersToPod is renamed to createContainerAndAttachToPod

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Work is required for https://github.com/containers/podman-desktop-extension-ai-lab/issues/691

### How to test this PR?

- [x] unit tests has been provided

You can check recipes are working as expected
- Start recipe
- Stop recipe
- Restart recipe