### PR TITLE
fix: json watcher parent problem

### DIFF
--- a/packages/backend/src/utils/JsonWatcher.spec.ts
+++ b/packages/backend/src/utils/JsonWatcher.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { promises, existsSync } from 'node:fs';
+import { promises, existsSync, mkdirSync } from 'node:fs';
 import type { FileSystemWatcher } from '@podman-desktop/api';
 import { EventEmitter, fs } from '@podman-desktop/api';
 import { JsonWatcher } from './JsonWatcher';
@@ -37,6 +37,7 @@ vi.mock('@podman-desktop/api', () => {
 vi.mock('node:fs', () => {
   return {
     existsSync: vi.fn(),
+    mkdirSync: vi.fn(),
     promises: {
       readFile: vi.fn(),
     },
@@ -68,6 +69,7 @@ test('should provide default value', async () => {
   await vi.waitFor(() => {
     expect(listener).toHaveBeenCalledWith('dummyDefaultvalue');
   });
+  expect(mkdirSync).toHaveBeenCalled();
   expect(existsSync).toHaveBeenCalledWith('dummyPath');
   expect(promises.readFile).not.toHaveBeenCalled();
 });

--- a/packages/backend/src/utils/JsonWatcher.ts
+++ b/packages/backend/src/utils/JsonWatcher.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { type Disposable, type FileSystemWatcher, fs, EventEmitter, type Event } from '@podman-desktop/api';
-import { promises, existsSync } from 'node:fs';
+import { promises, existsSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
 
 export class JsonWatcher<T> implements Disposable {
   #fileSystemWatcher: FileSystemWatcher | undefined;
@@ -31,6 +32,10 @@ export class JsonWatcher<T> implements Disposable {
 
   init(): void {
     try {
+      // we create the parent directory of the
+      mkdirSync(path.dirname(this.path), { recursive: true });
+
+      // create file system watcher
       this.#fileSystemWatcher = fs.createFileSystemWatcher(this.path);
       // Setup listeners
       this.#fileSystemWatcher.onDidChange(this.onDidChange.bind(this));
@@ -43,14 +48,17 @@ export class JsonWatcher<T> implements Disposable {
   }
 
   private onDidCreate(): void {
+    console.log('JsonWatcher onDidCreate', this.path);
     this.requestUpdate();
   }
 
   private onDidDelete(): void {
+    console.log('JsonWatcher onDidDelete', this.path);
     this.requestUpdate();
   }
 
   private onDidChange(): void {
+    console.log('JsonWatcher onDidChange', this.path);
     this.requestUpdate();
   }
 


### PR DESCRIPTION
### What does this PR do?

The file system watcher[^1] used by Podman Desktop has a design flaw, it does not detect changes when targeting a file in a folder than does not exist.

In our scenario, on fresh install, we were activating the file system watcher on `~/.local/share/containers/podman-desktop/extensions-storage/redhat.ai-lab/user-catalog.json` however on fresh install the `redhat.ai-lab` folder does not exists.

Therefore, when we import our first model, and `redhat.ai-lab` directory is created, then `user-catalog.json` created, the file system watcher does not detect it.

To fix this, inside our JsonWatcher class, we simply need to run a `mkdir` to ensure the parent directory of our target exists. 

[^1]: https://github.com/paulmillr/chokidar

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Reference https://github.com/paulmillr/chokidar/issues/1278

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1134

### How to test this PR?

- [x]: Unit tests has been provided

#### Manually

- Delete `~/.local/share/containers/podman-desktop/extensions-storage/redhat.ai-lab` folder
- Start Podam Desktop with AI Lab
- Import model

See how it now appears in the catalog, as it is detected by the file watcher now