### PR TITLE
refactor: moving pod events method to PodManager

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -578,10 +578,10 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
       this.notify();
     });
 
-    this.podmanConnection.onPodStart((pod: PodInfo) => {
+    this.podManager.onStartPodEvent((pod: PodInfo) => {
       this.adoptPod(pod);
     });
-    this.podmanConnection.onPodRemove((podId: string) => {
+    this.podManager.onRemovePodEvent(({ podId }) => {
       this.forgetPodById(podId);
     });
 

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -28,9 +28,6 @@ import { getFirstRunningPodmanConnection } from '../utils/podman';
 export type startupHandle = () => void;
 export type machineStartHandle = () => void;
 export type machineStopHandle = () => void;
-export type podStartHandle = (pod: PodInfo) => void;
-export type podStopHandle = (pod: PodInfo) => void;
-export type podRemoveHandle = (podId: string) => void;
 
 export class PodmanConnection implements Disposable {
   #firstFound = false;

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -20,7 +20,6 @@ import {
   type RegisterContainerConnectionEvent,
   provider,
   type UpdateContainerConnectionEvent,
-  type PodInfo,
   type Disposable,
 } from '@podman-desktop/api';
 import { getFirstRunningPodmanConnection } from '../utils/podman';

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -20,7 +20,6 @@ import {
   type RegisterContainerConnectionEvent,
   provider,
   type UpdateContainerConnectionEvent,
-  containerEngine,
   type PodInfo,
   type Disposable,
 } from '@podman-desktop/api';
@@ -38,16 +37,12 @@ export class PodmanConnection implements Disposable {
   #toExecuteAtStartup: startupHandle[] = [];
   #toExecuteAtMachineStop: machineStopHandle[] = [];
   #toExecuteAtMachineStart: machineStartHandle[] = [];
-  #toExecuteAtPodStart: podStartHandle[] = [];
-  #toExecuteAtPodStop: podStopHandle[] = [];
-  #toExecuteAtPodRemove: podRemoveHandle[] = [];
 
   #onEventDisposable: Disposable | undefined;
 
   init(): void {
     this.listenRegistration();
     this.listenMachine();
-    this.watchPods();
   }
 
   dispose(): void {
@@ -113,66 +108,5 @@ export class PodmanConnection implements Disposable {
 
   onMachineStop(f: machineStopHandle) {
     this.#toExecuteAtMachineStop.push(f);
-  }
-
-  watchPods() {
-    if (this.#onEventDisposable !== undefined) throw new Error('already watching pods.');
-
-    this.#onEventDisposable = containerEngine.onEvent(event => {
-      if (event.Type !== 'pod') {
-        return;
-      }
-      switch (event.status) {
-        case 'remove':
-          for (const f of this.#toExecuteAtPodRemove) {
-            f(event.id);
-          }
-          break;
-        case 'start':
-          containerEngine
-            .listPods()
-            .then((pods: PodInfo[]) => {
-              const pod = pods.find((p: PodInfo) => p.Id === event.id);
-              if (!pod) {
-                return;
-              }
-              for (const f of this.#toExecuteAtPodStart) {
-                f(pod);
-              }
-            })
-            .catch((err: unknown) => {
-              console.error(err);
-            });
-          break;
-        case 'stop':
-          containerEngine
-            .listPods()
-            .then((pods: PodInfo[]) => {
-              const pod = pods.find((p: PodInfo) => p.Id === event.id);
-              if (!pod) {
-                return;
-              }
-              for (const f of this.#toExecuteAtPodStop) {
-                f(pod);
-              }
-            })
-            .catch((err: unknown) => {
-              console.error(err);
-            });
-          break;
-      }
-    });
-  }
-
-  onPodStart(f: podStartHandle) {
-    this.#toExecuteAtPodStart.push(f);
-  }
-
-  onPodStop(f: podStopHandle) {
-    this.#toExecuteAtPodStop.push(f);
-  }
-
-  onPodRemove(f: podRemoveHandle) {
-    this.#toExecuteAtPodRemove.push(f);
   }
 }

--- a/packages/backend/src/managers/recipes/PodManager.spec.ts
+++ b/packages/backend/src/managers/recipes/PodManager.spec.ts
@@ -19,7 +19,7 @@
 import { beforeEach, describe, vi, expect, test } from 'vitest';
 import { PodManager } from './PodManager';
 import type { ContainerInspectInfo, ContainerJSONEvent, PodCreateOptions, PodInfo } from '@podman-desktop/api';
-import { EventEmitter , containerEngine } from '@podman-desktop/api';
+import { EventEmitter, containerEngine } from '@podman-desktop/api';
 
 vi.mock('@podman-desktop/api', () => ({
   containerEngine: {

--- a/packages/backend/src/managers/recipes/PodManager.spec.ts
+++ b/packages/backend/src/managers/recipes/PodManager.spec.ts
@@ -18,8 +18,8 @@
 
 import { beforeEach, describe, vi, expect, test } from 'vitest';
 import { PodManager } from './PodManager';
-import type { ContainerInspectInfo, PodCreateOptions, PodInfo } from '@podman-desktop/api';
-import { containerEngine } from '@podman-desktop/api';
+import type { ContainerInspectInfo, ContainerJSONEvent, PodCreateOptions, PodInfo } from '@podman-desktop/api';
+import { EventEmitter , containerEngine } from '@podman-desktop/api';
 
 vi.mock('@podman-desktop/api', () => ({
   containerEngine: {
@@ -29,7 +29,9 @@ vi.mock('@podman-desktop/api', () => ({
     startPod: vi.fn(),
     createPod: vi.fn(),
     inspectContainer: vi.fn(),
+    onEvent: vi.fn(),
   },
+  EventEmitter: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -45,6 +47,18 @@ beforeEach(() => {
       },
     } as unknown as ContainerInspectInfo;
   });
+
+  // mocking the EventEmitter mechanism
+  const listeners: ((value: unknown) => void)[] = [];
+
+  vi.mocked(EventEmitter).mockReturnValue({
+    event: vi.fn().mockImplementation(callback => {
+      listeners.push(callback);
+    }),
+    fire: vi.fn().mockImplementation((content: unknown) => {
+      listeners.forEach(listener => listener(content));
+    }),
+  } as unknown as EventEmitter<unknown>);
 });
 
 test('getAllPods should use container engine list pods method', async () => {
@@ -233,4 +247,113 @@ test('createPod should call containerEngine.createPod', async () => {
   };
   await new PodManager().createPod(options);
   expect(containerEngine.createPod).toHaveBeenCalledWith(options);
+});
+
+test('dispose should dispose onEvent disposable', () => {
+  const disposableMock = vi.fn();
+  vi.mocked(containerEngine.onEvent).mockImplementation(() => {
+    return { dispose: disposableMock };
+  });
+
+  const podManager = new PodManager();
+  podManager.init();
+
+  podManager.dispose();
+
+  expect(containerEngine.onEvent).toHaveBeenCalled();
+  expect(disposableMock).toHaveBeenCalled();
+});
+
+const getInitializedPodManager = (): {
+  onEventListener: (e: ContainerJSONEvent) => unknown;
+  podManager: PodManager;
+} => {
+  let func: ((e: ContainerJSONEvent) => unknown) | undefined = undefined;
+  vi.mocked(containerEngine.onEvent).mockImplementation(fn => {
+    func = fn;
+    return { dispose: vi.fn() };
+  });
+
+  const podManager = new PodManager();
+  podManager.init();
+
+  if (!func) throw new Error('listener should be defined');
+
+  return { onEventListener: func, podManager };
+};
+
+describe('events', () => {
+  test('onStartPodEvent listener should be called on start pod event', async () => {
+    vi.mocked(containerEngine.listPods).mockResolvedValue([
+      {
+        Id: 'pod-id-1',
+        Labels: {
+          'dummy-key': 'dummy-value',
+          hello: 'world',
+        },
+      },
+    ] as unknown as PodInfo[]);
+
+    const { onEventListener, podManager } = getInitializedPodManager();
+
+    const startListenerMock = vi.fn();
+    podManager.onStartPodEvent(startListenerMock);
+
+    onEventListener({ id: 'pod-id-1', Type: 'pod', type: '', status: 'start' });
+
+    await vi.waitFor(() => {
+      expect(startListenerMock).toHaveBeenCalledWith({
+        Id: 'pod-id-1',
+        Labels: {
+          'dummy-key': 'dummy-value',
+          hello: 'world',
+        },
+      });
+    });
+  });
+
+  test('onStopPodEvent listener should be called on start pod event', async () => {
+    vi.mocked(containerEngine.listPods).mockResolvedValue([
+      {
+        Id: 'pod-id-1',
+        Labels: {
+          'dummy-key': 'dummy-value',
+          hello: 'world',
+        },
+      },
+    ] as unknown as PodInfo[]);
+
+    const { onEventListener, podManager } = getInitializedPodManager();
+
+    const stopListenerMock = vi.fn();
+    podManager.onStopPodEvent(stopListenerMock);
+
+    onEventListener({ id: 'pod-id-1', Type: 'pod', type: '', status: 'stop' });
+
+    await vi.waitFor(() => {
+      expect(stopListenerMock).toHaveBeenCalledWith({
+        Id: 'pod-id-1',
+        Labels: {
+          'dummy-key': 'dummy-value',
+          hello: 'world',
+        },
+      });
+    });
+  });
+
+  test('onRemovePodEvent listener should be called on start pod event', async () => {
+    const { onEventListener, podManager } = getInitializedPodManager();
+
+    const removeListenerMock = vi.fn();
+    podManager.onRemovePodEvent(removeListenerMock);
+
+    onEventListener({ id: 'pod-id-1', Type: 'pod', type: '', status: 'remove' });
+
+    await vi.waitFor(() => {
+      expect(removeListenerMock).toHaveBeenCalledWith({
+        podId: 'pod-id-1',
+      });
+    });
+    expect(containerEngine.listPods).not.toHaveBeenCalled();
+  });
 });

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -164,6 +164,7 @@ export class Studio {
     this.#extensionContext.subscriptions.push(builderManager);
 
     const podManager = new PodManager();
+    podManager.init();
     this.#extensionContext.subscriptions.push(podManager);
 
     this.modelsManager = new ModelsManager(


### PR DESCRIPTION
### What does this PR do?

This PR moves and cleanup the logic of capturing pod event, previously located in PodmanConnection class, inside the PodManager.

The following changes are included:
- Using `EventEmitter` instead of declaring new types and storing the listeners in arrays
- Adding tests

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1129

### How to test this PR?

- [x] Unit tests has been provided