### PR TITLE
feat: creating extension configuration registry

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,13 +19,6 @@
           "format": "folder",
           "default": "",
           "description": "Custom path where to download models. Note: The extension must be restarted for changes to take effect. (Default is blank)"
-        },
-        "ai-lab.experimentalGPU": {
-          "type": "boolean",
-          "default": false,
-          "hidden": true,
-          "description": "Experimental GPU support for inference servers",
-          "when": "isWindows"
         }
       }
     },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,6 +19,13 @@
           "format": "folder",
           "default": "",
           "description": "Custom path where to download models. Note: The extension must be restarted for changes to take effect. (Default is blank)"
+        },
+        "ai-lab.experimentalGPU": {
+          "type": "boolean",
+          "default": false,
+          "hidden": true,
+          "description": "Experimental GPU support for inference servers",
+          "when": "isWindows"
         }
       }
     },

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -400,7 +400,7 @@ test('deleteModel deletes the model folder', async () => {
   if (process.platform === 'win32') {
     modelsDir = 'C:\\home\\user\\aistudio\\models';
   } else {
-    modelsDir = '/home/user/aistudio/';
+    modelsDir = '/home/user/aistudio/models';
   }
   const now = new Date();
   mockFiles(now);

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -22,7 +22,7 @@ import fs, { type Stats, type PathLike } from 'node:fs';
 import path from 'node:path';
 import { ModelsManager } from './modelsManager';
 import { env, process as coreProcess, Disposable } from '@podman-desktop/api';
-import type { Configuration, RunResult, TelemetryLogger, Webview } from '@podman-desktop/api';
+import type { RunResult, TelemetryLogger, Webview } from '@podman-desktop/api';
 import type { CatalogManager, catalogUpdateHandle } from './catalogManager';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import * as utils from '../utils/utils';
@@ -50,18 +50,8 @@ vi.mock('../utils/podman', () => ({
   getPodmanCli: mocks.getPodmanCliMock,
 }));
 
-const getConfigurationMock = vi.fn().mockReturnValue('');
-const config: Configuration = {
-  get: getConfigurationMock,
-  has: () => true,
-  update: () => Promise.resolve(),
-};
-
 vi.mock('@podman-desktop/api', () => {
   return {
-    configuration: {
-      getConfiguration: (): Configuration => config,
-    },
     Disposable: {
       create: vi.fn(),
     },
@@ -165,14 +155,14 @@ function mockFiles(now: Date) {
 test('getModelsInfo should get models in local directory', async () => {
   const now = new Date();
   mockFiles(now);
-  let appdir: string;
+  let modelsDir: string;
   if (process.platform === 'win32') {
-    appdir = 'C:\\home\\user\\aistudio';
+    modelsDir = 'C:\\home\\user\\aistudio\\models';
   } else {
-    appdir = '/home/user/aistudio';
+    modelsDir = '/home/user/aistudio/models';
   }
   const manager = new ModelsManager(
-    appdir,
+    modelsDir,
     {
       postMessage: vi.fn(),
     } as unknown as Webview,
@@ -221,14 +211,14 @@ test('getModelsInfo should return an empty array if the models folder does not e
   vi.spyOn(os, 'homedir').mockReturnValue('/home/user');
   const existsSyncSpy = vi.spyOn(fs, 'existsSync');
   existsSyncSpy.mockReturnValue(false);
-  let appdir: string;
+  let modelsDir: string;
   if (process.platform === 'win32') {
-    appdir = 'C:\\home\\user\\aistudio';
+    modelsDir = 'C:\\home\\user\\aistudio\\models';
   } else {
-    appdir = '/home/user/aistudio';
+    modelsDir = '/home/user/aistudio/models';
   }
   const manager = new ModelsManager(
-    appdir,
+    modelsDir,
     {} as Webview,
     {
       getModels(): ModelInfo[] {
@@ -261,14 +251,14 @@ test('getLocalModelsFromDisk should return undefined Date and size when stat fai
     return { isDirectory: () => true } as Stats;
   });
 
-  let appdir: string;
+  let modelsDir: string;
   if (process.platform === 'win32') {
-    appdir = 'C:\\home\\user\\aistudio';
+    modelsDir = 'C:\\home\\user\\aistudio\\models';
   } else {
-    appdir = '/home/user/aistudio';
+    modelsDir = '/home/user/aistudio/models';
   }
   const manager = new ModelsManager(
-    appdir,
+    modelsDir,
     {
       postMessage: vi.fn(),
     } as unknown as Webview,
@@ -322,14 +312,14 @@ test('getLocalModelsFromDisk should skip folders containing tmp files', async ()
     }
   });
 
-  let appdir: string;
+  let modelsDir: string;
   if (process.platform === 'win32') {
-    appdir = 'C:\\home\\user\\aistudio';
+    modelsDir = 'C:\\home\\user\\aistudio\\models';
   } else {
-    appdir = '/home/user/aistudio';
+    modelsDir = '/home/user/aistudio/models';
   }
   const manager = new ModelsManager(
-    appdir,
+    modelsDir,
     {
       postMessage: vi.fn(),
     } as unknown as Webview,
@@ -360,14 +350,14 @@ test('loadLocalModels should post a message with the message on disk and on cata
   mockFiles(now);
 
   const postMessageMock = vi.fn();
-  let appdir: string;
+  let modelsDir: string;
   if (process.platform === 'win32') {
-    appdir = 'C:\\home\\user\\aistudio';
+    modelsDir = 'C:\\home\\user\\aistudio\\models';
   } else {
-    appdir = '/home/user/aistudio';
+    modelsDir = '/home/user/aistudio/models';
   }
   const manager = new ModelsManager(
-    appdir,
+    modelsDir,
     {
       postMessage: postMessageMock,
     } as unknown as Webview,
@@ -406,11 +396,11 @@ test('loadLocalModels should post a message with the message on disk and on cata
 });
 
 test('deleteModel deletes the model folder', async () => {
-  let appdir: string;
+  let modelsDir: string;
   if (process.platform === 'win32') {
-    appdir = 'C:\\home\\user\\aistudio';
+    modelsDir = 'C:\\home\\user\\aistudio\\models';
   } else {
-    appdir = '/home/user/aistudio';
+    modelsDir = '/home/user/aistudio/';
   }
   const now = new Date();
   mockFiles(now);
@@ -418,7 +408,7 @@ test('deleteModel deletes the model folder', async () => {
   rmSpy.mockResolvedValue();
   const postMessageMock = vi.fn();
   const manager = new ModelsManager(
-    appdir,
+    modelsDir,
     {
       postMessage: postMessageMock,
     } as unknown as Webview,
@@ -472,11 +462,11 @@ test('deleteModel deletes the model folder', async () => {
 
 describe('deleting models', () => {
   test('deleteModel fails to delete the model folder', async () => {
-    let appdir: string;
+    let modelsDir: string;
     if (process.platform === 'win32') {
-      appdir = 'C:\\home\\user\\aistudio';
+      modelsDir = 'C:\\home\\user\\aistudio\\models';
     } else {
-      appdir = '/home/user/aistudio';
+      modelsDir = '/home/user/aistudio/models';
     }
     const now = new Date();
     mockFiles(now);
@@ -484,7 +474,7 @@ describe('deleting models', () => {
     rmSpy.mockRejectedValue(new Error('failed'));
     const postMessageMock = vi.fn();
     const manager = new ModelsManager(
-      appdir,
+      modelsDir,
       {
         postMessage: postMessageMock,
       } as unknown as Webview,
@@ -844,42 +834,4 @@ describe('downloadModel', () => {
     expect(mocks.performDownloadMock).toHaveBeenCalledTimes(1);
     expect(mocks.onEventDownloadMock).toHaveBeenCalledTimes(2);
   });
-});
-
-test('download directory should be equals to the one set in the settings', async () => {
-  const now = new Date();
-  mockFiles(now);
-
-  getConfigurationMock.mockReturnValue('/my_custom_directory');
-  const postMessageMock = vi.fn();
-  let appdir: string;
-  if (process.platform === 'win32') {
-    appdir = 'C:\\home\\user\\aistudio';
-  } else {
-    appdir = '/home/user/aistudio';
-  }
-  const manager = new ModelsManager(
-    appdir,
-    {
-      postMessage: postMessageMock,
-    } as unknown as Webview,
-    {
-      getModels: () => {
-        return [
-          {
-            id: 'model-id-1',
-          },
-        ] as ModelInfo[];
-      },
-      onCatalogUpdate(_listener: catalogUpdateHandle): Disposable {
-        return Disposable.create(() => {});
-      },
-    } as CatalogManager,
-    telemetryLogger,
-    taskRegistry,
-    cancellationTokenRegistryMock,
-  );
-  manager.init();
-  const directory = manager.getModelsDirectory();
-  expect(directory).equals('/my_custom_directory');
 });

--- a/packages/backend/src/registries/ConfigurationRegistry.spec.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { vi, expect, test } from 'vitest';
+import { configuration, type Configuration, type Webview } from '@podman-desktop/api';
+import { ConfigurationRegistry } from './ConfigurationRegistry';
+
+const fakeConfiguration = {
+  get: vi.fn(),
+  has: vi.fn(),
+} as unknown as Configuration;
+
+const webviewMock = {
+  postMessage: vi.fn(),
+} as unknown as Webview;
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    configuration: {
+      getConfiguration: () => fakeConfiguration,
+      onDidChangeConfiguration: vi.fn(),
+    },
+  };
+});
+
+test('init should init listener', () => {
+  const registry = new ConfigurationRegistry(webviewMock, 'appdir');
+  vi.mocked(fakeConfiguration.has).mockReturnValue(true);
+
+  registry.init();
+  expect(configuration.onDidChangeConfiguration).toHaveBeenCalled();
+});
+
+test('dispose should dispose listener', () => {
+  const registry = new ConfigurationRegistry(webviewMock, 'appdir');
+  vi.mocked(fakeConfiguration.has).mockReturnValue(true);
+
+  const disposeMock = vi.fn();
+  vi.mocked(configuration.onDidChangeConfiguration).mockReturnValue({ dispose: disposeMock });
+
+  registry.init();
+  expect(configuration.onDidChangeConfiguration).toHaveBeenCalled();
+
+  registry.dispose();
+  expect(disposeMock).toHaveBeenCalled();
+});

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -38,7 +38,6 @@ export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> imp
 
   getExtensionConfiguration(): ExtensionConfiguration {
     return {
-      experimentalGPU: this.#configuration.get<boolean>('experimentalGPU') ?? false,
       modelsPath: this.getModelsPath(),
     };
   }

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -21,7 +21,7 @@ import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfig
 import { Messages } from '@shared/Messages';
 import path from 'node:path';
 
-const CONFIGURATION_SECTIONS: string[] = ['ai-lab.experimentalGPU', 'ai-lab.models.path'];
+const CONFIGURATION_SECTIONS: string[] = ['ai-lab.models.path'];
 
 export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> implements Disposable {
   #configuration: Configuration;

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -48,10 +48,6 @@ export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> imp
   }
 
   init(): void {
-    for (const section of CONFIGURATION_SECTIONS) {
-      if (!this.#configuration.has(section)) throw new Error(`Missing configuration section ${section}.`);
-    }
-
     this.#configurationDisposable = configuration.onDidChangeConfiguration(event => {
       if (CONFIGURATION_SECTIONS.some(section => event.affectsConfiguration(section))) {
         this.notify();

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { configuration, type Configuration, type Disposable, type Webview } from '@podman-desktop/api';
+import { Publisher } from '../utils/Publisher';
+import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
+import { Messages } from '@shared/Messages';
+
+const CONFIGURATION_SECTIONS: string[] = ['ai-lab.experimentalGPU'];
+
+export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> implements Disposable {
+  #configuration: Configuration;
+  #configurationDisposable: Disposable | undefined;
+
+  constructor(webview: Webview) {
+    super(webview, Messages.MSG_CONFIGURATION_UPDATE, () => this.getExtensionConfiguration());
+
+    this.#configuration = configuration.getConfiguration('ai-lab');
+  }
+
+  getExtensionConfiguration(): ExtensionConfiguration {
+    return {
+      experimentalGPU: this.#configuration.get<boolean>('experimentalGPU') ?? false,
+    };
+  }
+
+  dispose(): void {
+    this.#configurationDisposable?.dispose();
+  }
+
+  init(): void {
+    configuration.onDidChangeConfiguration(event => {
+      if (CONFIGURATION_SECTIONS.some(section => event.affectsConfiguration(section))) {
+        this.notify();
+      }
+    });
+  }
+}

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -39,8 +39,16 @@ export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> imp
   getExtensionConfiguration(): ExtensionConfiguration {
     return {
       experimentalGPU: this.#configuration.get<boolean>('experimentalGPU') ?? false,
-      modelsPath: this.#configuration.get<string>('models.path') ?? path.join(this.appUserDirectory, 'models'),
+      modelsPath: this.getModelsPath(),
     };
+  }
+
+  private getModelsPath(): string {
+    const value = this.#configuration.get<string>('models.path');
+    if (value && value.length > 0) {
+      return value;
+    }
+    return path.join(this.appUserDirectory, 'models');
   }
 
   dispose(): void {

--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -38,6 +38,7 @@ import type { CancellationTokenRegistry } from './registries/CancellationTokenRe
 import path from 'node:path';
 import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
 import * as podman from './utils/podman';
+import type { ConfigurationRegistry } from './registries/ConfigurationRegistry';
 
 vi.mock('./ai.json', () => {
   return {
@@ -139,6 +140,7 @@ beforeEach(async () => {
     {} as unknown as PlaygroundV2Manager,
     {} as unknown as SnippetManager,
     {} as unknown as CancellationTokenRegistry,
+    {} as unknown as ConfigurationRegistry,
   );
   vi.mock('node:fs');
 

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -45,6 +45,8 @@ import type { CancellationTokenRegistry } from './registries/CancellationTokenRe
 import type { LocalModelImportInfo } from '@shared/src/models/ILocalModelInfo';
 import { checkContainerConnectionStatusAndResources, getPodmanConnection } from './utils/podman';
 import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
+import type { ConfigurationRegistry } from './registries/ConfigurationRegistry';
 
 interface PortQuickPickItem extends podmanDesktopApi.QuickPickItem {
   port: number;
@@ -62,6 +64,7 @@ export class StudioApiImpl implements StudioAPI {
     private playgroundV2: PlaygroundV2Manager,
     private snippetManager: SnippetManager,
     private cancellationTokenRegistry: CancellationTokenRegistry,
+    private configurationRegistry: ConfigurationRegistry,
   ) {}
 
   async requestDeleteConversation(conversationId: string): Promise<void> {
@@ -97,6 +100,10 @@ export class StudioApiImpl implements StudioAPI {
 
   async getPlaygroundConversations(): Promise<Conversation[]> {
     return this.playgroundV2.getConversations();
+  }
+
+  async getExtensionConfiguration(): Promise<ExtensionConfiguration> {
+    return this.configurationRegistry.getExtensionConfiguration();
   }
 
   async getSnippetLanguages(): Promise<Language[]> {

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -50,6 +50,12 @@ vi.mock('../package.json', () => ({
 
 vi.mock('@podman-desktop/api', async () => {
   return {
+    configuration: {
+      getConfiguration: () => ({
+        get: vi.fn(),
+      }),
+      onDidChangeConfiguration: vi.fn(),
+    },
     version: '1.8.0',
     fs: {
       createFileSystemWatcher: () => ({

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -44,6 +44,7 @@ import { PodManager } from './managers/recipes/PodManager';
 import { initWebview } from './webviewUtils';
 import { LlamaCppPython } from './workers/provider/LlamaCppPython';
 import { InferenceProviderRegistry } from './registries/InferenceProviderRegistry';
+import { ConfigurationRegistry } from './registries/ConfigurationRegistry';
 
 export class Studio {
   readonly #extensionContext: ExtensionContext;
@@ -74,6 +75,7 @@ export class Studio {
   #playgroundManager: PlaygroundV2Manager | undefined;
   #applicationManager: ApplicationManager | undefined;
   #inferenceProviderRegistry: InferenceProviderRegistry | undefined;
+  #configurationRegistry: ConfigurationRegistry | undefined;
 
   constructor(readonly extensionContext: ExtensionContext) {
     this.#extensionContext = extensionContext;
@@ -125,6 +127,13 @@ export class Studio {
      */
     this.#cancellationTokenRegistry = new CancellationTokenRegistry();
     this.#extensionContext.subscriptions.push(this.#cancellationTokenRegistry);
+
+    /**
+     * The configuration registry manage the extension preferences/settings
+     */
+    this.#configurationRegistry = new ConfigurationRegistry(this.#panel.webview);
+    this.#configurationRegistry?.init();
+    this.#extensionContext.subscriptions.push(this.#configurationRegistry);
 
     /**
      * The container registry handle the events linked to containers (start, remove, die...)
@@ -280,6 +289,7 @@ export class Studio {
       this.#playgroundManager,
       this.#snippetManager,
       this.#cancellationTokenRegistry,
+      this.#configurationRegistry,
     );
     // Register the instance
     this.#rpcExtension.registerInstance<StudioApiImpl>(StudioApiImpl, this.#studioApi);

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -110,6 +110,11 @@ export class Studio {
       );
     }
 
+    /**
+     * Storage directory for the extension provided by podman desktop
+     */
+    const appUserDirectory = this.extensionContext.storagePath;
+
     this.#telemetry.logUsage('start');
 
     /**
@@ -131,7 +136,7 @@ export class Studio {
     /**
      * The configuration registry manage the extension preferences/settings
      */
-    this.#configurationRegistry = new ConfigurationRegistry(this.#panel.webview);
+    this.#configurationRegistry = new ConfigurationRegistry(this.#panel.webview, appUserDirectory);
     this.#configurationRegistry?.init();
     this.#extensionContext.subscriptions.push(this.#configurationRegistry);
 
@@ -141,8 +146,6 @@ export class Studio {
     this.#containerRegistry = new ContainerRegistry();
     this.#containerRegistry.init();
     this.#extensionContext.subscriptions.push(this.#containerRegistry);
-
-    const appUserDirectory = this.extensionContext.storagePath;
 
     /**
      * The RpcExtension handle the communication channels between the frontend and the backend
@@ -192,7 +195,7 @@ export class Studio {
      * The ModelManager role is to download and
      */
     this.#modelsManager = new ModelsManager(
-      appUserDirectory,
+      this.#configurationRegistry.getExtensionConfiguration().modelsPath,
       this.#panel.webview,
       this.#catalogManager,
       this.#telemetry,

--- a/packages/frontend/src/stores/extensionConfiguration.ts
+++ b/packages/frontend/src/stores/extensionConfiguration.ts
@@ -22,15 +22,18 @@ import { Messages } from '@shared/Messages';
 import { rpcBrowser, studioClient } from '/@/utils/client';
 import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
 
-export const configuration: Readable<ExtensionConfiguration | undefined> = readable<ExtensionConfiguration>(undefined, set => {
-  const sub = rpcBrowser.subscribe(Messages.MSG_CONFIGURATION_UPDATE, msg => {
-    set(msg);
-  });
-  // Initialize the store manually
-  studioClient.getExtensionConfiguration().then(state => {
-    set(state);
-  });
-  return () => {
-    sub.unsubscribe();
-  };
-});
+export const configuration: Readable<ExtensionConfiguration | undefined> = readable<ExtensionConfiguration>(
+  undefined,
+  set => {
+    const sub = rpcBrowser.subscribe(Messages.MSG_CONFIGURATION_UPDATE, msg => {
+      set(msg);
+    });
+    // Initialize the store manually
+    studioClient.getExtensionConfiguration().then(state => {
+      set(state);
+    });
+    return () => {
+      sub.unsubscribe();
+    };
+  },
+);

--- a/packages/frontend/src/stores/extensionConfiguration.ts
+++ b/packages/frontend/src/stores/extensionConfiguration.ts
@@ -22,7 +22,7 @@ import { Messages } from '@shared/Messages';
 import { rpcBrowser, studioClient } from '/@/utils/client';
 import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
 
-export const configuration: Readable<ExtensionConfiguration> = readable<ExtensionConfiguration>({}, set => {
+export const configuration: Readable<ExtensionConfiguration | undefined> = readable<ExtensionConfiguration>(undefined, set => {
   const sub = rpcBrowser.subscribe(Messages.MSG_CONFIGURATION_UPDATE, msg => {
     set(msg);
   });

--- a/packages/frontend/src/stores/extensionConfiguration.ts
+++ b/packages/frontend/src/stores/extensionConfiguration.ts
@@ -22,7 +22,7 @@ import { Messages } from '@shared/Messages';
 import { rpcBrowser, studioClient } from '/@/utils/client';
 import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
 
-export const configuration: Readable<ExtensionConfiguration> = readable<ExtensionConfiguration>(undefined, set => {
+export const configuration: Readable<ExtensionConfiguration> = readable<ExtensionConfiguration>({}, set => {
   const sub = rpcBrowser.subscribe(Messages.MSG_CONFIGURATION_UPDATE, msg => {
     set(msg);
   });

--- a/packages/frontend/src/stores/extensionConfiguration.ts
+++ b/packages/frontend/src/stores/extensionConfiguration.ts
@@ -16,17 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum Messages {
-  MSG_NEW_CATALOG_STATE = 'new-catalog-state',
-  MSG_TASKS_UPDATE = 'tasks-update',
-  MSG_NEW_MODELS_STATE = 'new-models-state',
-  MSG_APPLICATIONS_STATE_UPDATE = 'applications-state-update',
-  MSG_LOCAL_REPOSITORY_UPDATE = 'local-repository-update',
-  MSG_INFERENCE_SERVERS_UPDATE = 'inference-servers-update',
-  MSG_MONITORING_UPDATE = 'monitoring-update',
-  MSG_SUPPORTED_LANGUAGES_UPDATE = 'supported-languages-supported',
-  MSG_CONVERSATIONS_UPDATE = 'conversations-update',
-  MSG_GPUS_UPDATE = 'gpus-update',
-  MSG_INFERENCE_PROVIDER_UPDATE = 'inference-provider-update',
-  MSG_CONFIGURATION_UPDATE = 'configuration-update',
-}
+import type { Readable } from 'svelte/store';
+import { readable } from 'svelte/store';
+import { Messages } from '@shared/Messages';
+import { rpcBrowser, studioClient } from '/@/utils/client';
+import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
+
+export const configuration: Readable<ExtensionConfiguration> = readable<ExtensionConfiguration>(undefined, set => {
+  const sub = rpcBrowser.subscribe(Messages.MSG_CONFIGURATION_UPDATE, msg => {
+    set(msg);
+  });
+  // Initialize the store manually
+  studioClient.getExtensionConfiguration().then(state => {
+    set(state);
+  });
+  return () => {
+    sub.unsubscribe();
+  };
+});

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -30,6 +30,7 @@ import type { ModelOptions } from './models/IModelOptions';
 import type { Conversation } from './models/IPlaygroundMessage';
 import type { LocalModelImportInfo } from './models/ILocalModelInfo';
 import type { ContainerConnectionInfo } from './models/IContainerConnectionInfo';
+import type { ExtensionConfiguration } from './models/IExtensionConfiguration';
 
 export abstract class StudioAPI {
   abstract ping(): Promise<string>;
@@ -146,6 +147,11 @@ export abstract class StudioAPI {
    * Return the conversations
    */
   abstract getPlaygroundConversations(): Promise<Conversation[]>;
+
+  /**
+   * Get the extension configuration (preferences)
+   */
+  abstract getExtensionConfiguration(): Promise<ExtensionConfiguration>;
 
   /**
    * Return the list of supported languages to generate code from.

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -17,6 +17,5 @@
  ***********************************************************************/
 
 export interface ExtensionConfiguration {
-  experimentalGPU: boolean;
   modelsPath: string;
 }

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -18,4 +18,5 @@
 
 export interface ExtensionConfiguration {
   experimentalGPU: boolean;
+  modelsPath: string;
 }

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -16,17 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum Messages {
-  MSG_NEW_CATALOG_STATE = 'new-catalog-state',
-  MSG_TASKS_UPDATE = 'tasks-update',
-  MSG_NEW_MODELS_STATE = 'new-models-state',
-  MSG_APPLICATIONS_STATE_UPDATE = 'applications-state-update',
-  MSG_LOCAL_REPOSITORY_UPDATE = 'local-repository-update',
-  MSG_INFERENCE_SERVERS_UPDATE = 'inference-servers-update',
-  MSG_MONITORING_UPDATE = 'monitoring-update',
-  MSG_SUPPORTED_LANGUAGES_UPDATE = 'supported-languages-supported',
-  MSG_CONVERSATIONS_UPDATE = 'conversations-update',
-  MSG_GPUS_UPDATE = 'gpus-update',
-  MSG_INFERENCE_PROVIDER_UPDATE = 'inference-provider-update',
-  MSG_CONFIGURATION_UPDATE = 'configuration-update',
+export interface ExtensionConfiguration {
+  experimentalGPU: boolean;
 }

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -17,6 +17,6 @@
  ***********************************************************************/
 
 export interface ExtensionConfiguration {
-  experimentalGPU: boolean;
-  modelsPath: string;
+  experimentalGPU?: boolean;
+  modelsPath?: string;
 }

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -17,6 +17,6 @@
  ***********************************************************************/
 
 export interface ExtensionConfiguration {
-  experimentalGPU?: boolean;
-  modelsPath?: string;
+  experimentalGPU: boolean;
+  modelsPath: string;
 }

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -50,5 +50,5 @@ export interface InferenceServerConfig {
    * @default undefined the GPU will not be used
    * -1 to offload all the layers
    */
-  gpu_layers?: number;
+  gpuLayers?: number;
 }

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -45,4 +45,10 @@ export interface InferenceServerConfig {
    * Model info for the models
    */
   modelsInfo: ModelInfo[];
+  /**
+   * Number of layers to offload to the GPU
+   * @default undefined the GPU will not be used
+   * -1 to offload all the layers
+   */
+  gpu_layers?: number;
 }

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -45,10 +45,4 @@ export interface InferenceServerConfig {
    * Model info for the models
    */
   modelsInfo: ModelInfo[];
-  /**
-   * Number of layers to offload to the GPU
-   * @default undefined the GPU will not be used
-   * -1 to offload all the layers
-   */
-  gpuLayers?: number;
 }


### PR DESCRIPTION
### What does this PR do?

Creating a dedicated registry to hold configuration (preferences) logic.

### Notable changes

- ConfigurationRegistry manage the `ai-lab.models.path` previously managed by `ModelsManager`
- Creating frontend store holding the configuration values

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] Unit tests has been provided