### PR TITLE
feat(inference): introducing InferenceProviders

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -65,7 +65,7 @@
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
-    "@podman-desktop/api": "0.0.202406050828-61eefc7",
+    "@podman-desktop/api": "1.10.3",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/postman-collection": "^3.5.10",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -65,7 +65,7 @@
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
-    "@podman-desktop/api": "0.0.202404101645-5d46ba5",
+    "@podman-desktop/api": "0.0.202406050828-61eefc7",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/postman-collection": "^3.5.10",

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -47,11 +47,11 @@ import { ApplicationRegistry } from '../registries/ApplicationRegistry';
 import type { TaskRegistry } from '../registries/TaskRegistry';
 import { Publisher } from '../utils/Publisher';
 import { isQEMUMachine } from '../utils/podman';
-import { SECOND } from '../utils/inferenceUtils';
 import { getModelPropertiesForEnvironment } from '../utils/modelsUtils';
 import { getRandomName } from '../utils/randomUtils';
 import type { BuilderManager } from './recipes/BuilderManager';
 import type { PodManager } from './recipes/PodManager';
+import { SECOND } from '../workers/provider/LlamaCppPython';
 
 export const LABEL_MODEL_ID = 'ai-lab-model-id';
 export const LABEL_MODEL_PORTS = 'ai-lab-model-ports';

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -223,7 +223,7 @@ describe('Create Inference Server', () => {
         modelsInfo: [],
         port: 8888,
       }),
-    ).rejects.toThrowError('o enabled provider could be found.');
+    ).rejects.toThrowError('no enabled provider could be found.');
   });
 
   test('inference provider provided should use get from InferenceProviderRegistry', async () => {

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -17,42 +17,35 @@
  ***********************************************************************/
 import {
   containerEngine,
-  provider,
   type Webview,
   type TelemetryLogger,
-  type ImageInfo,
   type ContainerInfo,
   type ContainerInspectInfo,
-  type ProviderContainerConnection,
 } from '@podman-desktop/api';
 import type { ContainerRegistry } from '../../registries/ContainerRegistry';
 import type { PodmanConnection } from '../podmanConnection';
 import { beforeEach, expect, describe, test, vi } from 'vitest';
 import { InferenceManager } from './inferenceManager';
 import type { ModelsManager } from '../modelsManager';
-import { LABEL_INFERENCE_SERVER, INFERENCE_SERVER_IMAGE } from '../../utils/inferenceUtils';
+import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { Messages } from '@shared/Messages';
+import type { InferenceProviderRegistry } from '../../registries/InferenceProviderRegistry';
+import type { InferenceProvider } from '../../workers/provider/InferenceProvider';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
     containerEngine: {
       startContainer: vi.fn(),
       stopContainer: vi.fn(),
-      listContainers: vi.fn(),
       inspectContainer: vi.fn(),
-      pullImage: vi.fn(),
-      listImages: vi.fn(),
-      createContainer: vi.fn(),
       deleteContainer: vi.fn(),
+      listContainers: vi.fn(),
     },
     Disposable: {
       from: vi.fn(),
       create: vi.fn(),
-    },
-    provider: {
-      getContainerConnections: vi.fn(),
     },
   };
 });
@@ -87,6 +80,11 @@ const taskRegistryMock = {
   getTasksByLabels: vi.fn(),
 } as unknown as TaskRegistry;
 
