### PR TITLE
chore(ci): add all e2e main linux workflow

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -1,0 +1,130 @@
+#
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: e2e-tests-main
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+    inputs:
+      organization:
+        default: 'containers'
+        description: 'Organization of the Podman Desktop repository'
+        type: string
+        required: true
+      repositoryName:
+        default: 'podman-desktop-extension-ai-lab'
+        description: 'Podman Desktop Extension AI Lab repository name'
+        type: string
+        required: true
+      branch:
+        default: 'main'
+        description: 'Podman Desktop Extension AI Lab repo branch'
+        type: string
+        required: true
+
+jobs:
+  e2e-tests:
+    name: Run E2E tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.organization }}/${{ github.event.inputs.repositoryName }}
+          ref: ${{ github.event.inputs.branch }}
+          path: ${{ github.event.inputs.repositoryName }}
+
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+        with: 
+          path: podman-desktop-extension-ai-lab
+
+      # Checkout podman desktop
+      - uses: actions/checkout@v4
+        with:
+          repository: containers/podman-desktop
+          ref: main
+          path: podman-desktop
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Update podman
+        run: |
+          # ubuntu version from kubic repository to install podman we need (v5)
+          ubuntu_version='23.04'
+          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
+          # install necessary dependencies for criu package which is not part of 23.04
+          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
+          # install criu manually from static location
+          curl -sLO http://cz.archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
+          sudo apt-get update -qq
+          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
+            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
+            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
+            sudo apt-get update && \
+            sudo apt-get -y install podman; }
+          podman version
+
+      - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
+        run: |
+          # allow unprivileged user namespace
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Build Podman Desktop for E2E tests
+        working-directory: ./podman-desktop
+        run: |
+          yarn --frozen-lockfile
+          yarn test:e2e:build
+
+      - name: Get yarn cache directory path
+        working-directory: ./podman-desktop-extension-ai-lab
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Ensure getting current HEAD version of the test framework
+        working-directory: ./podman-desktop-extension-ai-lab/tests/playwright
+        run: yarn add -D @podman-desktop/tests-playwright@next
+
+      - name: Execute yarn in AI Lab Extension
+        working-directory: ./podman-desktop-extension-ai-lab
+        run: yarn --frozen-lockfile
+
+      - name: Run All E2E tests
+        working-directory: ./podman-desktop-extension-ai-lab
+        env:
+          PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
+        run: yarn test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-tests
+          path: ./**/tests/output/


### PR DESCRIPTION
### What does this PR do?
Add e2e main test workflow running on linux on demand and after push into main.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->