### PR TITLE
hotfix: enum inference type wrong string value

### DIFF
--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -91,8 +91,8 @@ describe('parseInferenceType', () => {
     expect(parseInferenceType(undefined)).toBe(InferenceType.NONE);
   });
 
-  test('llamacpp should return the proper InferenceType.LLAMA_CPP', () => {
-    expect(parseInferenceType('llamacpp')).toBe(InferenceType.LLAMA_CPP);
+  test('llama-cpp should return the proper InferenceType.LLAMA_CPP', () => {
+    expect(parseInferenceType('llama-cpp')).toBe(InferenceType.LLAMA_CPP);
   });
 });
 
@@ -115,7 +115,7 @@ describe('getInferenceType', () => {
     expect(
       getInferenceType([
         {
-          backend: 'llamacpp',
+          backend: 'llama-cpp',
         } as unknown as ModelInfo,
       ]),
     ).toBe(InferenceType.LLAMA_CPP);
@@ -125,10 +125,10 @@ describe('getInferenceType', () => {
     expect(
       getInferenceType([
         {
-          backend: 'llamacpp',
+          backend: 'llama-cpp',
         },
         {
-          backend: 'llamacpp',
+          backend: 'llama-cpp',
         },
       ] as unknown as ModelInfo[]),
     ).toBe(InferenceType.LLAMA_CPP);
@@ -138,10 +138,10 @@ describe('getInferenceType', () => {
     expect(
       getInferenceType([
         {
-          backend: 'llamacpp',
+          backend: 'llama-cpp',
         },
         {
-          backend: 'whispercpp',
+          backend: 'whisper-cpp',
         },
       ] as unknown as ModelInfo[]),
     ).toBe(InferenceType.NONE);

--- a/packages/shared/src/models/IInference.ts
+++ b/packages/shared/src/models/IInference.ts
@@ -18,8 +18,8 @@
 import type { ModelInfo } from './IModelInfo';
 
 export enum InferenceType {
-  LLAMA_CPP = 'llamacpp',
-  WHISPER_CPP = 'whispercpp',
+  LLAMA_CPP = 'llama-cpp',
+  WHISPER_CPP = 'whisper-cpp',
   NONE = 'none',
 }
 


### PR DESCRIPTION
### What does this PR do?

In the `ai.json` we used `llama-cpp` with a `-` but in the InferenceType we are missing it.

https://github.com/containers/podman-desktop-extension-ai-lab/blob/5ddb5c548173f8b2b29787fb7f1740f12df49f2a/packages/backend/src/assets/ai.json#L28

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- Being able to start any model from the catalog