+const inferenceProviderRegistryMock = {
+  getAll: vi.fn(),
+  get: vi.fn(),
+} as unknown as InferenceProviderRegistry;
+
 const getInitializedInferenceManager = async (): Promise<InferenceManager> => {
   const manager = new InferenceManager(
     webviewMock,
@@ -95,6 +93,7 @@ const getInitializedInferenceManager = async (): Promise<InferenceManager> => {
     modelsManager,
     telemetryMock,
     taskRegistryMock,
+    inferenceProviderRegistryMock,
   );
   manager.init();
   await vi.waitUntil(manager.isInitialize.bind(manager), {
@@ -119,26 +118,6 @@ beforeEach(() => {
       Health: undefined,
     },
   } as unknown as ContainerInspectInfo);
-  vi.mocked(provider.getContainerConnections).mockReturnValue([
-    {
-      providerId: 'test@providerId',
-      connection: {
-        type: 'podman',
-        name: 'test@connection',
-        status: () => 'started',
-      },
-    } as unknown as ProviderContainerConnection,
-  ]);
-  vi.mocked(containerEngine.listImages).mockResolvedValue([
-    {
-      Id: 'dummyImageId',
-      engineId: 'dummyEngineId',
-      RepoTags: [INFERENCE_SERVER_IMAGE],
-    },
-  ] as unknown as ImageInfo[]);
-  vi.mocked(containerEngine.createContainer).mockResolvedValue({
-    id: 'dummyCreatedContainerId',
-  });
   vi.mocked(taskRegistryMock.getTasksByLabels).mockReturnValue([]);
   vi.mocked(modelsManager.getLocalModelPath).mockReturnValue('/local/model.guff');
   vi.mocked(modelsManager.uploadModelToPodmanMachine).mockResolvedValue('/mnt/path/model.guff');
@@ -233,119 +212,59 @@ describe('init Inference Manager', () => {
  * Testing the creation logic
  */
 describe('Create Inference Server', () => {
-  test('unknown providerId', async () => {
+  test('no provider available should throw an error', async () => {
+    vi.mocked(inferenceProviderRegistryMock.getAll).mockReturnValue([]);
+
     const inferenceManager = await getInitializedInferenceManager();
     await expect(
-      inferenceManager.createInferenceServer(
-        {
-          providerId: 'unknown',
-        } as unknown as InferenceServerConfig,
-        'dummyTrackingId',
-      ),
-    ).rejects.toThrowError('cannot find any started container provider.');
-
-    expect(provider.getContainerConnections).toHaveBeenCalled();
-  });
-
-  test('unknown imageId', async () => {
-    const inferenceManager = await getInitializedInferenceManager();
-    await expect(
-      inferenceManager.createInferenceServer(
-        {
-          providerId: 'test@providerId',
-          image: 'unknown',
-        } as unknown as InferenceServerConfig,
-        'dummyTrackingId',
-      ),
-    ).rejects.toThrowError('image unknown not found.');
-
-    expect(containerEngine.listImages).toHaveBeenCalled();
-  });
-
-  test('empty modelsInfo', async () => {
-    const inferenceManager = await getInitializedInferenceManager();
-    await expect(
-      inferenceManager.createInferenceServer(
-        {
-          providerId: 'test@providerId',
-          image: INFERENCE_SERVER_IMAGE,
-          modelsInfo: [],
-        } as unknown as InferenceServerConfig,
-        'dummyTrackingId',
-      ),
-    ).rejects.toThrowError('Need at least one model info to start an inference server.');
-  });
-
-  test('valid InferenceServerConfig', async () => {
-    const inferenceManager = await getInitializedInferenceManager();
-    await inferenceManager.createInferenceServer(
-      {
+      inferenceManager.createInferenceServer({
+        inferenceProvider: undefined,
+        labels: {},
+        modelsInfo: [],
         port: 8888,
-        providerId: 'test@providerId',
-        image: INFERENCE_SERVER_IMAGE,
-        modelsInfo: [
-          {
-            id: 'dummyModelId',
-            file: {
-              file: 'model.guff',
-              path: '/mnt/path',
-            },
-          },
-        ],
-      } as unknown as InferenceServerConfig,
-      'dummyTrackingId',
-    );
+      }),
+    ).rejects.toThrowError('o enabled provider could be found.');
+  });
 
-    expect(modelsManager.uploadModelToPodmanMachine).toHaveBeenCalledWith(
-      {
-        id: 'dummyModelId',
-        file: {
-          file: 'model.guff',
-          path: '/mnt/path',
-        },
-      },
-      {
-        trackingId: 'dummyTrackingId',
-      },
-    );
-    expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining(
-        'Pulling ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:',
-      ),
-      'loading',
-      {
-        trackingId: 'dummyTrackingId',
-      },
-    );
-    expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(2, 'Creating container.', 'loading', {
-      trackingId: 'dummyTrackingId',
-    });
-    expect(taskRegistryMock.updateTask).toHaveBeenLastCalledWith({
-      state: 'success',
-    });
-    expect(containerEngine.createContainer).toHaveBeenCalled();
-    expect(inferenceManager.getServers()).toStrictEqual([
-      {
-        connection: {
-          port: 8888,
-        },
-        container: {
-          containerId: 'dummyCreatedContainerId',
-          engineId: 'dummyEngineId',
-        },
-        models: [
-          {
-            file: {
-              file: 'model.guff',
-              path: '/mnt/path',
-            },
-            id: 'dummyModelId',
-          },
-        ],
-        status: 'running',
-      },
-    ]);
+  test('inference provider provided should use get from InferenceProviderRegistry', async () => {
+    vi.mocked(inferenceProviderRegistryMock.get).mockReturnValue({
+      enabled: () => false,
+    } as unknown as InferenceProvider);
+
+    const inferenceManager = await getInitializedInferenceManager();
+    await expect(
+      inferenceManager.createInferenceServer({
+        inferenceProvider: 'dummy-inference-provider',
+        labels: {},
+        modelsInfo: [],
+        port: 8888,
+      }),
+    ).rejects.toThrowError('provider requested is not enabled.');
+    expect(inferenceProviderRegistryMock.get).toHaveBeenCalledWith('dummy-inference-provider');
+  });
+
+  test('selected inference provider should receive config', async () => {
+    const provider: InferenceProvider = {
+      enabled: () => true,
+      name: 'dummy-inference-provider',
+      dispose: () => {},
+      perform: vi.fn().mockResolvedValue({ id: 'dummy-container-id', engineId: 'dummy-engine-id' }),
+    } as unknown as InferenceProvider;
+    vi.mocked(inferenceProviderRegistryMock.get).mockReturnValue(provider);
+
+    const inferenceManager = await getInitializedInferenceManager();
+
+    const config: InferenceServerConfig = {
+      inferenceProvider: 'dummy-inference-provider',
+      labels: {},
+      modelsInfo: [],
+      port: 8888,
+    };
+    const result = await inferenceManager.createInferenceServer(config);
+
+    expect(provider.perform).toHaveBeenCalledWith(config);
+
+    expect(result).toBe('dummy-container-id');
   });
 });
 
@@ -509,33 +428,6 @@ describe('Request Create Inference Server', () => {
 
     expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(1, 'Creating Inference server', 'loading', {
       trackingId: identifier,
-    });
-  });
-
-  test('Pull image error should be reflected in task registry', async () => {
-    vi.mocked(containerEngine.pullImage).mockRejectedValue(new Error('dummy pull image error'));
-
-    const inferenceManager = await getInitializedInferenceManager();
-    inferenceManager.requestCreateInferenceServer({
-      port: 8888,
-      providerId: 'test@providerId',
-      image: 'quay.io/bootsy/playground:v0',
-      modelsInfo: [
-        {
-          id: 'dummyModelId',
-          file: {
-            file: 'dummyFile',
-            path: 'dummyPath',
-          },
-        },
-      ],
-    } as unknown as InferenceServerConfig);
-
-    await vi.waitFor(() => {
-      expect(taskRegistryMock.updateTask).toHaveBeenLastCalledWith({
-        state: 'error',
-        error: 'Something went wrong while trying to create an inference server Error: dummy pull image error.',
-      });
     });
   });
 });

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -24,7 +24,6 @@ import type { InferenceServer } from '@shared/src/models/IInference';
 import type { InferenceManager } from './inference/inferenceManager';
 import { Messages } from '@shared/Messages';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
-import { INFERENCE_SERVER_IMAGE } from '../utils/inferenceUtils';
 import type { TaskRegistry } from '../registries/TaskRegistry';
 import type { Task, TaskState } from '@shared/src/models/ITask';
 
@@ -333,20 +332,21 @@ test('creating a new playground with no model served should start an inference s
     } as unknown as ModelInfo,
     'tracking-1',
   );
-  expect(createInferenceServerMock).toHaveBeenCalledWith(
-    {
-      image: INFERENCE_SERVER_IMAGE,
-      labels: {},
-      modelsInfo: [
-        {
-          id: 'model-1',
-          name: 'Model 1',
-        },
-      ],
-      port: expect.anything(),
+  expect(createInferenceServerMock).toHaveBeenCalledWith({
+    image: undefined,
+    providerId: undefined,
+    inferenceProvider: undefined,
+    labels: {
+      trackingId: 'tracking-1',
     },
-    expect.anything(),
-  );
+    modelsInfo: [
+      {
+        id: 'model-1',
+        name: 'Model 1',
+      },
+    ],
+    port: expect.anything(),
+  });
 });
 
 test('creating a new playground with the model already served should not start an inference server', async () => {

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -117,8 +117,10 @@ export class PlaygroundV2Manager implements Disposable {
       await this.inferenceManager.createInferenceServer(
         await withDefaultConfiguration({
           modelsInfo: [model],
+          labels: {
+            trackingId: trackingId,
+          },
         }),
-        trackingId,
       );
     } else if (server.status === 'stopped') {
       await this.inferenceManager.startInferenceServer(server.container.containerId);

--- a/packages/backend/src/registries/InferenceProviderRegistry.ts
+++ b/packages/backend/src/registries/InferenceProviderRegistry.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { Publisher } from '../utils/Publisher';
+import type { InferenceProvider } from '../workers/provider/InferenceProvider';
+import { Disposable, type Webview } from '@podman-desktop/api';
+import { Messages } from '@shared/Messages';
+
+export class InferenceProviderRegistry extends Publisher<string[]> {
+  #providers: Map<string, InferenceProvider>;
+  constructor(webview: Webview) {
+    super(webview, Messages.MSG_INFERENCE_PROVIDER_UPDATE, () => this.getAll().map(provider => provider.name));
+    this.#providers = new Map();
+  }
+
+  register(provider: InferenceProvider): Disposable {
+    this.#providers.set(provider.name, provider);
+
+    this.notify();
+    return Disposable.create(() => {
+      this.unregister(provider.name);
+    });
+  }
+
+  unregister(name: string): void {
+    this.#providers.delete(name);
+  }
+
+  getAll(): InferenceProvider[] {
+    return Array.from(this.#providers.values());
+  }
+
+  get(name: string): InferenceProvider {
+    const provider = this.#providers.get(name);
+    if(provider === undefined) throw new Error(`no provider with name ${name} was found.`);
+    return provider;
+  }
+}

--- a/packages/backend/src/registries/InferenceProviderRegistry.ts
+++ b/packages/backend/src/registries/InferenceProviderRegistry.ts
@@ -46,7 +46,7 @@ export class InferenceProviderRegistry extends Publisher<string[]> {
 
   get(name: string): InferenceProvider {
     const provider = this.#providers.get(name);
-    if(provider === undefined) throw new Error(`no provider with name ${name} was found.`);
+    if (provider === undefined) throw new Error(`no provider with name ${name} was found.`);
     return provider;
   }
 }

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
   vi.mocked(getFreeRandomPort).mockResolvedValue(8888);
 });
 
+// TODO: move to LlamaCppPython.spec.ts
 describe('generateContainerCreateOptions', () => {
   test('valid arguments', () => {
     const result = generateContainerCreateOptions(

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -28,8 +28,6 @@ import type { CreationInferenceServerOptions, InferenceServerConfig } from '@sha
 import { getFreeRandomPort } from './ports';
 import type { InferenceServer } from '@shared/src/models/IInference';
 
-export const SECOND: number = 1_000_000_000;
-
 export const LABEL_INFERENCE_SERVER: string = 'ai-lab-inference-server';
 
 /**
@@ -101,6 +99,7 @@ export async function withDefaultConfiguration(
     labels: options.labels || {},
     modelsInfo: options.modelsInfo,
     providerId: options.providerId,
+    inferenceProvider: options.inferenceProvider,
   };
 }
 

--- a/packages/backend/src/workers/IWorker.ts
+++ b/packages/backend/src/workers/IWorker.ts
@@ -18,5 +18,5 @@
 
 export interface IWorker<T, R> {
   enabled(): boolean;
-  perform(trackingId: T): Promise<R>;
+  perform(args: T): Promise<R>;
 }

--- a/packages/backend/src/workers/provider/InferenceProvider.spec.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.spec.ts
@@ -18,11 +18,10 @@
 
 import { vi, describe, test, expect, beforeEach } from 'vitest';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
-import { InferenceProvider } from './InferenceProvider';
+import { type BetterContainerCreateResult, InferenceProvider } from './InferenceProvider';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { containerEngine } from '@podman-desktop/api';
 import type {
-  ContainerCreateResult,
   ContainerProviderConnection,
   ImageInfo,
   ProviderContainerConnection,
@@ -76,15 +75,19 @@ class TestInferenceProvider extends InferenceProvider {
     return super.pullImage(providerId, image, labels);
   }
 
-  publicCreateContainer(
+  async publicCreateContainer(
     engineId: string,
     containerCreateOptions: ContainerCreateOptions,
     labels: { [id: string]: string } = {},
-  ): Promise<ContainerCreateResult> {
-    return this.createContainer(engineId, containerCreateOptions, labels);
+  ): Promise<BetterContainerCreateResult> {
+    const result = await this.createContainer(engineId, containerCreateOptions, labels);
+    return {
+      id: result.id,
+      engineId: engineId,
+    };
   }
 
-  async perform(_config: InferenceServerConfig): Promise<ContainerCreateResult> {
+  async perform(_config: InferenceServerConfig): Promise<BetterContainerCreateResult> {
     throw new Error('not implemented');
   }
   dispose(): void {}
@@ -105,7 +108,6 @@ beforeEach(() => {
   );
   vi.mocked(containerEngine.createContainer).mockResolvedValue({
     id: 'dummy-container-id',
-    engineId: 'dummy-engine-id',
   });
 });
 

--- a/packages/backend/src/workers/provider/InferenceProvider.spec.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.spec.ts
@@ -1,0 +1,208 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { vi, describe, test, expect, beforeEach } from 'vitest';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import { InferenceProvider } from './InferenceProvider';
+import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
+import { containerEngine } from '@podman-desktop/api';
+import type {
+  ContainerCreateResult,
+  ContainerProviderConnection,
+  ImageInfo,
+  ProviderContainerConnection,
+  ContainerCreateOptions,
+} from '@podman-desktop/api';
+import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
+import type { TaskState } from '@shared/src/models/ITask';
+
+vi.mock('../../utils/inferenceUtils', () => ({
+  getProviderContainerConnection: vi.fn(),
+  getImageInfo: vi.fn(),
+  LABEL_INFERENCE_SERVER: 'ai-lab-inference-server',
+}));
+
+vi.mock('@podman-desktop/api', () => ({
+  containerEngine: {
+    createContainer: vi.fn(),
+  },
+}));
+
+const DummyProviderContainerConnection: ProviderContainerConnection = {
+  providerId: 'dummy-provider-id',
+  connection: {
+    name: 'dummy-provider-connection',
+    type: 'podman',
+  } as unknown as ContainerProviderConnection,
+};
+
+const DummyImageInfo: ImageInfo = {
+  Id: 'dummy-image-id',
+  engineId: 'dummy-engine-id',
+} as unknown as ImageInfo;
+
+const taskRegistry: TaskRegistry = {
+  createTask: vi.fn(),
+  updateTask: vi.fn(),
+} as unknown as TaskRegistry;
+
+class TestInferenceProvider extends InferenceProvider {
+  name: string = 'test-inference-provider';
+
+  constructor() {
+    super(taskRegistry);
+  }
+
+  enabled(): boolean {
+    throw new Error('not implemented');
+  }
+
+  publicPullImage(providerId: string | undefined, image: string, labels: { [id: string]: string }) {
+    return super.pullImage(providerId, image, labels);
+  }
+
+  publicCreateContainer(
+    engineId: string,
+    containerCreateOptions: ContainerCreateOptions,
+    labels: { [id: string]: string } = {},
+  ): Promise<ContainerCreateResult> {
+    return this.createContainer(engineId, containerCreateOptions, labels);
+  }
+
+  async perform(_config: InferenceServerConfig): Promise<ContainerCreateResult> {
+    throw new Error('not implemented');
+  }
+  dispose(): void {}
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(getProviderContainerConnection).mockReturnValue(DummyProviderContainerConnection);
+  vi.mocked(getImageInfo).mockResolvedValue(DummyImageInfo);
+  vi.mocked(taskRegistry.createTask).mockImplementation(
+    (name: string, state: TaskState, labels: { [id: string]: string } = {}) => ({
+      id: 'dummy-task-id',
+      name: name,
+      state: state,
+      labels: labels,
+    }),
+  );
+  vi.mocked(containerEngine.createContainer).mockResolvedValue({
+    id: 'dummy-container-id',
+    engineId: 'dummy-engine-id',
+  });
+});
+
+describe('pullImage', () => {
+  test('should create a task and mark as success on completion', async () => {
+    const provider = new TestInferenceProvider();
+    await provider.publicPullImage('dummy-provider-id', 'dummy-image', {
+      key: 'value',
+    });
+
+    expect(taskRegistry.createTask).toHaveBeenCalledWith('Pulling dummy-image.', 'loading', {
+      key: 'value',
+    });
+
+    expect(taskRegistry.updateTask).toHaveBeenCalledWith({
+      id: 'dummy-task-id',
+      name: 'Pulling dummy-image.',
+      labels: {
+        key: 'value',
+      },
+      state: 'success',
+    });
+  });
+
+  test('should mark the task as error when pulling failed', async () => {
+    const provider = new TestInferenceProvider();
+    vi.mocked(getImageInfo).mockRejectedValue(new Error('dummy test error'));
+
+    await expect(
+      provider.publicPullImage('dummy-provider-id', 'dummy-image', {
+        key: 'value',
+      }),
+    ).rejects.toThrowError('dummy test error');
+
+    expect(taskRegistry.updateTask).toHaveBeenCalledWith({
+      id: 'dummy-task-id',
+      name: 'Pulling dummy-image.',
+      labels: {
+        key: 'value',
+      },
+      state: 'error',
+      error: 'Something went wrong while pulling dummy-image: Error: dummy test error',
+    });
+  });
+});
+
+describe('createContainer', () => {
+  test('should create a task and mark as success on completion', async () => {
+    const provider = new TestInferenceProvider();
+    await provider.publicCreateContainer(
+      'dummy-engine-id',
+      {
+        name: 'dummy-container-name',
+      },
+      {
+        key: 'value',
+      },
+    );
+
+    expect(taskRegistry.createTask).toHaveBeenCalledWith('Creating container.', 'loading', {
+      key: 'value',
+    });
+
+    expect(taskRegistry.updateTask).toHaveBeenCalledWith({
+      id: 'dummy-task-id',
+      name: 'Creating container.',
+      labels: {
+        key: 'value',
+      },
+      state: 'success',
+    });
+  });
+
+  test('should mark the task as error when creation failed', async () => {
+    const provider = new TestInferenceProvider();
+    vi.mocked(containerEngine.createContainer).mockRejectedValue(new Error('dummy test error'));
+
+    await expect(
+      provider.publicCreateContainer(
+        'dummy-provider-id',
+        {
+          name: 'dummy-container-name',
+        },
+        {
+          key: 'value',
+        },
+      ),
+    ).rejects.toThrowError('dummy test error');
+
+    expect(taskRegistry.updateTask).toHaveBeenCalledWith({
+      id: 'dummy-task-id',
+      name: 'Creating container.',
+      labels: {
+        key: 'value',
+      },
+      state: 'error',
+      error: 'Something went wrong while creating container: Error: dummy test error',
+    });
+  });
+});

--- a/packages/backend/src/workers/provider/InferenceProvider.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.ts
@@ -30,7 +30,9 @@ import { getImageInfo, getProviderContainerConnection } from '../../utils/infere
 
 export type BetterContainerCreateResult = ContainerCreateResult & { engineId: string };
 
-export abstract class InferenceProvider implements IWorker<InferenceServerConfig, BetterContainerCreateResult>, Disposable {
+export abstract class InferenceProvider
+  implements IWorker<InferenceServerConfig, BetterContainerCreateResult>, Disposable
+{
   protected constructor(private taskRegistry: TaskRegistry) {}
 
   abstract name: string;

--- a/packages/backend/src/workers/provider/InferenceProvider.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.ts
@@ -39,7 +39,7 @@ export abstract class InferenceProvider implements IWorker<InferenceServerConfig
   protected async createContainer(
     engineId: string,
     containerCreateOptions: ContainerCreateOptions,
-    labels: { [id: string]: string } = {},
+    labels: { [id: string]: string },
   ): Promise<ContainerCreateResult> {
     const containerTask = this.taskRegistry.createTask(`Creating container.`, 'loading', labels);
 

--- a/packages/backend/src/workers/provider/InferenceProvider.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.ts
@@ -28,19 +28,21 @@ import type { IWorker } from '../IWorker';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
 
-export abstract class InferenceProvider implements IWorker<InferenceServerConfig, ContainerCreateResult>, Disposable {
+export type BetterContainerCreateResult = ContainerCreateResult & { engineId: string };
+
+export abstract class InferenceProvider implements IWorker<InferenceServerConfig, BetterContainerCreateResult>, Disposable {
   protected constructor(private taskRegistry: TaskRegistry) {}
 
   abstract name: string;
   abstract enabled(): boolean;
-  abstract perform(config: InferenceServerConfig): Promise<ContainerCreateResult>;
+  abstract perform(config: InferenceServerConfig): Promise<BetterContainerCreateResult>;
   abstract dispose(): void;
 
   protected async createContainer(
     engineId: string,
     containerCreateOptions: ContainerCreateOptions,
     labels: { [id: string]: string },
-  ): Promise<ContainerCreateResult> {
+  ): Promise<BetterContainerCreateResult> {
     const containerTask = this.taskRegistry.createTask(`Creating container.`, 'loading', labels);
 
     try {

--- a/packages/backend/src/workers/provider/InferenceProvider.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.ts
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type {
+  ContainerCreateOptions,
+  Disposable,
+  ImageInfo,
+  PullEvent,
+} from '@podman-desktop/api';
+import {
+  containerEngine
+} from '@podman-desktop/api';
+import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
+import type { IWorker } from '../IWorker';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
+
+// hopefully get replaced by https://github.com/containers/podman-desktop/pull/7464
+export interface BetterContainerCreateResult {
+  id: string;
+  engineId: string;
+}
+
+export abstract class InferenceProvider implements IWorker<InferenceServerConfig, BetterContainerCreateResult>, Disposable {
+  constructor(private taskRegistry: TaskRegistry) {}
+
+  abstract name: string;
+  abstract enabled(): boolean;
+  abstract perform(config: InferenceServerConfig): Promise<BetterContainerCreateResult>;
+  abstract dispose(): void;
+
+  protected async createContainer(
+    engineId: string,
+    containerCreateOptions: ContainerCreateOptions,
+    labels: { [id: string]: string } = {},
+  ): Promise<BetterContainerCreateResult> {
+    const containerTask = this.taskRegistry.createTask(`Creating container.`, 'loading', labels);
+
+    try {
+      const result = await containerEngine.createContainer(
+        engineId,
+        containerCreateOptions,
+      );
+      // update the task
+      containerTask.state = 'success';
+      containerTask.progress = undefined;
+      // return the BetterContainerCreateResult
+      return {
+        id: result.id,
+        engineId: engineId,
+      };
+    } catch (err: unknown) {
+      containerTask.state = 'error';
+      containerTask.progress = undefined;
+      containerTask.error = `Something went wrong while creating container: ${String(err)}`;
+      throw err;
+    } finally {
+      this.taskRegistry.updateTask(containerTask);
+    }
+  }
+
+  /**
+   * This method allows to pull the image, while creating a task for the user to follow progress
+   * @param providerId
+   * @param image
+   * @param labels
+   * @protected
+   */
+  protected pullImage(providerId: string | undefined, image: string, labels: { [id: string]: string }): Promise<ImageInfo> {
+    // Creating a task to follow pulling progress
+    const pullingTask = this.taskRegistry.createTask(`Pulling ${image}.`, 'loading', labels);
+
+    // Get the provider
+    const provider = getProviderContainerConnection(providerId);
+
+    // get the default image info for this provider
+    return getImageInfo(
+      provider.connection,
+      image,
+      (_event: PullEvent) => {},
+    ).catch((err: unknown) => {
+      pullingTask.state = 'error';
+      pullingTask.progress = undefined;
+      pullingTask.error = `Something went wrong while pulling ${image}: ${String(err)}`;
+      throw err;
+    }).then((imageInfo) => {
+      pullingTask.state = 'success';
+      pullingTask.progress = undefined;
+      return imageInfo;
+    }).finally(() => {
+      this.taskRegistry.updateTask(pullingTask);
+    });
+  }
+}

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -1,0 +1,223 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { vi, describe, test, expect, beforeEach } from 'vitest';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import { LLAMA_CPP_INFERENCE_IMAGE, LlamaCppPython, SECOND } from './LlamaCppPython';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
+import type { ContainerProviderConnection, ImageInfo, ProviderContainerConnection } from '@podman-desktop/api';
+import { containerEngine } from '@podman-desktop/api';
+
+vi.mock('@podman-desktop/api', () => ({
+  containerEngine: {
+    createContainer: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/inferenceUtils', () => ({
+  getProviderContainerConnection: vi.fn(),
+  getImageInfo: vi.fn(),
+  LABEL_INFERENCE_SERVER: 'ai-lab-inference-server',
+}));
+
+const taskRegistry: TaskRegistry = {
+  createTask: vi.fn(),
+  updateTask: vi.fn(),
+} as unknown as TaskRegistry;
+
+const DummyModel: ModelInfo = {
+  name: 'dummy model',
+  id: 'dummy-model-id',
+  file: {
+    file: 'dummy-file.guff',
+    path: 'dummy-path',
+  },
+  properties: {},
+  description: 'dummy-desc',
+  hw: 'dummy-hardware',
+};
+
+const DummyProviderContainerConnection: ProviderContainerConnection = {
+  providerId: 'dummy-provider-id',
+  connection: {
+    name: 'dummy-provider-connection',
+    type: 'podman',
+  } as unknown as ContainerProviderConnection,
+};
+
+const DummyImageInfo: ImageInfo = {
+  Id: 'dummy-image-id',
+  engineId: 'dummy-engine-id',
+} as unknown as ImageInfo;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(getProviderContainerConnection).mockReturnValue(DummyProviderContainerConnection);
+  vi.mocked(getImageInfo).mockResolvedValue(DummyImageInfo);
+  vi.mocked(taskRegistry.createTask).mockReturnValue({ id: 'dummy-task-id', name: '', labels: {}, state: 'loading' });
+  vi.mocked(containerEngine.createContainer).mockResolvedValue({
+    id: 'dummy-container-id',
+    engineId: 'dummy-engine-id',
+  });
+});
+
+test('LlamaCppPython being the default, it should always be enable', () => {
+  const provider = new LlamaCppPython(taskRegistry);
+  expect(provider.enabled()).toBeTruthy();
+});
+
+describe('perform', () => {
+  test('config without image should use defined image', async () => {
+    const provider = new LlamaCppPython(taskRegistry);
+
+    await provider.perform({
+      port: 8000,
+      image: undefined,
+      labels: {},
+      modelsInfo: [DummyModel],
+      providerId: undefined,
+    });
+
+    expect(getProviderContainerConnection).toHaveBeenCalledWith(undefined);
+    expect(getImageInfo).toHaveBeenCalledWith(
+      DummyProviderContainerConnection.connection,
+      LLAMA_CPP_INFERENCE_IMAGE,
+      expect.anything(),
+    );
+  });
+
+  test('config without models should throw an error', async () => {
+    const provider = new LlamaCppPython(taskRegistry);
+
+    await expect(
+      provider.perform({
+        port: 8000,
+        image: undefined,
+        labels: {},
+        modelsInfo: [],
+        providerId: undefined,
+      }),
+    ).rejects.toThrowError('Need at least one model info to start an inference server.');
+  });
+
+  test('config model without file should throw an error', async () => {
+    const provider = new LlamaCppPython(taskRegistry);
+
+    await expect(
+      provider.perform({
+        port: 8000,
+        image: undefined,
+        labels: {},
+        modelsInfo: [
+          {
+            id: 'invalid',
+          } as unknown as ModelInfo,
+        ],
+        providerId: undefined,
+      }),
+    ).rejects.toThrowError('The model info file provided is undefined');
+  });
+
+  test('valid config should produce expected CreateContainerOptions', async () => {
+    const provider = new LlamaCppPython(taskRegistry);
+
+    await provider.perform({
+      port: 8888,
+      image: undefined,
+      labels: {},
+      modelsInfo: [DummyModel],
+      providerId: undefined,
+    });
+
+    expect(containerEngine.createContainer).toHaveBeenCalledWith(DummyImageInfo.engineId, {
+      Cmd: ['--models-path', '/models', '--context-size', '700', '--threads', '4'],
+      Detach: true,
+      Env: ['MODEL_PATH=/models/dummy-file.guff', 'HOST=0.0.0.0', 'PORT=8000'],
+      ExposedPorts: {
+        '8888': {},
+      },
+      HealthCheck: {
+        Interval: SECOND * 5,
+        Retries: 20,
+        Test: ['CMD-SHELL', 'curl -sSf localhost:8000/docs > /dev/null'],
+      },
+      HostConfig: {
+        AutoRemove: false,
+        Mounts: [
+          {
+            Source: 'dummy-path',
+            Target: '/models',
+            Type: 'bind',
+          },
+        ],
+        PortBindings: {
+          '8000/tcp': [
+            {
+              HostPort: '8888',
+            },
+          ],
+        },
+        SecurityOpt: ['label=disable'],
+      },
+      Image: DummyImageInfo.Id,
+      Labels: {
+        'ai-lab-inference-server': `["${DummyModel.id}"]`,
+      },
+    });
+  });
+
+  test('model properties should be made uppercased', async () => {
+    const provider = new LlamaCppPython(taskRegistry);
+
+    await provider.perform({
+      port: 8000,
+      image: undefined,
+      labels: {},
+      modelsInfo: [
+        {
+          ...DummyModel,
+          properties: {
+            basicProp: 'basicProp',
+            lotOfCamelCases: 'lotOfCamelCases',
+            lowercase: 'lowercase',
+            chatFormat: 'dummyChatFormat',
+          },
+        },
+      ],
+      providerId: undefined,
+    });
+
+    expect(containerEngine.createContainer).toHaveBeenCalledWith(DummyImageInfo.engineId, {
+      Env: expect.arrayContaining([
+        'MODEL_BASIC_PROP=basicProp',
+        'MODEL_LOT_OF_CAMEL_CASES=lotOfCamelCases',
+        'MODEL_LOWERCASE=lowercase',
+        'MODEL_CHAT_FORMAT=dummyChatFormat',
+      ]),
+      Cmd: expect.anything(),
+      HealthCheck: expect.anything(),
+      HostConfig: expect.anything(),
+      ExposedPorts: expect.anything(),
+      Labels: expect.anything(),
+      Image: DummyImageInfo.Id,
+      Detach: true,
+    });
+  });
+});

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -74,7 +74,6 @@ beforeEach(() => {
   vi.mocked(taskRegistry.createTask).mockReturnValue({ id: 'dummy-task-id', name: '', labels: {}, state: 'loading' });
   vi.mocked(containerEngine.createContainer).mockResolvedValue({
     id: 'dummy-container-id',
-    engineId: 'dummy-engine-id',
   });
 });
 

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -1,0 +1,115 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type {
+  ContainerCreateOptions,
+  ImageInfo,
+} from '@podman-desktop/api';
+import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
+import { type BetterContainerCreateResult, InferenceProvider } from './InferenceProvider';
+import { getModelPropertiesForEnvironment } from '../../utils/modelsUtils';
+import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
+import {
+  LABEL_INFERENCE_SERVER,
+  SECOND,
+} from '../../utils/inferenceUtils';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+
+const INFERENCE_SERVER_IMAGE =
+  'ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:0.3.2';
+
+export class LlamaCppPython extends InferenceProvider {
+  name: string;
+
+  constructor(taskRegistry: TaskRegistry) {
+    super(taskRegistry);
+    this.name = 'Llamacpp';
+  }
+
+  dispose() {}
+
+  public enabled = (): boolean => true;
+
+  protected async getContainerCreateOptions(config: InferenceServerConfig, imageInfo: ImageInfo): Promise<ContainerCreateOptions> {
+    if (config.modelsInfo.length === 0) throw new Error('Need at least one model info to start an inference server.');
+
+    if (config.modelsInfo.length > 1) {
+      throw new Error('Currently the inference server does not support multiple models serving.');
+    }
+
+    const modelInfo = config.modelsInfo[0];
+
+    if (modelInfo.file === undefined) {
+      throw new Error('The model info file provided is undefined');
+    }
+
+    const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
+    envs.push(...getModelPropertiesForEnvironment(modelInfo));
+
+    return {
+      Image: imageInfo.Id,
+      Detach: true,
+      ExposedPorts: { [`${config.port}`]: {} },
+      HostConfig: {
+        AutoRemove: false,
+        Mounts: [
+          {
+            Target: '/models',
+            Source: modelInfo.file.path,
+            Type: 'bind',
+          },
+        ],
+        SecurityOpt: [DISABLE_SELINUX_LABEL_SECURITY_OPTION],
+        PortBindings: {
+          '8000/tcp': [
+            {
+              HostPort: `${config.port}`,
+            },
+          ],
+        },
+      },
+      HealthCheck: {
+        // must be the port INSIDE the container not the exposed one
+        Test: ['CMD-SHELL', `curl -sSf localhost:8000/docs > /dev/null`],
+        Interval: SECOND * 5,
+        Retries: 4 * 5,
+      },
+      Labels: {
+        ...config.labels,
+        [LABEL_INFERENCE_SERVER]: JSON.stringify(config.modelsInfo.map(model => model.id)),
+      },
+      Env: envs,
+      Cmd: ['--models-path', '/models', '--context-size', '700', '--threads', '4'],
+    };
+  }
+
+  async perform(config: InferenceServerConfig): Promise<BetterContainerCreateResult> {
+    if(!this.enabled()) throw new Error('not enabled');
+
+    // pull the image
+    const imageInfo: ImageInfo = await this.pullImage(config.providerId, config.image ?? INFERENCE_SERVER_IMAGE, config.labels);
+
+    // Get the container creation options
+    const containerCreateOptions: ContainerCreateOptions = await this.getContainerCreateOptions(config, imageInfo);
+
+    // Create the container
+    return this.createContainer(
+      imageInfo.engineId,
+      containerCreateOptions,
+    );
+  }
+}

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -15,9 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { ContainerCreateOptions, ContainerCreateResult, ImageInfo } from '@podman-desktop/api';
+import type { ContainerCreateOptions, ImageInfo } from '@podman-desktop/api';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
-import { InferenceProvider } from './InferenceProvider';
+import { type BetterContainerCreateResult, InferenceProvider } from './InferenceProvider';
 import { getModelPropertiesForEnvironment } from '../../utils/modelsUtils';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
 import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
@@ -96,7 +96,7 @@ export class LlamaCppPython extends InferenceProvider {
     };
   }
 
-  async perform(config: InferenceServerConfig): Promise<ContainerCreateResult> {
+  async perform(config: InferenceServerConfig): Promise<BetterContainerCreateResult> {
     if (!this.enabled()) throw new Error('not enabled');
 
     // pull the image

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -110,6 +110,6 @@ export class LlamaCppPython extends InferenceProvider {
     const containerCreateOptions: ContainerCreateOptions = await this.getContainerCreateOptions(config, imageInfo);
 
     // Create the container
-    return this.createContainer(imageInfo.engineId, containerCreateOptions);
+    return this.createContainer(imageInfo.engineId, containerCreateOptions, config.labels);
   }
 }

--- a/packages/shared/Messages.ts
+++ b/packages/shared/Messages.ts
@@ -27,4 +27,5 @@ export enum Messages {
   MSG_SUPPORTED_LANGUAGES_UPDATE = 'supported-languages-supported',
   MSG_CONVERSATIONS_UPDATE = 'conversations-update',
   MSG_GPUS_UPDATE = 'gpus-update',
+  MSG_INFERENCE_PROVIDER_UPDATE = 'inference-provider-update',
 }

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -31,7 +31,7 @@ export interface InferenceServerConfig {
   /**
    * Image to use
    */
-  image: string;
+  image?: string;
   /**
    * Labels to use for the container
    */

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -29,6 +29,10 @@ export interface InferenceServerConfig {
    */
   providerId?: string;
   /**
+   * The name of the inference provider to use
+   */
+  inferenceProvider?: string;
+  /**
    * Image to use
    */
   image?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,10 +391,10 @@
   dependencies:
     playwright "1.42.1"
 
-"@podman-desktop/api@0.0.202406050828-61eefc7":
-  version "0.0.202406050828-61eefc7"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-0.0.202406050828-61eefc7.tgz#a50ab32f53200e1b88bc1d2b15cf7aba586bac5d"
-  integrity sha512-a54i9sFXIaBO18w/Nv+c+4Fre6D4n8sygyDLR67H5125zeZpMsY05GJDvqDnXpoQZzp/4pvA9RoXZoGWU8vJrw==
+"@podman-desktop/api@1.10.3":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.10.3.tgz#c4c17e96aa3f70acd47162cc2d02cd0f3290fd52"
+  integrity sha512-jc5mYPsNz59e+o+1fQR67TPUWQoIuEssMtSwOgqdV/k0lSk05p5ErotrgeKT7WVXb7XxYOx0E4MtTTY5Kf7cyw==
 
 "@podman-desktop/tests-playwright@^1.10.3":
   version "1.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,10 +391,10 @@
   dependencies:
     playwright "1.42.1"
 
-"@podman-desktop/api@0.0.202404101645-5d46ba5":
-  version "0.0.202404101645-5d46ba5"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-0.0.202404101645-5d46ba5.tgz#562aa4470057bfc7869b576d9691da2ffe49fa18"
-  integrity sha512-5FwFhBrOGb2Nhd0buGZCigAewnio8xlkenmIKW0Ew2jqeoKffgW6e4bpvRTsl9JeGiQqrEa5jkZP6cft+xlGfA==
+"@podman-desktop/api@0.0.202406050828-61eefc7":
+  version "0.0.202406050828-61eefc7"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-0.0.202406050828-61eefc7.tgz#a50ab32f53200e1b88bc1d2b15cf7aba586bac5d"
+  integrity sha512-a54i9sFXIaBO18w/Nv+c+4Fre6D4n8sygyDLR67H5125zeZpMsY05GJDvqDnXpoQZzp/4pvA9RoXZoGWU8vJrw==
 
 "@podman-desktop/tests-playwright@^1.10.3":
   version "1.10.3"


### PR DESCRIPTION
### What does this PR do?

Introducing `InferenceProvider` interface, which is an abstraction class made to create InferenceServers. In todays implementation we do not make distinctions between `backends` (llamacpp, whispercpp etc.)

This is the first step in abstracting the inference providers, to ease the customization of inference server with new provider in the future (whispercpp, llamacpp-cuda, ollama etc.)

### Documentation

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/f68273e3-4141-4c2d-9f57-fa376a3b7c19)

[![](https://mermaid.ink/img/pako:eNp1kcFugzAMhl_Fyrl9AQ69bNPEAQnRKxcvMSwaOMxxkKqq774gSqtuXU5O_P3-f8VnY4MjU5hI34nY0qvHXnBsGfJBq0EgRZL1PqGot35CVigrwAgldySLrkLG_ilXNw8g1BJm70igod5HlVPLq2rx2e8Ph7Iqci_HifoihEo37ZFk3jzKamPfOCYhmHHwDmzgzvdJUH3gB7JuCngnvSfZgsQrVjd3d03C_5M362UeMX4M5P7Sv2GLwwATSRdkhMAQaSCrz5Wr1uzMSDKid3lD5-WtNfpJI7WmyKVD-WpNy5fMYdJwPLE1hUqinUmTyz933aYpOhwiXX4AV1unEw?type=png)](https://mermaid.live/edit#pako:eNp1kcFugzAMhl_Fyrl9AQ69bNPEAQnRKxcvMSwaOMxxkKqq774gSqtuXU5O_P3-f8VnY4MjU5hI34nY0qvHXnBsGfJBq0EgRZL1PqGot35CVigrwAgldySLrkLG_ilXNw8g1BJm70igod5HlVPLq2rx2e8Ph7Iqci_HifoihEo37ZFk3jzKamPfOCYhmHHwDmzgzvdJUH3gB7JuCngnvSfZgsQrVjd3d03C_5M362UeMX4M5P7Sv2GLwwATSRdkhMAQaSCrz5Wr1uzMSDKid3lD5-WtNfpJI7WmyKVD-WpNy5fMYdJwPLE1hUqinUmTyz933aYpOhwiXX4AV1unEw)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1112

### How to test this PR?

- [x] unit tests has been provided

#### Manually (recommended)

- Create an inference server
- Start chatbot recipe