### PR TITLE
chore: moving static webview logic to dedicated util file

### DIFF
--- a/packages/backend/src/webviewUtils.spec.ts
+++ b/packages/backend/src/webviewUtils.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi, describe } from 'vitest';
+import { initWebview } from './webviewUtils';
+import type { Uri } from '@podman-desktop/api';
+import { promises } from 'node:fs';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    Uri: class {
+      static joinPath = () => ({ fsPath: '.' });
+    },
+    window: {
+      createWebviewPanel: () => ({
+        webview: {
+          html: '',
+          onDidReceiveMessage: vi.fn(),
+          postMessage: vi.fn(),
+          asWebviewUri: () => 'dummy-src',
+        },
+        onDidChangeViewState: vi.fn(),
+      }),
+    },
+  };
+});
+
+vi.mock('node:fs', () => ({
+  promises: {
+    readFile: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('panel should have file content as html', async () => {
+  vi.mocked(promises.readFile).mockImplementation(() => {
+    return Promise.resolve('<html></html>');
+  });
+
+  const panel = await initWebview({} as unknown as Uri);
+  expect(panel.webview.html).toBe('<html></html>');
+});
+
+test('script src should be replaced with asWebviewUri result', async () => {
+  vi.mocked(promises.readFile).mockImplementation(() => {
+    return Promise.resolve('<script type="module" crossorigin src="./index-RKnfBG18.js"></script>');
+  });
+
+  const panel = await initWebview({} as unknown as Uri);
+  expect(panel.webview.html).toBe('<script type="module" crossorigin src="dummy-src"></script>');
+});
+
+test('links src should be replaced with asWebviewUri result', async () => {
+  vi.mocked(promises.readFile).mockImplementation(() => {
+    return Promise.resolve('<link rel="stylesheet" href="./styles.css">');
+  });
+
+  const panel = await initWebview({} as unknown as Uri);
+  expect(panel.webview.html).toBe('<link rel="stylesheet" href="dummy-src">');
+});

--- a/packages/backend/src/webviewUtils.ts
+++ b/packages/backend/src/webviewUtils.ts
@@ -1,0 +1,73 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { Uri, type WebviewOptions, type WebviewPanel, window } from '@podman-desktop/api';
+import { promises } from 'node:fs';
+
+function getWebviewOptions(extensionUri: Uri): WebviewOptions {
+  return {
+    // Enable javascript in the webview
+    // enableScripts: true,
+
+    // And restrict the webview to only loading content from our extension's `media` directory.
+    localResourceRoots: [Uri.joinPath(extensionUri, 'media')],
+  };
+}
+
+export async function initWebview(extensionUri: Uri): Promise<WebviewPanel> {
+  // register webview
+  const panel = window.createWebviewPanel('studio', 'AI Lab', getWebviewOptions(extensionUri));
+
+  // update html
+  const indexHtmlUri = Uri.joinPath(extensionUri, 'media', 'index.html');
+  const indexHtmlPath = indexHtmlUri.fsPath;
+
+  let indexHtml = await promises.readFile(indexHtmlPath, 'utf8');
+
+  // replace links with webView Uri links
+  // in the content <script type="module" crossorigin src="./index-RKnfBG18.js"></script> replace src with webview.asWebviewUri
+  const scriptLink = indexHtml.match(/<script.*?src="(.*?)".*?>/g);
+  if (scriptLink) {
+    scriptLink.forEach(link => {
+      const src = link.match(/src="(.*?)"/);
+      if (src) {
+        const webviewSrc = panel.webview.asWebviewUri(Uri.joinPath(extensionUri, 'media', src[1]));
+        if (!webviewSrc) throw new Error('undefined webviewSrc');
+        indexHtml = indexHtml.replace(src[1], webviewSrc.toString());
+      }
+    });
+  }
+
+  // and now replace for css file as well
+  const cssLink = indexHtml.match(/<link.*?href="(.*?)".*?>/g);
+  if (cssLink) {
+    cssLink.forEach(link => {
+      const href = link.match(/href="(.*?)"/);
+      if (href) {
+        const webviewHref = panel.webview.asWebviewUri(Uri.joinPath(extensionUri, 'media', href[1]));
+        if (!webviewHref)
+          throw new Error('Something went wrong while replacing links with webView Uri links: undefined webviewHref');
+        indexHtml = indexHtml.replace(href[1], webviewHref.toString());
+      }
+    });
+  }
+
+  panel.webview.html = indexHtml;
+
+  return panel;
+}


### PR DESCRIPTION
### What does this PR do?

Our `studio.ts` start to become a bit too big and do too much stuff, this quick PR move webview logic (replace src of scripts and links) to dedicated `webviewUtils` file.

Moreover I added tests for the webview, which were non existant before

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] Unit tests has been provided