### PR TITLE
fix: concurrency issue between catalog and inference manager

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -33,6 +33,7 @@ import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { Messages } from '@shared/Messages';
 import type { InferenceProviderRegistry } from '../../registries/InferenceProviderRegistry';
 import type { InferenceProvider } from '../../workers/provider/InferenceProvider';
+import type { CatalogManager } from '../catalogManager';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
@@ -86,7 +87,15 @@ const inferenceProviderRegistryMock = {
   get: vi.fn(),
 } as unknown as InferenceProviderRegistry;
 
+const catalogManager = {
+  onCatalogUpdate: vi.fn(),
+} as unknown as CatalogManager;
+
 const getInitializedInferenceManager = async (): Promise<InferenceManager> => {
+  vi.mocked(catalogManager.onCatalogUpdate).mockImplementation(fn => {
+    fn();
+    return { dispose: vi.fn() };
+  });
   const manager = new InferenceManager(
     webviewMock,
     containerRegistryMock,
@@ -95,6 +104,7 @@ const getInitializedInferenceManager = async (): Promise<InferenceManager> => {
     telemetryMock,
     taskRegistryMock,
     inferenceProviderRegistryMock,
+    catalogManager,
   );
   manager.init();
   await vi.waitUntil(manager.isInitialize.bind(manager), {

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -248,6 +248,7 @@ export class Studio {
       this.#telemetry,
       this.#taskRegistry,
       this.#inferenceProviderRegistry,
+      this.#catalogManager,
     );
     this.#inferenceManager.init();
     this.#extensionContext.subscriptions.push(this.#inferenceManager);


### PR DESCRIPTION
### What does this PR do?

To fix the concurrency issue, (Inference Manager getting the containers list before the catalog has loaded the models from the files), I changed the InferenceManager to refresh the inferenceServers when the catalog is updated. Making the InferenceServer event base for its initialization.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1215

### How to test this PR?

- [x] unit tests has been added to ensure expected behaviour 