### PR TITLE
fix: add hover to recipe card (#843)

### DIFF
--- a/packages/frontend/src/lib/RecipeCard.svelte
+++ b/packages/frontend/src/lib/RecipeCard.svelte
@@ -4,6 +4,7 @@ import Card from '/@/lib/Card.svelte';
 import type { Recipe } from '@shared/src/models/IRecipe';
 
 export let background: string = 'bg-charcoal-700';
+export let backgroundHover: string = 'hover:bg-charcoal-500';
 
 export let recipe: Recipe;
 export let displayDescription: boolean = true;
@@ -14,4 +15,4 @@ export let displayDescription: boolean = true;
   title="{recipe.name}"
   description="{displayDescription ? recipe.description : ''}"
   icon="{getIcon(recipe.icon)}"
-  classes="{background} flex-grow p-4 h-full" />
+  classes="{background} {backgroundHover} flex-grow p-4 h-full" />


### PR DESCRIPTION
### What does this PR do?

It just adds the hover state to recipe card

### Screenshot / video of UI

![hover_card](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/1581b656-0236-412a-a0a9-45d727f05440)

### What issues does this PR fix or reference?

it fixes #843 

### How to test this PR?

1. go to the recipes page and hover a card