### PR TITLE
fix: importing model fresh install

### DIFF
--- a/packages/backend/src/managers/catalogManager.spec.ts
+++ b/packages/backend/src/managers/catalogManager.spec.ts
@@ -42,6 +42,7 @@ vi.mock('node:fs', () => {
       readFile: vi.fn(),
       stat: vi.fn(),
       writeFile: vi.fn(),
+      mkdir: vi.fn(),
     },
   };
 });
@@ -183,6 +184,7 @@ test('expect to call writeFile in addLocalModelsToCatalog with catalog updated',
     },
   ]);
 
+  expect(promises.mkdir).toHaveBeenCalled();
   expect(writeFileMock).toBeCalledWith('path', JSON.stringify(updatedCatalog, undefined, 2), 'utf-8');
 });
 

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -225,6 +225,9 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
     // Add all our models infos to the user's models catalog
     content.models.push(...models);
 
+    // ensure parent directory exists
+    await promises.mkdir(path.dirname(userCatalogPath), { recursive: true });
+
     // overwrite the existing catalog
     return promises.writeFile(userCatalogPath, JSON.stringify(content, undefined, 2), 'utf-8');
   }


### PR DESCRIPTION
### What does this PR do?

Fixes the import model issue happening on fresh install 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1132

### How to test this PR?

- [x] Regression test has been added

#### Manually

- Delete the folder `~/.local/share/containers/podman-desktop/extensions-storage/redhat.ai-lab` (or rename it)
- Start podman desktop with AI Lab
- Import a model (do not do anything else)