### PR TITLE
Light mode for Services page

### DIFF
--- a/packages/frontend/src/lib/table/service/ServiceColumnModelName.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceColumnModelName.svelte
@@ -4,13 +4,13 @@ export let object: InferenceServer;
 </script>
 
 {#if object.models.length === 1}
-  <span class="text-sm text-gray-700">
+  <span class="text-sm text-[var(--pd-table-body-text)]">
     {object.models[0].name}
   </span>
 {:else}
   <ul>
     {#each object.models as model}
-      <li class="text-sm text-gray-700">{model.name}</li>
+      <li class="text-sm text-[var(--pd-table-body-text)]">{model.name}</li>
     {/each}
   </ul>
 {/if}

--- a/packages/frontend/src/lib/table/service/ServiceColumnName.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceColumnName.svelte
@@ -10,7 +10,7 @@ function openDetails() {
 
 <button
   title="Open service details"
-  class="text-sm text-gray-700 w-full text-ellipsis overflow-hidden"
+  class="text-sm text-[var(--pd-table-body-text-highlight)] w-full text-ellipsis overflow-hidden"
   on:click="{() => openDetails()}">
   {object.container.containerId}
 </button>

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -65,21 +65,23 @@ function createNewService() {
               row="{row}"
               bind:selectedItemsNumber="{selectedItemsNumber}" />
           {:else}
-            <div role="status">
-              There is no model service. You can <a
-                href="{'javascript:void(0);'}"
-                class="underline"
-                role="button"
-                title="Create a new Model Service"
-                on:click="{createNewService}">create one now</a
-              >.
+            <div class="text-[var(--pd-details-body-text)]">
+              <div role="status">
+                There is no model service. You can <a
+                  href="{'javascript:void(0);'}"
+                  class="underline"
+                  role="button"
+                  title="Create a new Model Service"
+                  on:click="{createNewService}">create one now</a
+                >.
+              </div>
+              <p>
+                A model service offers a configurable endpoint via an OpenAI-compatible web server, facilitating a
+                seamless integration of AI capabilities into existing applications. Upon initialization, effortlessly
+                access detailed service information and generate code snippets in multiple programming languages to ease
+                application integration.
+              </p>
             </div>
-            <p>
-              A model service offers a configurable endpoint via an OpenAI-compatible web server, facilitating a
-              seamless integration of AI capabilities into existing applications. Upon initialization, effortlessly
-              access detailed service information and generate code snippets in multiple programming languages to ease
-              application integration.
-            </p>
           {/if}
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?

Light mode for Services page

~~Needs https://github.com/containers/podman-desktop-extension-ai-lab/pull/1246 to get the good background~~

Actions depend on https://github.com/containers/podman-desktop-extension-ai-lab/issues/964

StatusIcon depend on #1271

### Screenshot / video of UI
![services-empty-light](https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/f2fa51f6-241c-4af4-a0f5-b0af1fb8dc57)
![services-empty-dark](https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/7db1e065-d1fa-4f1c-ab73-da44a83d35a5)
![services-dark](https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/1e11df5d-b220-4e19-b656-a04574483269)
![services-light](https://github.com/containers/podman-desktop-extension-ai-lab/assets/9973512/202a1fb4-cd35-4255-a55a-df60d3e6b93f)


### What issues does this PR fix or reference?

Fixes #1270 

### How to test this PR?

<!-- Please explain steps to reproduce -->