### PR TITLE
feat(application): adding start stop actions

### DIFF
--- a/packages/backend/src/managers/recipes/PodManager.spec.ts
+++ b/packages/backend/src/managers/recipes/PodManager.spec.ts
@@ -18,12 +18,16 @@
 
 import { beforeEach, describe, vi, expect, test } from 'vitest';
 import { PodManager } from './PodManager';
-import type { ContainerInspectInfo, PodInfo } from '@podman-desktop/api';
+import type { ContainerInspectInfo, PodCreateOptions, PodInfo } from '@podman-desktop/api';
 import { containerEngine } from '@podman-desktop/api';
 
 vi.mock('@podman-desktop/api', () => ({
   containerEngine: {
     listPods: vi.fn(),
+    stopPod: vi.fn(),
+    removePod: vi.fn(),
+    startPod: vi.fn(),
+    createPod: vi.fn(),
     inspectContainer: vi.fn(),
   },
 }));
@@ -205,4 +209,28 @@ describe('getPod', () => {
     expect(pod.engineId).toBe('engine-3');
     expect(pod.Id).toBe('pod-id-3');
   });
+});
+
+test('stopPod should call containerEngine.stopPod', async () => {
+  await new PodManager().stopPod('dummy-engine-id', 'dummy-pod-id');
+  expect(containerEngine.stopPod).toHaveBeenCalledWith('dummy-engine-id', 'dummy-pod-id');
+});
+
+test('removePod should call containerEngine.removePod', async () => {
+  await new PodManager().removePod('dummy-engine-id', 'dummy-pod-id');
+  expect(containerEngine.removePod).toHaveBeenCalledWith('dummy-engine-id', 'dummy-pod-id');
+});
+
+test('startPod should call containerEngine.startPod', async () => {
+  await new PodManager().startPod('dummy-engine-id', 'dummy-pod-id');
+  expect(containerEngine.startPod).toHaveBeenCalledWith('dummy-engine-id', 'dummy-pod-id');
+});
+
+test('createPod should call containerEngine.createPod', async () => {
+  const options: PodCreateOptions = {
+    name: 'dummy-name',
+    portmappings: [],
+  };
+  await new PodManager().createPod(options);
+  expect(containerEngine.createPod).toHaveBeenCalledWith(options);
 });

--- a/packages/backend/src/managers/recipes/PodManager.ts
+++ b/packages/backend/src/managers/recipes/PodManager.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { Disposable, PodInfo } from '@podman-desktop/api';
+import type { Disposable, PodCreateOptions, PodInfo } from '@podman-desktop/api';
 import { containerEngine } from '@podman-desktop/api';
 import type { PodHealth } from '@shared/src/models/IApplicationState';
 import { getPodHealth } from '../../utils/podsUtils';
@@ -80,5 +80,21 @@ export class PodManager implements Disposable {
     const result = pods.find(pod => pod.engineId === engineId && pod.Id === Id);
     if (!result) throw new Error(`pod with engineId ${engineId} and Id ${Id} cannot be found.`);
     return result;
+  }
+
+  async stopPod(engineId: string, id: string): Promise<void> {
+    return containerEngine.stopPod(engineId, id);
+  }
+
+  async removePod(engineId: string, id: string): Promise<void> {
+    return containerEngine.removePod(engineId, id);
+  }
+
+  async startPod(engineId: string, id: string): Promise<void> {
+    return containerEngine.startPod(engineId, id);
+  }
+
+  async createPod(podOptions: PodCreateOptions): Promise<{ engineId: string; Id: string }> {
+    return containerEngine.createPod(podOptions);
   }
 }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -271,6 +271,18 @@ export class StudioApiImpl implements StudioAPI {
     return this.applicationManager.getApplicationsState();
   }
 
