### PR TITLE
feat(Inference): supporting gpu layers

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,12 +23,11 @@
         "ai-lab.experimentalGPU": {
           "type": "boolean",
           "default": false,
-          "hidden": true,
           "description": "Experimental GPU support for inference servers",
           "when": "isWindows"
         }
       }
-    },
+     },
     "icons": {
       "brain-icon": {
         "description": "Brain icon",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
           "description": "Experimental GPU support for inference servers"
         }
       }
-     },
+    },
     "icons": {
       "brain-icon": {
         "description": "Brain icon",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,8 +23,7 @@
         "ai-lab.experimentalGPU": {
           "type": "boolean",
           "default": false,
-          "description": "Experimental GPU support for inference servers",
-          "when": "isWindows"
+          "description": "Experimental GPU support for inference servers"
         }
       }
      },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,6 +19,13 @@
           "format": "folder",
           "default": "",
           "description": "Custom path where to download models. Note: The extension must be restarted for changes to take effect. (Default is blank)"
+        },
+        "ai-lab.experimentalGPU": {
+          "type": "boolean",
+          "default": false,
+          "hidden": true,
+          "description": "Experimental GPU support for inference servers",
+          "when": "isWindows"
         }
       }
     },

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -400,6 +400,7 @@ test('creating a new playground with no model served should start an inference s
     'tracking-1',
   );
   expect(createInferenceServerMock).toHaveBeenCalledWith({
+    gpuLayers: expect.any(Number),
     image: undefined,
     providerId: undefined,
     inferenceProvider: undefined,

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -21,7 +21,7 @@ import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfig
 import { Messages } from '@shared/Messages';
 import path from 'node:path';
 
-const CONFIGURATION_SECTIONS: string[] = ['ai-lab.models.path'];
+const CONFIGURATION_SECTIONS: string[] = ['ai-lab.models.path', 'ai-lab.experimentalGPU'];
 
 export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> implements Disposable {
   #configuration: Configuration;
@@ -39,6 +39,7 @@ export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> imp
   getExtensionConfiguration(): ExtensionConfiguration {
     return {
       modelsPath: this.getModelsPath(),
+      experimentalGPU: this.#configuration.get<boolean>('experimentalGPU') ?? false,
     };
   }
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -262,7 +262,7 @@ export class Studio {
     this.#inferenceProviderRegistry = new InferenceProviderRegistry(this.#panel.webview);
     this.#extensionContext.subscriptions.push(
       this.#inferenceProviderRegistry.register(
-        new LlamaCppPython(this.#taskRegistry, this.#podmanConnection, this.#gpuManager),
+        new LlamaCppPython(this.#taskRegistry, this.#podmanConnection, this.#gpuManager, this.#configurationRegistry),
       ),
     );
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -46,6 +46,7 @@ import { LlamaCppPython } from './workers/provider/LlamaCppPython';
 import { InferenceProviderRegistry } from './registries/InferenceProviderRegistry';
 import { ConfigurationRegistry } from './registries/ConfigurationRegistry';
 import { RecipeManager } from './managers/recipes/RecipeManager';
+import { GPUManager } from './managers/GPUManager';
 
 export class Studio {
   readonly #extensionContext: ExtensionContext;
@@ -78,6 +79,7 @@ export class Studio {
   #recipeManager: RecipeManager | undefined;
   #inferenceProviderRegistry: InferenceProviderRegistry | undefined;
   #configurationRegistry: ConfigurationRegistry | undefined;
+  #gpuManager: GPUManager | undefined;
 
   constructor(readonly extensionContext: ExtensionContext) {
     this.#extensionContext = extensionContext;
@@ -248,12 +250,18 @@ export class Studio {
     this.#extensionContext.subscriptions.push(this.#applicationManager);
 
     /**
+     * GPUManager is a class responsible for detecting and storing the GPU specs
+     */
+    this.#gpuManager = new GPUManager(this.#panel.webview);
+    this.#extensionContext.subscriptions.push(this.#gpuManager);
+
+    /**
      * The Inference Provider registry stores all the InferenceProvider (aka backend) which
      * can be used to create InferenceServers
      */
     this.#inferenceProviderRegistry = new InferenceProviderRegistry(this.#panel.webview);
     this.#extensionContext.subscriptions.push(
-      this.#inferenceProviderRegistry.register(new LlamaCppPython(this.#taskRegistry, this.#podmanConnection)),
+      this.#inferenceProviderRegistry.register(new LlamaCppPython(this.#taskRegistry, this.#podmanConnection, this.#gpuManager)),
     );
 
     /**

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -261,7 +261,9 @@ export class Studio {
      */
     this.#inferenceProviderRegistry = new InferenceProviderRegistry(this.#panel.webview);
     this.#extensionContext.subscriptions.push(
-      this.#inferenceProviderRegistry.register(new LlamaCppPython(this.#taskRegistry, this.#podmanConnection, this.#gpuManager)),
+      this.#inferenceProviderRegistry.register(
+        new LlamaCppPython(this.#taskRegistry, this.#podmanConnection, this.#gpuManager),
+      ),
     );
 
     /**

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -109,6 +109,7 @@ export async function withDefaultConfiguration(
     modelsInfo: options.modelsInfo,
     providerId: options.providerId,
     inferenceProvider: options.inferenceProvider,
+    gpuLayers: options.gpuLayers,
   };
 }
 

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -109,7 +109,7 @@ export async function withDefaultConfiguration(
     modelsInfo: options.modelsInfo,
     providerId: options.providerId,
     inferenceProvider: options.inferenceProvider,
-    gpuLayers: options.gpuLayers,
+    gpuLayers: options.gpuLayers !== undefined ? options.gpuLayers : -1,
   };
 }
 

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -23,7 +23,7 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
 import type { ContainerProviderConnection, ImageInfo, ProviderContainerConnection } from '@podman-desktop/api';
 import { containerEngine } from '@podman-desktop/api';
-import { GPUManager } from '../../managers/GPUManager';
+import type { GPUManager } from '../../managers/GPUManager';
 import type { PodmanConnection } from '../../managers/podmanConnection';
 import { VMType } from '@shared/src/models/IPodman';
 
@@ -44,9 +44,7 @@ const taskRegistry: TaskRegistry = {
   updateTask: vi.fn(),
 } as unknown as TaskRegistry;
 
-const gpuManager: GPUManager = {
-
-} as unknown as GPUManager;
+const gpuManager: GPUManager = {} as unknown as GPUManager;
 
 const DummyModel: ModelInfo = {
   name: 'dummy model',
@@ -74,12 +72,13 @@ const DummyImageInfo: ImageInfo = {
 } as unknown as ImageInfo;
 
 const podmanConnection: PodmanConnection = {
-  getVMType: vi.fn().mockResolvedValue(VMType.WSL),
+  getVMType: vi.fn(),
 } as unknown as PodmanConnection;
 
 beforeEach(() => {
   vi.resetAllMocks();
 
+  vi.mocked(podmanConnection.getVMType).mockResolvedValue(VMType.WSL);
   vi.mocked(getProviderContainerConnection).mockReturnValue(DummyProviderContainerConnection);
   vi.mocked(getImageInfo).mockResolvedValue(DummyImageInfo);
   vi.mocked(taskRegistry.createTask).mockReturnValue({ id: 'dummy-task-id', name: '', labels: {}, state: 'loading' });

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { vi, describe, test, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { LLAMA_CPP_CPU, LLAMA_CPP_CUDA, LlamaCppPython, SECOND } from './LlamaCppPython';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
@@ -27,6 +27,7 @@ import type { GPUManager } from '../../managers/GPUManager';
 import type { PodmanConnection } from '../../managers/podmanConnection';
 import { VMType } from '@shared/src/models/IPodman';
 import type { ConfigurationRegistry } from '../../registries/ConfigurationRegistry';
+import { GPUVendor } from '@shared/src/models/IGPUInfo';
 
 vi.mock('@podman-desktop/api', () => ({
   containerEngine: {
@@ -253,6 +254,7 @@ describe('perform', () => {
       {
         vram: 1024,
         model: 'nvidia',
+        vendor: GPUVendor.NVIDIA,
       },
     ]);
 

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -24,7 +24,7 @@ import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { InferenceType } from '@shared/src/models/IInference';
 import type { GPUManager } from '../../managers/GPUManager';
-import type { IGPUInfo } from '@shared/src/models/IGPUInfo';
+import { GPUVendor, type IGPUInfo } from '@shared/src/models/IGPUInfo';
 import { VMType } from '@shared/src/models/IPodman';
 import type { PodmanConnection } from '../../managers/podmanConnection';
 import type { ConfigurationRegistry } from '../../registries/ConfigurationRegistry';
@@ -207,7 +207,7 @@ export class LlamaCppPython extends InferenceProvider {
   protected getLlamaCppInferenceImage(vmType: VMType, gpu?: IGPUInfo): string {
     switch (vmType) {
       case VMType.WSL:
-        return gpu?.model.includes('nvidia') ? LLAMA_CPP_CUDA : LLAMA_CPP_CPU;
+        return gpu?.vendor === GPUVendor.NVIDIA ? LLAMA_CPP_CUDA : LLAMA_CPP_CPU;
       case VMType.LIBKRUN:
         return gpu ? LLAMA_CPP_MAC_GPU : LLAMA_CPP_CPU;
       // no GPU support

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -110,6 +110,7 @@ export class LlamaCppPython extends InferenceProvider {
 
           user = '0';
 
+          entrypoint = '/usr/bin/sh';
           cmd = [
             '-c',
             '/usr/bin/ln -s /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && chmod 755 ./run.sh && ./run.sh',
@@ -130,7 +131,6 @@ export class LlamaCppPython extends InferenceProvider {
         Count: -1, // -1: all
       });
 
-      entrypoint = '/usr/bin/sh';
       envs.push(`GPU_LAYERS=${config.gpuLayers}`);
     }
 

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -36,9 +36,9 @@ export const LLAMA_CPP_MAC_GPU = 'quay.io/ai-lab/llamacpp-python-vulkan:latest';
 export const SECOND: number = 1_000_000_000;
 
 interface Device {
-  PathOnHost: string,
-  PathInContainer: string,
-  CgroupPermissions: string,
+  PathOnHost: string;
+  PathInContainer: string;
+  CgroupPermissions: string;
 }
 
 export class LlamaCppPython extends InferenceProvider {
@@ -47,7 +47,7 @@ export class LlamaCppPython extends InferenceProvider {
     private podmanConnection: PodmanConnection,
     private gpuManager: GPUManager,
   ) {
-    super(taskRegistry, InferenceType.LLAMA_CPP, 'LLama-cpp (CPU)');
+    super(taskRegistry, InferenceType.LLAMA_CPP, 'LLama-cpp');
   }
 
   dispose() {}
@@ -173,10 +173,11 @@ export class LlamaCppPython extends InferenceProvider {
     let gpu: IGPUInfo | undefined = undefined;
 
     // get the first GPU if requested
-    if((config.gpuLayers ?? 0) !== 0) {
+    if ((config.gpuLayers ?? 0) !== 0) {
       const gpus: IGPUInfo[] = await this.gpuManager.collectGPUs();
-      if(gpus.length === 0) throw new Error('no gpu was found.');
-      if(gpus.length > 1) console.warn(`found ${gpus.length} gpus: using multiple GPUs is not supported. Using ${gpus[0].model}.`);
+      if (gpus.length === 0) throw new Error('no gpu was found.');
+      if (gpus.length > 1)
+        console.warn(`found ${gpus.length} gpus: using multiple GPUs is not supported. Using ${gpus[0].model}.`);
       gpu = gpus[0];
     }
 

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -57,8 +57,8 @@ export class LlamaCppPython extends InferenceProvider {
   protected async getContainerCreateOptions(
     config: InferenceServerConfig,
     imageInfo: ImageInfo,
-    gpu?: IGPUInfo,
     vmType: VMType,
+    gpu?: IGPUInfo,
   ): Promise<ContainerCreateOptions> {
     if (config.modelsInfo.length === 0) throw new Error('Need at least one model info to start an inference server.');
 
@@ -89,7 +89,7 @@ export class LlamaCppPython extends InferenceProvider {
     let cmd: string[] = [];
     let user: string | undefined = undefined;
 
-    if(gpu) {
+    if (gpu) {
       // mounting
 
       switch (vmType) {
@@ -123,7 +123,7 @@ export class LlamaCppPython extends InferenceProvider {
       }
 
       // adding gpu capabilities
-      deviceRequests.push( {
+      deviceRequests.push({
         Capabilities: [['gpu']],
         Count: -1, // -1: all
       });
@@ -194,15 +194,15 @@ export class LlamaCppPython extends InferenceProvider {
     const containerCreateOptions: ContainerCreateOptions = await this.getContainerCreateOptions(
       config,
       imageInfo,
-      gpu,
       vmType,
+      gpu,
     );
 
     // Create the container
     return this.createContainer(imageInfo.engineId, containerCreateOptions, config.labels);
   }
 
-  protected getLlamaCppInferenceImage(vmType: VMType, gpu?: IGPUInfo) {
+  protected getLlamaCppInferenceImage(vmType: VMType, gpu?: IGPUInfo): string {
     switch (vmType) {
       case VMType.WSL:
         return gpu?.model.includes('nvidia') ? LLAMA_CPP_CUDA : LLAMA_CPP_CPU;

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -75,7 +75,7 @@ const onGPULayersInput = (event: Event): void => {
     console.warn('invalid value for gpu layers', e);
     gpuLayers = 0;
   }
-}
+};
 
 // Submit method when the form is valid
 const submit = async () => {

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -15,7 +15,6 @@ import ContainerConnectionStatusInfo from '../lib/notification/ContainerConnecti
 import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 import { checkContainerConnectionStatus } from '../utils/connectionUtils';
 import { Button, ErrorMessage, FormPage, Input } from '@podman-desktop/ui-svelte';
-import { configuration } from '/@/stores/extensionConfiguration';
 
 // List of the models available locally
 let localModels: ModelInfo[];
@@ -25,9 +24,6 @@ $: localModels = $modelsInfo.filter(model => model.file);
 let containerPort: number | undefined = undefined;
 // The modelId is the bind value to form input
 let modelId: string | undefined = undefined;
-// number of
-let gpuLayers: number = 0;
-
 // If the creation of a new inference service fail
 let errorMsg: string | undefined = undefined;
 
@@ -47,9 +43,6 @@ $: available = containerId && $inferenceServers.some(server => server.container.
 
 $: loading = trackingId !== undefined && !error;
 
-let gpuEnabled: boolean;
-$: gpuEnabled = $configuration?.experimentalGPU ?? false;
-
 let connectionInfo: ContainerConnectionInfo | undefined;
 $: if (localModels && modelId) {
   checkContainerConnectionStatus(localModels, modelId, 'inference')
@@ -67,16 +60,6 @@ const onContainerPortInput = (event: Event): void => {
   }
 };
 
-const onGPULayersInput = (event: Event): void => {
-  const raw = (event.target as HTMLInputElement).value;
-  try {
-    gpuLayers = parseInt(raw);
-  } catch (e: unknown) {
-    console.warn('invalid value for gpu layers', e);
-    gpuLayers = 0;
-  }
-};
-
 // Submit method when the form is valid
 const submit = async () => {
   errorMsg = undefined;
@@ -89,7 +72,6 @@ const submit = async () => {
     trackingId = await studioClient.requestCreateInferenceServer({
       modelsInfo: [model],
       port: containerPort,
-      gpuLayers: gpuLayers,
     });
   } catch (err: unknown) {
     trackingId = undefined;
@@ -219,20 +201,6 @@ export function goToUpPage(): void {
             aria-label="Port input"
             disabled={loading}
             required />
-          <!-- GPU section -->
-          {#if gpuEnabled}
-            <label for="gpuOffloading" class="pt-4 block mb-2 text-sm font-bold text-gray-400">GPU Offloading</label>
-            <Input
-              type="number"
-              bind:value="{gpuLayers}"
-              on:input="{onGPULayersInput}"
-              class="w-full"
-              placeholder="0 to disabled"
-              name="gpuOffloading"
-              aria-label="GPU Offloading"
-              disabled="{loading}"
-              required />
-          {/if}
         </div>
         {#if errorMsg !== undefined}
           <ErrorMessage error={errorMsg} />

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -17,7 +17,6 @@
  ***********************************************************************/
 
 export interface ExtensionConfiguration {
-  modelsPath: string;
   experimentalGPU: boolean;
   modelsPath: string;
 }

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -19,4 +19,5 @@
 export interface ExtensionConfiguration {
   modelsPath: string;
   experimentalGPU: boolean;
+  modelsPath: string;
 }

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -18,4 +18,5 @@
 
 export interface ExtensionConfiguration {
   modelsPath: string;
+  experimentalGPU: boolean;
 }

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -50,5 +50,5 @@ export interface InferenceServerConfig {
    * @default undefined the GPU will not be used
    * -1 to offload all the layers
    */
-  gpu_layers?: number;
+  gpuLayers?: number;
 }

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -45,4 +45,10 @@ export interface InferenceServerConfig {
    * Model info for the models
    */
   modelsInfo: ModelInfo[];
+  /**
+   * Number of layers to offload to the GPU
+   * @default undefined the GPU will not be used
+   * -1 to offload all the layers
+   */
+  gpu_layers?: number;
 }


### PR DESCRIPTION
### What does this PR do?

Add an `experimental GPU` preference. When enabled, it will uses the matching container image for the VMType used

- On WSL and with a NVIDIA GPU 
- On Libkrun => llamacpp mac vulkan 

### Screenshot / video of UI

New option `Experimental GPU` in podman desktop preferences

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/01c7d1d9-aa7b-42ea-8d45-f6a1ac5e7408)

### Side by Side playground comparison 

https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/6a8c5308-dc96-40bc-9200-210bd1fe9477

### What issues does this PR fix or reference?

Need https://github.com/containers/podman-desktop-extension-ai-lab/pull/1278 to be merged
Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1279

### How to test this PR?

**Require to be on windows with a WSL podman machine and a NVIDIA GPU**

- Turn on the experimental flag in the preference
- Set a value for the gpu offloading (E.g. 20)
- Start the inference server
- Go to playground, notice the speed
