### PR TITLE
fix: prevent using keyboard in plyaground while request is ongoing

### DIFF
--- a/packages/frontend/src/pages/Playground.spec.ts
+++ b/packages/frontend/src/pages/Playground.spec.ts
@@ -305,7 +305,7 @@ test('send prompt should be enabled initially, with a system prompt', async () =
   });
 });
 
-test('sending prompt should disable the send button', async () => {
+test('sending prompt should disable the send button and the input element', async () => {
   vi.mocked(studioClient.getCatalog).mockResolvedValue({
     models: [
       {
@@ -346,10 +346,12 @@ test('sending prompt should disable the send button', async () => {
   await waitFor(() => {
     send = screen.getByRole('button', { name: 'Send prompt' });
     expect(send).toBeDisabled();
+    const input = screen.getByRole('textbox', { name: 'prompt' });
+    expect(input).toBeDisabled();
   });
 });
 
-test('sending prompt not using button should disable the send button', async () => {
+test('sending prompt not using button should disable the send button and the input element', async () => {
   vi.mocked(studioClient.getCatalog).mockResolvedValue({
     models: [
       {
@@ -391,10 +393,12 @@ test('sending prompt not using button should disable the send button', async () 
   await waitFor(() => {
     prompt = screen.getByRole('button', { name: 'Send prompt' });
     expect(prompt).toBeDisabled();
+    const input = screen.getByRole('textbox', { name: 'prompt' });
+    expect(input).toBeDisabled();
   });
 });
 
-test('receiving complete message should enable the send button', async () => {
+test('receiving complete message should enable the send button and the input element', async () => {
   vi.mocked(studioClient.getCatalog).mockResolvedValue({
     models: [
       {
@@ -435,6 +439,8 @@ test('receiving complete message should enable the send button', async () => {
   await waitFor(() => {
     send = screen.getByRole('button', { name: 'Send prompt' });
     expect(send).toBeDisabled();
+    const input = screen.getByRole('textbox', { name: 'prompt' });
+    expect(input).toBeDisabled();
   });
 
   customConversations.set([
@@ -461,6 +467,8 @@ test('receiving complete message should enable the send button', async () => {
   await waitFor(() => {
     send = screen.getByRole('button', { name: 'Send prompt' });
     expect(send).toBeEnabled();
+    const input = screen.getByRole('textbox', { name: 'prompt' });
+    expect(input).toBeEnabled();
   });
 });
 

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -261,7 +261,8 @@ function getSendPromptTitle(sendEnabled: boolean, status?: string, health?: stri
             on:keydown="{handleKeydown}"
             rows="2"
             class="w-full p-2 outline-none text-sm rounded-sm bg-charcoal-800 text-white placeholder-white"
-            placeholder="Type your prompt here"></textarea>
+            placeholder="Type your prompt here"
+            disabled="{!sendEnabled}"></textarea>
 
           <div class="flex-none text-right m-4">
             <Button


### PR DESCRIPTION
Fixes #1087

### What does this PR do?

Prevent using keyboard while there is a request being processed

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#1087

### How to test this PR?

Use the playground