### PR TITLE
chore(tailwindcss): uses podman desktop var for markdown

### DIFF
--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -47,12 +47,12 @@ module.exports = {
       typography: (theme) => ({
         DEFAULT: {
           css: {
-            color: tailwindColors.gray[100],
-            '--tw-prose-headings': tailwindColors.gray[100],
-            '--tw-prose-bold': tailwindColors.gray[100],
-            '--tw-prose-links': tailwindColors.purple[500],
-            '--tw-prose-code': tailwindColors.purple[400],
-            // ...
+            color: 'var(--pd-details-body-text)',
+            '--tw-prose-body': 'var(--pd-details-body-text)',
+            '--tw-prose-bold': 'var(--pd-details-body-text)',
+            '--tw-prose-hr': 'var(--pd-details-body-text)',
+            '--tw-prose-links': 'var(--pd-link)',
+            '--tw-prose-code': 'var(--pd-details-body-text)',
           },
         },
       }),

--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -50,6 +50,8 @@ module.exports = {
             color: 'var(--pd-details-body-text)',
             '--tw-prose-body': 'var(--pd-details-body-text)',
             '--tw-prose-bold': 'var(--pd-details-body-text)',
+            '--tw-prose-headings': 'var(--pd-details-body-text)',
+            '--tw-prose-quotes': 'var(--pd-details-body-text)',
             '--tw-prose-hr': 'var(--pd-details-body-text)',
             '--tw-prose-links': 'var(--pd-link)',
             '--tw-prose-code': 'var(--pd-details-body-text)',


### PR DESCRIPTION
### What does this PR do?

We are not using the same markdown component as podman desktop; therefore we need to propagate some of the css variable to the component. We are using the https://github.com/tailwindlabs/tailwindcss-typography, and as mention in their documentation, we can easily define custom value.

### Screenshot / video of UI

| Light | Dark |
| --- | --- |
| ![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/b85d9be9-9406-4358-b12b-5cf50ed1093f) | ![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/9282eac5-6132-4f6a-8503-2b91b83431fc) |
| ![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/82802349-2432-4c5a-8d83-ca0b9a8bce96) | ![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/2b727a0d-5d5f-44cd-b4d6-286512dc0265) |

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1253

### How to test this PR?

<!-- Please explain steps to reproduce -->