### PR TITLE
fix: invalid SHA256 for facebook/detr-resnet-101 model

### DIFF
--- a/packages/backend/src/assets/ai.json
+++ b/packages/backend/src/assets/ai.json
@@ -312,7 +312,7 @@
       "properties": {
         "name": "facebook/detr-resnet-101"
       },
-      "sha256": "0943b5a9085a95a0e3ecc1c99a7db0451ecb9d79f4dcb543b0939c1a12481a5d",
+      "sha256": "893ae2442b36b2e8e1134ccbf8c0d9bd670648d0964509202ab30c9cbb3d2114",
       "backend": "none"
     }
   ],


### PR DESCRIPTION
Fixes #1187

### What does this PR do?

Use SHA256 in catalog for facebook/detr-resnet-101 model

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#1187 

### How to test this PR?

Download the model