### PR TITLE
Light mode for AI apps list

### DIFF
--- a/packages/frontend/src/lib/table/application/ColumnAge.svelte
+++ b/packages/frontend/src/lib/table/application/ColumnAge.svelte
@@ -6,6 +6,6 @@ import type { ApplicationState } from '@shared/src/models/IApplicationState';
 export let object: ApplicationState;
 </script>
 
-<div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
+<div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
   {humanizeAge(moment(object.pod.Created).unix())}
 </div>

--- a/packages/frontend/src/lib/table/application/ColumnModel.svelte
+++ b/packages/frontend/src/lib/table/application/ColumnModel.svelte
@@ -9,10 +9,10 @@ $: name = $catalog.models.find(r => r.id === object.modelId)?.name;
 </script>
 
 <div class="flex flex-col">
-  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis">
+  <div class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
     {name}
   </div>
-  <div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
+  <div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
     {displayPorts(object.modelPorts)}
   </div>
 </div>

--- a/packages/frontend/src/lib/table/application/ColumnPod.svelte
+++ b/packages/frontend/src/lib/table/application/ColumnPod.svelte
@@ -4,6 +4,6 @@ import type { ApplicationState } from '@shared/src/models/IApplicationState';
 export let object: ApplicationState;
 </script>
 
-<div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
+<div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
   {object.pod.Name}
 </div>

--- a/packages/frontend/src/lib/table/application/ColumnRecipe.svelte
+++ b/packages/frontend/src/lib/table/application/ColumnRecipe.svelte
@@ -10,10 +10,10 @@ $: name = $catalog.recipes.find(r => r.id === object.recipeId)?.name;
 </script>
 
 <div class="flex flex-col">
-  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis">
+  <div class="text-sm text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
     {name}
   </div>
-  <div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
+  <div class="text-sm text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
     {displayPorts(object.appPorts)}
   </div>
 </div>

--- a/packages/frontend/src/pages/Applications.svelte
+++ b/packages/frontend/src/pages/Applications.svelte
@@ -46,7 +46,7 @@ onMount(() => {
         {#if data?.length > 0}
           <Table kind="AI App" data="{data}" columns="{columns}" row="{row}"></Table>
         {:else}
-          <div class="w-full flex items-center justify-center">
+          <div class="w-full flex items-center justify-center text-[var(--pd-content-text)]">
             <div role="status">
               There is no AI App running. You may run a new AI App via the <a
                 href="{'javascript:void(0);'}"


### PR DESCRIPTION
### What does this PR do?

Light mode for AI apps list

~~Needs https://github.com/containers/podman-desktop-extension-ai-lab/pull/1246 to get the good background~~

Actions depend on https://github.com/containers/podman-desktop-extension-ai-lab/issues/964

### Screenshot / video of UI

![apps-light](https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/7e8199da-afbd-4436-be00-0a3ac7ae5b3a)
![apps-dark](https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/dd8417db-77ca-4027-870b-9fd395de1d9c)


### What issues does this PR fix or reference?

Fixes #1263 

### How to test this PR?

<!-- Please explain steps to reproduce -->