+  async requestStartApplication(recipeId: string, modelId: string): Promise<void> {
+    this.applicationManager.startApplication(recipeId, modelId).catch((err: unknown) => {
+      console.error('Something went wrong while trying to start application', err);
+    });
+  }
+
+  async requestStopApplication(recipeId: string, modelId: string): Promise<void> {
+    this.applicationManager.stopApplication(recipeId, modelId).catch((err: unknown) => {
+      console.error('Something went wrong while trying to stop application', err);
+    });
+  }
+
   async requestRemoveApplication(recipeId: string, modelId: string): Promise<void> {
     const recipe = this.catalogManager.getRecipeById(recipeId);
     // Do not wait on the promise as the api would probably timeout before the user answer.
@@ -282,7 +294,7 @@ export class StudioApiImpl implements StudioAPI {
       )
       .then((result: string | undefined) => {
         if (result === 'Confirm') {
-          this.applicationManager.deleteApplication(recipeId, modelId).catch((err: unknown) => {
+          this.applicationManager.removeApplication(recipeId, modelId).catch((err: unknown) => {
             console.error(`error deleting AI App's pod: ${String(err)}`);
             podmanDesktopApi.window
               .showErrorMessage(

--- a/packages/frontend/src/lib/ApplicationActions.svelte
+++ b/packages/frontend/src/lib/ApplicationActions.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
-import { faRotateForward, faArrowUpRightFromSquare, faTrash, faBookOpen } from '@fortawesome/free-solid-svg-icons';
+import {
+  faRotateForward,
+  faArrowUpRightFromSquare,
+  faTrash,
+  faBookOpen,
+  faStop,
+  faPlay,
+} from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '/@/lib/button/ListItemButtonIcon.svelte';
 import { studioClient } from '/@/utils/client';
 import type { ApplicationState } from '@shared/src/models/IApplicationState';
 import { router } from 'tinro';
 import DropDownMenu from './DropDownMenu.svelte';
 import FlatMenu from './FlatMenu.svelte';
+import { onMount } from 'svelte';
 export let object: ApplicationState | undefined;
 export let recipeId: string;
 export let modelId: string;
@@ -14,6 +22,18 @@ export let enableGoToRecipeAction = false;
 
 function deleteApplication() {
   studioClient.requestRemoveApplication(recipeId, modelId).catch(err => {
+    console.error(`Something went wrong while trying to delete AI App: ${String(err)}.`);
+  });
+}
+
+function startApplication() {
+  studioClient.requestStartApplication(recipeId, modelId).catch(err => {
+    console.error(`Something went wrong while trying to start AI App: ${String(err)}.`);
+  });
+}
+
+function stopApplication() {
+  studioClient.requestStopApplication(recipeId, modelId).catch(err => {
     console.error(`Something went wrong while trying to delete AI App: ${String(err)}.`);
   });
 }
@@ -40,12 +60,21 @@ if (dropdownMenu) {
 } else {
   actionsStyle = FlatMenu;
 }
+
+let exited = object?.pod?.Containers?.every(container => container.Status === 'exited');
+
+onMount(() => {
+  console.log(object?.pod);
+});
 </script>
 
 {#if object?.pod !== undefined}
-  <ListItemButtonIcon icon="{faTrash}" onClick="{() => deleteApplication()}" title="Delete AI App" />
-
-  <ListItemButtonIcon icon="{faArrowUpRightFromSquare}" onClick="{() => openApplication()}" title="Open AI App" />
+  {#if exited}
+    <ListItemButtonIcon icon="{faPlay}" onClick="{() => startApplication()}" title="Start AI App" />
+  {:else}
+    <ListItemButtonIcon icon="{faStop}" onClick="{() => stopApplication()}" title="Stop AI App" />
+    <ListItemButtonIcon icon="{faArrowUpRightFromSquare}" onClick="{() => openApplication()}" title="Open AI App" />
+  {/if}
 
   <svelte:component this="{actionsStyle}">
     <ListItemButtonIcon
@@ -59,6 +88,12 @@ if (dropdownMenu) {
       onClick="{() => redirectToRecipe()}"
       title="Open Recipe"
       hidden="{!enableGoToRecipeAction}"
+      menu="{dropdownMenu}" />
+
+    <ListItemButtonIcon
+      icon="{faTrash}"
+      onClick="{() => deleteApplication()}"
+      title="Delete AI App"
       menu="{dropdownMenu}" />
   </svelte:component>
 {/if}

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -34,7 +34,16 @@ import type { ContainerConnectionInfo } from './models/IContainerConnectionInfo'
 export abstract class StudioAPI {
   abstract ping(): Promise<string>;
   abstract getCatalog(): Promise<ApplicationCatalog>;
+
+  // Application related methods
   abstract pullApplication(recipeId: string, modelId: string): Promise<void>;
+  abstract requestStopApplication(recipeId: string, modelId: string): Promise<void>;
+  abstract requestStartApplication(recipeId: string, modelId: string): Promise<void>;
+  abstract requestRemoveApplication(recipeId: string, modelId: string): Promise<void>;
+  abstract requestRestartApplication(recipeId: string, modelId: string): Promise<void>;
+  abstract requestOpenApplication(recipeId: string, modelId: string): Promise<void>;
+  abstract getApplicationsState(): Promise<ApplicationState[]>;
+
   abstract openURL(url: string): Promise<boolean>;
   abstract openFile(file: string, recipeId?: string): Promise<boolean>;
   abstract openDialog(options?: OpenDialogOptions): Promise<Uri[] | undefined>;
@@ -54,11 +63,6 @@ export abstract class StudioAPI {
   abstract navigateToPod(podId: string): Promise<void>;
   abstract navigateToResources(): Promise<void>;
   abstract navigateToEditConnectionProvider(connectionName: string): Promise<void>;
-
-  abstract getApplicationsState(): Promise<ApplicationState[]>;
-  abstract requestRemoveApplication(recipeId: string, modelId: string): Promise<void>;
-  abstract requestRestartApplication(recipeId: string, modelId: string): Promise<void>;
-  abstract requestOpenApplication(recipeId: string, modelId: string): Promise<void>;
 
   abstract telemetryLogUsage(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;
   abstract telemetryLogError(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/containers/podman-desktop-extension-ai-lab/pull/1114, this PR adds the possibility to start/stop an application (pod). To be able to keep it stopped, without deleting it.

⚠️ We have a lack of transition state, we might want to add them in a separate PR to improve the user experience

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/2c04e2bf-5f85-44dc-89b0-dea1d3412fda

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1070, https://github.com/containers/podman-desktop-extension-ai-lab/issues/691

### How to test this PR?

- [x] Unit tests has been provided

#### Manually

- Start a recipe, go to `Running` page, stop, start, restart, remove