### PR TITLE
feat: prevent user from deleting model when inUse

### DIFF
--- a/packages/frontend/src/lib/icons/ModelWhite.svelte
+++ b/packages/frontend/src/lib/icons/ModelWhite.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
+export let size = '40';
 export let solid: boolean = false;
-const fg = solid ? 'white' : '#888';
+
+const fg = solid ? 'white' : 'currentColor';
 </script>
 
-<div role="img" class="rounded py-[6px] pl-[7px] pr-[5px]" class:bg-green-400="{solid}">
-  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<div role="img">
+  <svg
+    width="{size}"
+    height="{size}"
+    style="{$$props.style}"
+    class="{$$props.class}"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg">
     <g clip-path="url(#clip0_47_118)">
       <g clip-path="url(#clip1_47_118)">
         <path

--- a/packages/frontend/src/lib/table/model/ModelColumnAction.spec.ts
+++ b/packages/frontend/src/lib/table/model/ModelColumnAction.spec.ts
@@ -214,6 +214,6 @@ test('Expect delete button to be disabled when model in use', async () => {
 
   await vi.waitFor(() => {
     // disable class
-    expect(deleteBtn.classList).toContain('text-gray-900');
+    expect(deleteBtn.classList).toContain('text-[var(--pd-action-button-disabled-text)]');
   });
 });

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -10,7 +10,6 @@ import { inferenceServers } from '/@/stores/inferenceServers';
 export let object: ModelInfo;
 
 let inUse: boolean = false;
