### PR TITLE
Light mode for playgrounds page

### DIFF
--- a/packages/frontend/src/lib/table/playground/PlaygroundColumnModel.svelte
+++ b/packages/frontend/src/lib/table/playground/PlaygroundColumnModel.svelte
@@ -6,6 +6,6 @@ import { catalog } from '/@/stores/catalog';
 $: name = $catalog.models.find(r => r.id === object.modelId)?.name;
 </script>
 
-<div class="text-sm text-gray-300 overflow-hidden text-ellipsis">
+<div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
   {name}
 </div>

--- a/packages/frontend/src/lib/table/playground/PlaygroundColumnName.svelte
+++ b/packages/frontend/src/lib/table/playground/PlaygroundColumnName.svelte
@@ -9,7 +9,7 @@ function openDetails() {
 </script>
 
 <button on:click="{() => openDetails()}">
-  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis">
+  <div class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
     {object.name}
   </div>
 </button>

--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -37,28 +37,30 @@ const openServicesPage = () => {
           {#if $conversations.length > 0}
             <Table kind="playground" data="{$conversations}" columns="{columns}" row="{row}"></Table>
           {:else}
-            <div role="status">
-              There is no playground environment. You can <a
-                href="{'javascript:void(0);'}"
-                class="underline"
-                role="button"
-                title="Create a new Playground environment"
-                on:click="{createNewPlayground}">create one now</a
-              >.
+            <div class="text-[var(--pd-details-body-text)]">
+              <div role="status">
+                There is no playground environment. You can <a
+                  href="{'javascript:void(0);'}"
+                  class="underline"
+                  role="button"
+                  title="Create a new Playground environment"
+                  on:click="{createNewPlayground}">create one now</a
+                >.
+              </div>
+              <p>
+                Playground environments allow for experimenting with available models in a local environment. An
+                intuitive user prompt helps in exploring the capabilities and accuracy of various models and aids in
+                finding the best model for the use case at hand.
+              </p>
+              <p>
+                Once started, each playground ships with a generic chat client to interact with the model service. The <button
+                  class="underline"
+                  title="Open the Services page"
+                  on:click="{openServicesPage}">Services</button>
+                page allows for accessing running model services and provides further details and code snippets to interact
+                with them.
+              </p>
             </div>
-            <p>
-              Playground environments allow for experimenting with available models in a local environment. An intuitive
-              user prompt helps in exploring the capabilities and accuracy of various models and aids in finding the
-              best model for the use case at hand.
-            </p>
-            <p>
-              Once started, each playground ships with a generic chat client to interact with the model service. The <button
-                class="underline"
-                title="Open the Services page"
-                on:click="{openServicesPage}">Services</button>
-              page allows for accessing running model services and provides further details and code snippets to interact
-              with them.
-            </p>
           {/if}
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?

Light mode for playgrounds page

~~Needs https://github.com/containers/podman-desktop-extension-ai-lab/pull/1246 to get the good background~~

Actions depend on #964

### Screenshot / video of UI
![playgrounds-light-2](https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/c4d80962-cf1a-4100-aabc-05670be59e0b)
![playground-light-1](https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/a45cae5c-b14b-4f70-972f-63f24e7b37e1)


### What issues does this PR fix or reference?

Fixes #1256 

### How to test this PR?

<!-- Please explain steps to reproduce -->