### PR TITLE
fix(InferenceManager): not initializing without user catalog

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -92,10 +92,6 @@ const catalogManager = {
 } as unknown as CatalogManager;
 
 const getInitializedInferenceManager = async (): Promise<InferenceManager> => {
-  vi.mocked(catalogManager.onCatalogUpdate).mockImplementation(fn => {
-    fn();
-    return { dispose: vi.fn() };
-  });
   const manager = new InferenceManager(
     webviewMock,
     containerRegistryMock,
@@ -138,9 +134,22 @@ beforeEach(() => {
  * Testing the initialization of the manager
  */
 describe('init Inference Manager', () => {
-  test('should be initialized', async () => {
-    const inferenceManager = await getInitializedInferenceManager();
-    expect(inferenceManager.isInitialize()).toBeTruthy();
+  test('should be initialized without catalog events', async () => {
+    const manager = new InferenceManager(
+      webviewMock,
+      containerRegistryMock,
+      podmanConnectionMock,
+      modelsManager,
+      telemetryMock,
+      taskRegistryMock,
+      inferenceProviderRegistryMock,
+      catalogManager,
+    );
+    manager.init();
+    await vi.waitUntil(manager.isInitialize.bind(manager), {
+      interval: 200,
+      timeout: 2000,
+    });
   });
 
   test('should have listed containers', async () => {

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -62,8 +62,9 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     this.podmanConnection.onMachineStop(this.watchMachineEvent.bind(this, 'stop'));
     this.containerRegistry.onStartContainerEvent(this.watchContainerStart.bind(this));
     this.catalogManager.onCatalogUpdate(() => {
-      this.retryableRefresh(3);
+      this.retryableRefresh(1);
     });
+    this.retryableRefresh(3);
   }
 
   public isInitialize(): boolean {


### PR DESCRIPTION
### What does this PR do?

Making the InferenceManager initialize by default, and on catalog update.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1333

### How to test this PR?

- [x] unit test has been added