### PR TITLE
fix: dispose webview panel

### DIFF
--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -96,6 +96,7 @@ export class Studio {
 
     // init webview
     this.#panel = await initWebview(this.#extensionContext.extensionUri);
+    this.#extensionContext.subscriptions.push(this.#panel);
 
     // Creating cancellation token registry
     const cancellationTokenRegistry = new CancellationTokenRegistry();


### PR DESCRIPTION
### What does this PR do?

https://github.com/containers/podman-desktop-extension-ai-lab/pull/1167 introduced a regression, it removed (by accident) to add the webview panel created to the subscriptions that must be disposed when the extension is stopped.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->