### PR TITLE
feat: adding InferenceType enum

### DIFF
--- a/packages/backend/src/assets/ai.json
+++ b/packages/backend/src/assets/ai.json
@@ -24,7 +24,8 @@
         "hf.MaziyarPanahi.phi-2.Q4_K_M",
         "hf.llmware.dragon-mistral-7b-q4_k_m",
         "hf.MaziyarPanahi.MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M"
-      ]
+      ],
+      "backend": "llama-cpp"
     },
     {
       "id": "summarizer",
@@ -50,7 +51,8 @@
         "hf.MaziyarPanahi.phi-2.Q4_K_M",
         "hf.llmware.dragon-mistral-7b-q4_k_m",
         "hf.MaziyarPanahi.MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M"
-      ]
+      ],
+      "backend": "llama-cpp"
     },
     {
       "id": "codegeneration",
@@ -76,7 +78,8 @@
         "hf.MaziyarPanahi.phi-2.Q4_K_M",
         "hf.llmware.dragon-mistral-7b-q4_k_m",
         "hf.MaziyarPanahi.MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M"
-      ]
+      ],
+      "backend": "llama-cpp"
     },
     {
       "id": "audio_to_text",
@@ -92,7 +95,8 @@
       "readme": "# Audio to Text Application\n\nThis recipe helps developers start building their own custom AI enabled audio transcription applications. It consists of two main components: the Model Service and the AI Application.\n\nThere are a few options today for local Model Serving, but this recipe will use [`whisper-cpp`](https://github.com/ggerganov/whisper.cpp.git) and its included Model Service. There is a Containerfile provided that can be used to build this Model Service within the repo, [`model_servers/whispercpp/base/Containerfile`](/model_servers/whispercpp/base/Containerfile).\n\nThe AI Application will connect to the Model Service via an API. The recipe relies on [Langchain's](https://python.langchain.com/docs/get_started/introduction) python package to simplify communication with the Model Service and uses [Streamlit](https://streamlit.io/) for the UI layer. You can find an example of the audio to text application below.\n\n\n![](/assets/whisper.png) \n\n## Try the Audio to Text Application:\n\nThe [Podman Desktop](https://podman-desktop.io) [AI Lab Extension](https://github.com/containers/podman-desktop-extension-ai-lab) includes this recipe among others. To try it out, open `Recipes Catalog` -> `Audio to Text` and follow the instructions to start the application.\n\n# Build the Application\n\nThe rest of this document will explain how to build and run the application from the terminal, and will go into greater detail on how each container in the application above is built, run, and  what purpose it serves in the overall application. All the recipes use a central [Makefile](../../common/Makefile.common) that includes variables populated with default values to simplify getting started. Please review the [Makefile docs](../../common/README.md), to learn about further customizing your application.\n\n* [Download a model](#download-a-model)\n* [Build the Model Service](#build-the-model-service)\n* [Deploy the Model Service](#deploy-the-model-service)\n* [Build the AI Application](#build-the-ai-application)\n* [Deploy the AI Application](#deploy-the-ai-application)\n* [Interact with the AI Application](#interact-with-the-ai-application)\n    * [Input audio files](#input-audio-files)\n\n## Download a model\n\nIf you are just getting started, we recommend using [ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp).\nThis is a well performant model with an MIT license.\nIt's simple to download a pre-converted whisper model from [huggingface.co](https://huggingface.co)\nhere: https://huggingface.co/ggerganov/whisper.cpp. There are a number of options, but we recommend to start with `ggml-small.bin`.\n\nThe recommended model can be downloaded using the code snippet below:\n\n```bash\ncd ../../../models\ncurl -sLO https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin\ncd ../recipes/audio/audio_to_text\n```\n\n_A full list of supported open models is forthcoming._\n\n\n## Build the Model Service\n\nThe complete instructions for building and deploying the Model Service can be found in the [whispercpp model-service document](../../../model_servers/whispercpp/README.md).\n\n```bash\n# from path model_servers/whispercpp from repo containers/ai-lab-recipes\nmake build\n```\nCheckout the [Makefile](../../../model_servers/whispercpp/Makefile) to get more details on different options for how to build.\n\n## Deploy the Model Service\n\nThe local Model Service relies on a volume mount to the localhost to access the model files. It also employs environment variables to dictate the model used and where its served. You can start your local Model Service using the following `make` command from `model_servers/whispercpp` set with reasonable defaults:\n\n```bash\n# from path model_servers/whispercpp from repo containers/ai-lab-recipes\nmake run\n```\n\n## Build the AI Application\n\nNow that the Model Service is running we want to build and deploy our AI Application. Use the provided Containerfile to build the AI Application\nimage from the [`audio-to-text/`](./) directory.\n\n```bash\n# from path recipes/audio/audio_to_text from repo containers/ai-lab-recipes\npodman build -t audio-to-text app\n```\n### Deploy the AI Application\n\nMake sure the Model Service is up and running before starting this container image.\nWhen starting the AI Application container image we need to direct it to the correct `MODEL_ENDPOINT`.\nThis could be any appropriately hosted Model Service (running locally or in the cloud) using a compatible API.\nThe following Podman command can be used to run your AI Application:\n\n```bash\npodman run --rm -it -p 8501:8501 -e MODEL_ENDPOINT=http://10.88.0.1:8001/inference audio-to-text \n```\n\n### Interact with the AI Application\n\nOnce the streamlit application is up and running, you should be able to access it at `http://localhost:8501`.\nFrom here, you can upload audio files from your local machine and translate the audio files as shown below.\n\nBy using this recipe and getting this starting point established,\nusers should now have an easier time customizing and building their own AI enabled applications.\n\n#### Input audio files\n\nWhisper.cpp requires as an input 16-bit WAV audio files.\nTo convert your input audio files to 16-bit WAV format you can use `ffmpeg` like this:\n\n```bash\nffmpeg -i <input.mp3> -ar 16000 -ac 1 -c:a pcm_s16le <output.wav>\n```\n",
       "models": [
         "hf.ggerganov.whisper.cpp"
-      ]
+      ],
+      "backend": "whisper-cpp"
     },
     {
       "id": "object_detection",
@@ -108,7 +112,8 @@
       "readme": "# Object Detection\n\nThis recipe helps developers start building their own custom AI enabled object detection applications. It consists of two main components: the Model Service and the AI Application.\n\nThere are a few options today for local Model Serving, but this recipe will use our FastAPI [`object_detection_python`](../../../model_servers/object_detection_python/src/object_detection_server.py) model server. There is a Containerfile provided that can be used to build this Model Service within the repo, [`model_servers/object_detection_python/base/Containerfile`](/model_servers/object_detection_python/base/Containerfile).\n\nThe AI Application will connect to the Model Service via an API. The recipe relies on [Streamlit](https://streamlit.io/) for the UI layer. You can find an example of the object detection application below.\n\n![](/assets/object_detection.png) \n\n## Try the Object Detection Application:\n\nThe [Podman Desktop](https://podman-desktop.io) [AI Lab Extension](https://github.com/containers/podman-desktop-extension-ai-lab) includes this recipe among others. To try it out, open `Recipes Catalog` -> `Object Detection` and follow the instructions to start the application.\n\n# Build the Application\n\nThe rest of this document will explain how to build and run the application from the terminal, and will go into greater detail on how each container in the application above is built, run, and  what purpose it serves in the overall application. All the Model Server elements of the recipe use a central Model Server [Makefile](../../../model_servers/common/Makefile.common) that includes variables populated with default values to simplify getting started. Currently we do not have a Makefile for the Application elements of the Recipe, but this coming soon, and will leverage the recipes common [Makefile](../../common/Makefile.common) to provide variable configuration and reasonable defaults to this Recipe's application.\n\n* [Download a model](#download-a-model)\n* [Build the Model Service](#build-the-model-service)\n* [Deploy the Model Service](#deploy-the-model-service)\n* [Build the AI Application](#build-the-ai-application)\n* [Deploy the AI Application](#deploy-the-ai-application)\n* [Interact with the AI Application](#interact-with-the-ai-application)\n\n## Download a model\n\nIf you are just getting started, we recommend using [facebook/detr-resnet-101](https://huggingface.co/facebook/detr-resnet-101).\nThis is a well performant model with an Apache-2.0 license.\nIt's simple to download a copy of the model from [huggingface.co](https://huggingface.co)\n\nYou can use the `download-model-facebook-detr-resnet-101` make target in the `model_servers/object_detection_python` directory to download and move the model into the models directory for you:\n\n```bash\n# from path model_servers/object_detection_python from repo containers/ai-lab-recipes\n make download-model-facebook-detr-resnet-101\n```\n\n## Build the Model Service\n\nThe You can build the Model Service from the [object_detection_python model-service directory](../../../model_servers/object_detection_python).\n\n```bash\n# from path model_servers/object_detection_python from repo containers/ai-lab-recipes\nmake build\n```\n\nCheckout the [Makefile](../../../model_servers/object_detection_python/Makefile) to get more details on different options for how to build.\n\n## Deploy the Model Service\n\nThe local Model Service relies on a volume mount to the localhost to access the model files. It also employs environment variables to dictate the model used and where its served. You can start your local Model Service using the following `make` command from the [`model_servers/object_detection_python`](../../../model_servers/object_detection_python) directory, which will be set with reasonable defaults:\n\n```bash\n# from path model_servers/object_detection_python from repo containers/ai-lab-recipes\nmake run\n```\n\nAs stated above, by default the model service will use [`facebook/detr-resnet-101`](https://huggingface.co/facebook/detr-resnet-101). However you can use other compatabale models. Simply pass the new `MODEL_NAME` and `MODEL_PATH` to the make command. Make sure the model is downloaded and exists in the [models directory](../../../models/):\n\n```bash\n# from path model_servers/object_detection_python from repo containers/ai-lab-recipes\nmake MODEL_NAME=facebook/detr-resnet-50 MODEL_PATH=/models/facebook/detr-resnet-50 run\n```\n\n## Build the AI Application\n\nNow that the Model Service is running we want to build and deploy our AI Application. Use the provided Containerfile to build the AI Application\nimage from the [`object_detection/`](./) recipe directory.\n\n```bash\n# from path recipes/computer_vision/object_detection from repo containers/ai-lab-recipes\npodman build -t object_detection_client .\n```\n\n### Deploy the AI Application\n\nMake sure the Model Service is up and running before starting this container image.\nWhen starting the AI Application container image we need to direct it to the correct `MODEL_ENDPOINT`.\nThis could be any appropriately hosted Model Service (running locally or in the cloud) using a compatible API.\nThe following Podman command can be used to run your AI Application:\n\n```bash\npodman run -p 8501:8501 -e MODEL_ENDPOINT=http://10.88.0.1:8000/detection object_detection_client\n```\n\n### Interact with the AI Application\n\nOnce the client is up a running, you should be able to access it at `http://localhost:8501`. From here you can upload images from your local machine and detect objects in the image as shown below. \n\nBy using this recipe and getting this starting point established,\nusers should now have an easier time customizing and building their own AI enabled applications.\n",
       "models": [
         "hf.facebook.detr-resnet-101"
-      ]
+      ],
+      "backend": "none"
     }
   ],
   "models": [
@@ -124,7 +129,8 @@
       "properties": {
         "chatFormat": "openchat"
       },
-      "sha256": "6adeaad8c048b35ea54562c55e454cc32c63118a32c7b8152cf706b290611487"
+      "sha256": "6adeaad8c048b35ea54562c55e454cc32c63118a32c7b8152cf706b290611487",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.instructlab.merlinite-7b-lab-GGUF",
@@ -138,7 +144,8 @@
       "properties": {
         "chatFormat": "openchat"
       },
-      "sha256": "9ca044d727db34750e1aeb04e3b18c3cf4a8c064a9ac96cf00448c506631d16c"
+      "sha256": "9ca044d727db34750e1aeb04e3b18c3cf4a8c064a9ac96cf00448c506631d16c",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.TheBloke.mistral-7b-instruct-v0.2.Q4_K_M",
@@ -149,7 +156,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
       "memory": 4370129224,
-      "sha256": "3e0039fd0273fcbebb49228943b17831aadd55cbcbf56f0af00499be2040ccf9"
+      "sha256": "3e0039fd0273fcbebb49228943b17831aadd55cbcbf56f0af00499be2040ccf9",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.NousResearch.Hermes-2-Pro-Mistral-7B.Q4_K_M",
@@ -160,7 +168,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/resolve/main/Hermes-2-Pro-Mistral-7B.Q4_K_M.gguf",
       "memory": 4370129224,
-      "sha256": "e1e4253b94e3c04c7b6544250f29ad864a56eb2126e61eb440991a8284453674"
+      "sha256": "e1e4253b94e3c04c7b6544250f29ad864a56eb2126e61eb440991a8284453674",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.ibm.merlinite-7b-Q4_K_M",
@@ -174,7 +183,8 @@
       "properties": {
         "chatFormat": "openchat"
       },
-      "sha256": "94f3a16321c9604ca22e970f3b89931ae5b4bbfd4c5d996e2bb606c506590666"
+      "sha256": "94f3a16321c9604ca22e970f3b89931ae5b4bbfd4c5d996e2bb606c506590666",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.TheBloke.mistral-7b-codealpaca-lora.Q4_K_M",
@@ -185,7 +195,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/TheBloke/Mistral-7B-codealpaca-lora-GGUF/resolve/main/mistral-7b-codealpaca-lora.Q4_K_M.gguf",
       "memory": 4370129224,
-      "sha256": "69c07f27f682ca8da59fcd8a981335876882a2577f0f9df51b49cf6b97fd470f"
+      "sha256": "69c07f27f682ca8da59fcd8a981335876882a2577f0f9df51b49cf6b97fd470f",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.TheBloke.mistral-7b-code-16k-qlora.Q4_K_M",
@@ -196,7 +207,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/TheBloke/Mistral-7B-Code-16K-qlora-GGUF/resolve/main/mistral-7b-code-16k-qlora.Q4_K_M.gguf",
       "memory": 4370129224,
-      "sha256": "0f3c9aced2de6caad52323fea5a92a22fba0b4efddb564fda7a3071e0614443f"
+      "sha256": "0f3c9aced2de6caad52323fea5a92a22fba0b4efddb564fda7a3071e0614443f",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.froggeric.Cerebrum-1.0-7b-Q4_KS",
@@ -210,7 +222,8 @@
       "properties": {
         "chatFormat": "openchat"
       },
-      "sha256": "98861462a0a80e08704631df23ffee860bd5634551c48d069d4daa3c8931bc52"
+      "sha256": "98861462a0a80e08704631df23ffee860bd5634551c48d069d4daa3c8931bc52",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.TheBloke.openchat-3.5-0106.Q4_K_M",
@@ -221,7 +234,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/TheBloke/openchat-3.5-0106-GGUF/resolve/main/openchat-3.5-0106.Q4_K_M.gguf",
       "memory": 4370129224,
-      "sha256": "49190d4d039e6dea463e567ebce707eb001648f4ba01e43eb7fa88d9975fc0ce"
+      "sha256": "49190d4d039e6dea463e567ebce707eb001648f4ba01e43eb7fa88d9975fc0ce",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.TheBloke.mistral-7b-openorca.Q4_K_M",
@@ -232,7 +246,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/TheBloke/Mistral-7B-OpenOrca-GGUF/resolve/main/mistral-7b-openorca.Q4_K_M.gguf",
       "memory": 4370129224,
-      "sha256": "83967e58c10c25fbe9d358b6d9e9a8212ca8a292061110dcb68511d39133407b"
+      "sha256": "83967e58c10c25fbe9d358b6d9e9a8212ca8a292061110dcb68511d39133407b",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.MaziyarPanahi.phi-2.Q4_K_M",
@@ -243,7 +258,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/MaziyarPanahi/phi-2-GGUF/resolve/main/phi-2.Q4_K_M.gguf",
       "memory": 1739461755,
-      "sha256": "013e0e421b70dc169adb0c0010171202371e907e5f648084e4ddc8ad9985127a"
+      "sha256": "013e0e421b70dc169adb0c0010171202371e907e5f648084e4ddc8ad9985127a",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.llmware.dragon-mistral-7b-q4_k_m",
@@ -257,7 +273,8 @@
       "properties": {
         "chatFormat": "openchat"
       },
-      "sha256": "1d8f463c4917480b770db5d7921f3d144471891c45a0d25ba3ab3dd753ec620f"
+      "sha256": "1d8f463c4917480b770db5d7921f3d144471891c45a0d25ba3ab3dd753ec620f",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.MaziyarPanahi.MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M",
@@ -268,7 +285,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/MaziyarPanahi/MixTAO-7Bx2-MoE-Instruct-v7.0-GGUF/resolve/main/MixTAO-7Bx2-MoE-Instruct-v7.0.Q4_K_M.gguf",
       "memory": 7784628224,
-      "sha256": "f5fcf04c77a5b69ae37791b48df90daa553e40b5a39efc9068258bedef373182"
+      "sha256": "f5fcf04c77a5b69ae37791b48df90daa553e40b5a39efc9068258bedef373182",
+      "backend": "llama-cpp"
     },
     {
       "id": "hf.ggerganov.whisper.cpp",
@@ -279,7 +297,8 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin",
       "memory": 487010000,
-      "sha256": "1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b"
+      "sha256": "1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b",
+      "backend": "whisper-cpp"
     },
     {
       "id": "hf.facebook.detr-resnet-101",
@@ -293,7 +312,8 @@
       "properties": {
         "name": "facebook/detr-resnet-101"
       },
-      "sha256": "0943b5a9085a95a0e3ecc1c99a7db0451ecb9d79f4dcb543b0939c1a12481a5d"
+      "sha256": "0943b5a9085a95a0e3ecc1c99a7db0451ecb9d79f4dcb543b0939c1a12481a5d",
+      "backend": "none"
     }
   ],
   "categories": [

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -33,7 +33,6 @@ import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { Messages } from '@shared/Messages';
 import type { InferenceProviderRegistry } from '../../registries/InferenceProviderRegistry';
 import type { InferenceProvider } from '../../workers/provider/InferenceProvider';
-import { InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('@podman-desktop/api', async () => {
   return {

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -33,6 +33,7 @@ import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { Messages } from '@shared/Messages';
 import type { InferenceProviderRegistry } from '../../registries/InferenceProviderRegistry';
 import type { InferenceProvider } from '../../workers/provider/InferenceProvider';
+import { InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
@@ -82,6 +83,7 @@ const taskRegistryMock = {
 
 const inferenceProviderRegistryMock = {
   getAll: vi.fn(),
+  getByType: vi.fn(),
   get: vi.fn(),
 } as unknown as InferenceProviderRegistry;
 
@@ -174,6 +176,7 @@ describe('init Inference Manager', () => {
         health: undefined,
         models: [],
         status: 'running',
+        type: expect.anything(),
       },
     ]);
   });
@@ -213,7 +216,7 @@ describe('init Inference Manager', () => {
  */
 describe('Create Inference Server', () => {
   test('no provider available should throw an error', async () => {
-    vi.mocked(inferenceProviderRegistryMock.getAll).mockReturnValue([]);
+    vi.mocked(inferenceProviderRegistryMock.getByType).mockReturnValue([]);
 
     const inferenceManager = await getInitializedInferenceManager();
     await expect(
@@ -548,6 +551,7 @@ describe('transition statuses', () => {
           models: expect.anything(),
           health: undefined,
           status: 'stopping',
+          type: expect.anything(),
         },
       ],
     });
@@ -562,6 +566,7 @@ describe('transition statuses', () => {
           models: expect.anything(),
           health: undefined,
           status: 'stopped',
+          type: expect.anything(),
         },
       ],
     });
@@ -596,6 +601,7 @@ describe('transition statuses', () => {
           models: expect.anything(),
           health: undefined,
           status: 'deleting',
+          type: expect.anything(),
         },
       ],
     });
@@ -631,6 +637,7 @@ describe('transition statuses', () => {
           models: expect.anything(),
           health: undefined,
           status: 'starting',
+          type: expect.anything(),
         },
       ],
     });
@@ -645,6 +652,7 @@ describe('transition statuses', () => {
           models: expect.anything(),
           health: undefined,
           status: 'running',
+          type: expect.anything(),
         },
       ],
     });

--- a/packages/backend/src/registries/InferenceProviderRegistry.ts
+++ b/packages/backend/src/registries/InferenceProviderRegistry.ts
@@ -19,6 +19,7 @@ import { Publisher } from '../utils/Publisher';
 import type { InferenceProvider } from '../workers/provider/InferenceProvider';
 import { Disposable, type Webview } from '@podman-desktop/api';
 import { Messages } from '@shared/Messages';
+import type { InferenceType } from '@shared/src/models/IInference';
 
 export class InferenceProviderRegistry extends Publisher<string[]> {
   #providers: Map<string, InferenceProvider>;
@@ -42,6 +43,10 @@ export class InferenceProviderRegistry extends Publisher<string[]> {
 
   getAll(): InferenceProvider[] {
     return Array.from(this.#providers.values());
+  }
+
+  getByType(type: InferenceType): InferenceProvider[] {
+    return Array.from(this.#providers.values()).filter(provider => provider.type === type);
   }
 
   get(name: string): InferenceProvider {

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -19,7 +19,7 @@ import { vi, test, expect, describe, beforeEach } from 'vitest';
 import { withDefaultConfiguration, isTransitioning, parseInferenceType, getInferenceType } from './inferenceUtils';
 import { getFreeRandomPort } from './ports';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
-import type { InferenceServer, InferenceServerStatus} from '@shared/src/models/IInference';
+import type { InferenceServer, InferenceServerStatus } from '@shared/src/models/IInference';
 import { InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('./ports', () => ({

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -26,7 +26,8 @@ import {
 } from '@podman-desktop/api';
 import type { CreationInferenceServerOptions, InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { getFreeRandomPort } from './ports';
-import type { InferenceServer } from '@shared/src/models/IInference';
+import { type InferenceServer, InferenceType } from '@shared/src/models/IInference';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export const LABEL_INFERENCE_SERVER: string = 'ai-lab-inference-server';
 
@@ -114,4 +115,26 @@ export function isTransitioning(server: InferenceServer): boolean {
   }
 
   return false;
+}
+
+/**
+ * Given a primitive (string) return the InferenceType enum
+ * @param value
+ */
+export function parseInferenceType(value: string | undefined): InferenceType {
+  if (!value) return InferenceType.NONE;
+  return (Object.values(InferenceType) as unknown as string[]).includes(value)
+    ? (value as unknown as InferenceType)
+    : InferenceType.NONE;
+}
+
+/**
+ * Let's collect the backend required by the provided models
+ * we only support one backend for all the models, if multiple are provided, NONE will be return
+ */
+export function getInferenceType(modelsInfo: ModelInfo[]): InferenceType {
+  const backends: InferenceType[] = modelsInfo.map(info => parseInferenceType(info.backend));
+  if (new Set(backends).size !== 1) return InferenceType.NONE;
+
+  return backends[0];
 }

--- a/packages/backend/src/workers/provider/InferenceProvider.spec.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.spec.ts
@@ -16,19 +16,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { vi, describe, test, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { type BetterContainerCreateResult, InferenceProvider } from './InferenceProvider';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
-import { containerEngine } from '@podman-desktop/api';
 import type {
+  ContainerCreateOptions,
   ContainerProviderConnection,
   ImageInfo,
   ProviderContainerConnection,
-  ContainerCreateOptions,
 } from '@podman-desktop/api';
+import { containerEngine } from '@podman-desktop/api';
 import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
 import type { TaskState } from '@shared/src/models/ITask';
+import { InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('../../utils/inferenceUtils', () => ({
   getProviderContainerConnection: vi.fn(),
@@ -61,10 +62,8 @@ const taskRegistry: TaskRegistry = {
 } as unknown as TaskRegistry;
 
 class TestInferenceProvider extends InferenceProvider {
-  name: string = 'test-inference-provider';
-
   constructor() {
-    super(taskRegistry);
+    super(taskRegistry, InferenceType.NONE, 'test-inference-provider');
   }
 
   enabled(): boolean {

--- a/packages/backend/src/workers/provider/InferenceProvider.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.ts
@@ -27,15 +27,25 @@ import type { InferenceServerConfig } from '@shared/src/models/InferenceServerCo
 import type { IWorker } from '../IWorker';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
+import type { InferenceType } from '@shared/src/models/IInference';
 
 export type BetterContainerCreateResult = ContainerCreateResult & { engineId: string };
 
 export abstract class InferenceProvider
   implements IWorker<InferenceServerConfig, BetterContainerCreateResult>, Disposable
 {
-  protected constructor(private taskRegistry: TaskRegistry) {}
+  readonly type: InferenceType;
+  readonly name: string;
 
-  abstract name: string;
+  protected constructor(
+    private taskRegistry: TaskRegistry,
+    type: InferenceType,
+    name: string,
+  ) {
+    this.type = type;
+    this.name = name;
+  }
+
   abstract enabled(): boolean;
   abstract perform(config: InferenceServerConfig): Promise<BetterContainerCreateResult>;
   abstract dispose(): void;

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -22,6 +22,7 @@ import { getModelPropertiesForEnvironment } from '../../utils/modelsUtils';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
 import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
+import { InferenceType } from '@shared/src/models/IInference';
 
 export const LLAMA_CPP_INFERENCE_IMAGE =
   'ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat:0.3.2';
@@ -29,11 +30,8 @@ export const LLAMA_CPP_INFERENCE_IMAGE =
 export const SECOND: number = 1_000_000_000;
 
 export class LlamaCppPython extends InferenceProvider {
-  name: string;
-
   constructor(taskRegistry: TaskRegistry) {
-    super(taskRegistry);
-    this.name = 'llama-cpp';
+    super(taskRegistry, InferenceType.LLAMA_CPP, 'LLama-cpp (CPU)');
   }
 
   dispose() {}

--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { vi, test, expect, beforeEach } from 'vitest';
-import { screen, render, fireEvent } from '@testing-library/svelte';
-import type { InferenceServer } from '@shared/src/models/IInference';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { type InferenceServer, InferenceType } from '@shared/src/models/IInference';
 import InferenceServerDetails from '/@/pages/InferenceServerDetails.svelte';
 import type { Language } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
@@ -112,6 +112,7 @@ beforeEach(() => {
         containerId: 'dummyContainerId',
         engineId: 'dummyEngineId',
       },
+      type: InferenceType.NONE,
     } as InferenceServer,
   ]);
 });

--- a/packages/frontend/src/pages/InferenceServers.spec.ts
+++ b/packages/frontend/src/pages/InferenceServers.spec.ts
@@ -20,7 +20,7 @@ import '@testing-library/jest-dom/vitest';
 import { vi, test, expect, beforeEach } from 'vitest';
 import { screen, render, fireEvent } from '@testing-library/svelte';
 import InferenceServers from '/@/pages/InferenceServers.svelte';
-import type { InferenceServer } from '@shared/src/models/IInference';
+import { type InferenceServer, InferenceType } from '@shared/src/models/IInference';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
 
@@ -70,6 +70,7 @@ test('store with inference server should display the table', async () => {
       connection: { port: 8888 },
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+      type: InferenceType.NONE,
     },
   ] as InferenceServer[]);
   render(InferenceServers);
@@ -98,6 +99,7 @@ test('table should have checkbox', async () => {
       connection: { port: 8888 },
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+      type: InferenceType.NONE,
     },
   ] as InferenceServer[]);
   render(InferenceServers);
@@ -117,6 +119,7 @@ test('delete button should delete selected item', async () => {
       connection: { port: 8888 },
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+      type: InferenceType.NONE,
     },
   ] as InferenceServer[]);
   render(InferenceServers);

--- a/packages/shared/src/models/IInference.ts
+++ b/packages/shared/src/models/IInference.ts
@@ -17,6 +17,12 @@
  ***********************************************************************/
 import type { ModelInfo } from './IModelInfo';
 
+export enum InferenceType {
+  LLAMA_CPP = 'llamacpp',
+  WHISPER_CPP = 'whispercpp',
+  NONE = 'none',
+}
+
 export type InferenceServerStatus = 'stopped' | 'running' | 'deleting' | 'stopping' | 'error' | 'starting';
 
 export interface InferenceServer {
@@ -55,4 +61,8 @@ export interface InferenceServer {
    * Exit code
    */
   exit?: number;
+  /**
+   * The type of inference server (aka backend)
+   */
+  type: InferenceType;
 }

--- a/packages/shared/src/models/IModelInfo.ts
+++ b/packages/shared/src/models/IModelInfo.ts
@@ -33,6 +33,11 @@ export interface ModelInfo {
     [key: string]: string;
   };
   sha256?: string;
+  /**
+   * The backend field aims to target which inference
+   * server the model requires
+   */
+  backend?: string;
 }
 
 export type ModelCheckerContext = 'inference' | 'recipe';

--- a/packages/shared/src/models/IRecipe.ts
+++ b/packages/shared/src/models/IRecipe.ts
@@ -27,4 +27,9 @@ export interface Recipe {
   readme: string;
   basedir?: string;
   models?: string[];
+  /**
+   * The backend field aims to target which inference
+   * server the recipe requires
+   */
+  backend?: string;
 }


### PR DESCRIPTION
### What does this PR do?

Adding the `InferenceType` enum, allowing `InferenceProvider` (see https://github.com/containers/podman-desktop-extension-ai-lab/pull/1161) to precise their _type_, in this context, it could be `llama-cpp`, `whisper-cpp` etc.

#### Notable change

- Adding new enum `InferenceType`
- Adding optional `backend` string property to `ModelInfo` interface
- Adding optional `backend` string property to `Recipe` interface
- adding `getByType` method to the `InferenceProviderRegistry`
- InferenceServer will check the `backend` property of models to select the `InferenceProvider`
- Improving `InferenceProvider` constructor

### Screenshot / video of UI

N/A no visual change

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1181
Part of https://github.com/containers/podman-desktop-extension-ai-lab/issues/1111

### How to test this PR?

- [x] Unit tests has been provided

#### Side effect 

Now, trying to start an InferenceServer with the WhisperModel will raise an error as we do not have any InferenceProvider for it. Same for `facebook/detr-resnet-101` model.

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/df40f94c-1fa0-4c60-ac19-d310624fb397)

ℹ️ This is good, this is what we expect !