-$: inUse;
 
 function deleteModel() {
   studioClient.requestRemoveLocalModel(object.id).catch(err => {

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -5,7 +5,12 @@ import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '../../button/ListItemButtonIcon.svelte';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
+import { onMount } from 'svelte';
+import { inferenceServers } from '/@/stores/inferenceServers';
 export let object: ModelInfo;
+
+let inUse: boolean = false;
+$: inUse;
 
 function deleteModel() {
   studioClient.requestRemoveLocalModel(object.id).catch(err => {
@@ -31,6 +36,12 @@ function createModelService() {
   router.goto('/service/create');
   router.location.query.replace({ 'model-id': object.id });
 }
+
+onMount(() => {
+  return inferenceServers.subscribe(servers => {
+    inUse = servers.some(server => server.models.some(model => model.id === object.id));
+  });
+});
 </script>
 
 {#if object.file !== undefined}
@@ -44,7 +55,12 @@ function createModelService() {
     onClick="{() => openModelFolder()}"
     title="Open Model Folder"
     enabled="{!object.state}" />
-  <ListItemButtonIcon icon="{faTrash}" onClick="{deleteModel}" title="Delete Model" enabled="{!object.state}" />
+  <span>{inUse}</span>
+  <ListItemButtonIcon
+    icon="{faTrash}"
+    onClick="{deleteModel}"
+    title="Delete Model"
+    enabled="{!inUse && !object.state}" />
 {:else}
   <ListItemButtonIcon icon="{faDownload}" onClick="{downloadModel}" title="Download Model" enabled="{!object.state}" />
 {/if}

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -10,6 +10,7 @@ import { inferenceServers } from '/@/stores/inferenceServers';
 export let object: ModelInfo;
 
 let inUse: boolean = false;
+$: inUse;
 
 function deleteModel() {
   studioClient.requestRemoveLocalModel(object.id).catch(err => {

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -55,7 +55,6 @@ onMount(() => {
     onClick="{() => openModelFolder()}"
     title="Open Model Folder"
     enabled="{!object.state}" />
-  <span>{inUse}</span>
   <ListItemButtonIcon
     icon="{faTrash}"
     onClick="{deleteModel}"

--- a/packages/frontend/src/lib/table/model/ModelColumnIcon.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnIcon.svelte
@@ -7,6 +7,7 @@ import StatusIcon from '/@/lib/StatusIcon.svelte';
 export let object: ModelInfo;
 
 let status: string | undefined = undefined;
+$: status;
 
 onMount(() => {
   return inferenceServers.subscribe(servers => {

--- a/packages/frontend/src/lib/table/model/ModelColumnIcon.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnIcon.svelte
@@ -7,7 +7,6 @@ import StatusIcon from '/@/lib/StatusIcon.svelte';
 export let object: ModelInfo;
 
 let status: string | undefined = undefined;
-$: status;
 
 onMount(() => {
   return inferenceServers.subscribe(servers => {

--- a/packages/frontend/src/lib/table/model/ModelColumnIcon.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnIcon.svelte
@@ -1,7 +1,23 @@
 <script lang="ts">
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import ModelWhite from '../../icons/ModelWhite.svelte';
+import { onMount } from 'svelte';
+import { inferenceServers } from '/@/stores/inferenceServers';
+import StatusIcon from '/@/lib/StatusIcon.svelte';
 export let object: ModelInfo;
+
+let status: string | undefined = undefined;
+$: status;
+
+onMount(() => {
+  return inferenceServers.subscribe(servers => {
+    if (servers.some(server => server.models.some(model => model.id === object.id))) {
+      status = 'USED';
+    } else {
+      status = object.file ? 'DOWNLOADED' : 'NONE';
+    }
+  });
+});
 </script>
 
-<ModelWhite solid="{!!object.file}" />
+<StatusIcon status="{status}" icon="{ModelWhite}" />

--- a/packages/frontend/src/lib/table/service/ServiceStatus.spec.ts
+++ b/packages/frontend/src/lib/table/service/ServiceStatus.spec.ts
@@ -20,7 +20,7 @@ import { expect, test, vi, describe } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import ServiceStatus from './ServiceStatus.svelte';
 import { studioClient } from '/@/utils/client';
-import type { InferenceServerStatus } from '@shared/src/models/IInference';
+import { type InferenceServerStatus, InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('../../../utils/client', async () => ({
   studioClient: {
@@ -39,6 +39,7 @@ describe('transition statuses', () => {
           connection: { port: 8888 },
           status: status,
           container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+          type: InferenceType.LLAMA_CPP,
         },
       });
 
@@ -62,6 +63,7 @@ describe('stable statuses', () => {
           connection: { port: 8888 },
           status: status,
           container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+          type: InferenceType.LLAMA_CPP,
         },
       });
 
@@ -86,6 +88,7 @@ test('defined health should not display a spinner', async () => {
       connection: { port: 8888 },
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+      type: InferenceType.LLAMA_CPP,
     },
   });
 
@@ -108,6 +111,7 @@ test('click on status icon should redirect to container', async () => {
       connection: { port: 8888 },
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+      type: InferenceType.LLAMA_CPP,
     },
   });
   // Get button and click on it
@@ -126,6 +130,7 @@ test('error status should show degraded', async () => {
       connection: { port: 8888 },
       status: 'error',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+      type: InferenceType.LLAMA_CPP,
     },
   });
   // Get button and click on it
@@ -140,6 +145,7 @@ test('running status with no healthcheck should show starting', async () => {
       connection: { port: 8888 },
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+      type: InferenceType.LLAMA_CPP,
     },
   });
   // Get button and click on it

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -21,6 +21,7 @@ import { screen, render, waitFor, within } from '@testing-library/svelte';
 import Models from './Models.svelte';
 import { router } from 'tinro';
 import userEvent from '@testing-library/user-event';
+import type { InferenceServer } from '@shared/src/models/IInference';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -44,6 +45,15 @@ const mocks = vi.hoisted(() => {
     getTasks: vi.fn().mockResolvedValue([]),
   };
 });
+
+vi.mock('../stores/inferenceServers', () => ({
+  inferenceServers: {
+    subscribe: (f: (msg: InferenceServer[]) => void) => {
+      f([]);
+      return () => {};
+    },
+  },
+}));
 
 vi.mock('/@/utils/client', async () => {
   return {

--- a/packages/frontend/src/pages/RecipeModels.spec.ts
+++ b/packages/frontend/src/pages/RecipeModels.spec.ts
@@ -23,12 +23,22 @@ import * as catalogStore from '/@/stores/catalog';
 import { readable } from 'svelte/store';
 import type { ApplicationCatalog } from '@shared/src/models/IApplicationCatalog';
 import RecipeModels from '/@/pages/RecipeModels.svelte';
+import type { InferenceServer } from '@shared/src/models/IInference';
 
 vi.mock('/@/stores/catalog', async () => {
   return {
     catalog: vi.fn(),
   };
 });
+
+vi.mock('../stores/inferenceServers', () => ({
+  inferenceServers: {
+    subscribe: (f: (msg: InferenceServer[]) => void) => {
+      f([]);
+      return () => {};
+    },
+  },
+}));
 
 beforeEach(() => {
   vi.resetAllMocks();


### PR DESCRIPTION
### What does this PR do?

Improve the Models page by changing the StatusIcon depending on the model usage.

When the model is used by an inference server, it is marked as `USED`. A model which is downloaded has a title `DOWNLOADED`.

The delete button is also disabled when model is inUse

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/d093d00e-8e32-4665-83f9-511087c32bd3)

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/eaf80c70-7118-49b5-a78f-139fc5890f03)

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/1ecbdd85-ea3c-4502-939d-ecf5a67ca530)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/791

### How to test this PR?

- [x] Unit tests has been provided