### PR TITLE
fix: display error message from chat conversation

### DIFF
--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -121,28 +121,6 @@ test('submit should throw an error if the server is unhealthy', async () => {
   );
 });
 
-test('submit should throw an error if the server is unhealthy', async () => {
-  vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
-    {
-      status: 'running',
-      health: {
-        Status: 'unhealthy',
-      },
-      models: [
-        {
-          id: 'model1',
-        },
-      ],
-    } as unknown as InferenceServer,
-  ]);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
-  await manager.createPlayground('p1', { id: 'model1' } as ModelInfo, 'tracking-1');
-  const playgroundId = manager.getConversations()[0].id;
-  await expect(manager.submit(playgroundId, 'dummyUserInput')).rejects.toThrowError(
-    'Inference server is not healthy, currently status: unhealthy.',
-  );
-});
-
 test('create playground should create conversation.', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
     {
@@ -335,7 +313,7 @@ test('error', async () => {
 
   // Wait for error message
   await vi.waitFor(() => {
-    expect((manager.getConversations()[0].messages[1] as ErrorMessage).message).toBeDefined();
+    expect((manager.getConversations()[0].messages[1] as ErrorMessage).error).toBeDefined();
   });
 
   const conversations = manager.getConversations();

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -26,6 +26,7 @@ import { Messages } from '@shared/Messages';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import type { TaskRegistry } from '../registries/TaskRegistry';
 import type { Task, TaskState } from '@shared/src/models/ITask';
+import { ChatMessage, ErrorMessage } from '@shared/src/models/IPlaygroundMessage';
 
 vi.mock('openai', () => ({
   default: vi.fn(),
@@ -120,6 +121,28 @@ test('submit should throw an error if the server is unhealthy', async () => {
   );
 });
 
+test('submit should throw an error if the server is unhealthy', async () => {
+  vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
+    {
+      status: 'running',
+      health: {
+        Status: 'unhealthy',
+      },
+      models: [
+        {
+          id: 'model1',
+        },
+      ],
+    } as unknown as InferenceServer,
+  ]);
+  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  await manager.createPlayground('p1', { id: 'model1' } as ModelInfo, 'tracking-1');
+  const playgroundId = manager.getConversations()[0].id;
+  await expect(manager.submit(playgroundId, 'dummyUserInput')).rejects.toThrowError(
+    'Inference server is not healthy, currently status: unhealthy.',
+  );
+});
+
 test('create playground should create conversation.', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
     {
@@ -185,7 +208,7 @@ test('valid submit should create IPlaygroundMessage and notify the webview', asy
 
   // Wait for assistant message to be completed
   await vi.waitFor(() => {
-    expect(manager.getConversations()[0].messages[1].content).toBeDefined();
+    expect((manager.getConversations()[0].messages[1] as ChatMessage).content).toBeDefined();
   });
 
   const conversations = manager.getConversations();
@@ -269,6 +292,72 @@ test('submit should send options', async () => {
     temperature: 0.123,
     max_tokens: 45,
     top_p: 0.345,
+  });
+});
+
+test('error', async () => {
+  vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
+    {
+      status: 'running',
+      health: {
+        Status: 'healthy',
+      },
+      models: [
+        {
+          id: 'dummyModelId',
+          file: {
+            file: 'dummyModelFile',
+          },
+        },
+      ],
+      connection: {
+        port: 8888,
+      },
+    } as unknown as InferenceServer,
+  ]);
+  const createMock = vi.fn().mockRejectedValue('Please reduce the length of the messages or completion.');
+  vi.mocked(OpenAI).mockReturnValue({
+    chat: {
+      completions: {
+        create: createMock,
+      },
+    },
+  } as unknown as OpenAI);
+
+  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, 'tracking-1');
+
+  const date = new Date(2000, 1, 1, 13);
+  vi.setSystemTime(date);
+
+  const playgrounds = manager.getConversations();
+  await manager.submit(playgrounds[0].id, 'dummyUserInput');
+
+  // Wait for error message
+  await vi.waitFor(() => {
+    expect((manager.getConversations()[0].messages[1] as ErrorMessage).message).toBeDefined();
+  });
+
+  const conversations = manager.getConversations();
+
+  expect(conversations.length).toBe(1);
+  expect(conversations[0].messages.length).toBe(2);
+  expect(conversations[0].messages[0]).toStrictEqual({
+    content: 'dummyUserInput',
+    id: expect.anything(),
+    options: undefined,
+    role: 'user',
+    timestamp: expect.any(Number),
+  });
+  expect(conversations[0].messages[1]).toStrictEqual({
+    message: 'Please reduce the length of the messages or completion. Note: You should start a new playground.',
+    id: expect.anything(),
+    timestamp: expect.any(Number),
+  });
+
+  expect(webviewMock.postMessage).toHaveBeenLastCalledWith({
+    id: Messages.MSG_CONVERSATIONS_UPDATE,
+    body: conversations,
   });
 });
 
@@ -570,7 +659,7 @@ describe('system prompt', () => {
 
     // Wait for assistant message to be completed
     await vi.waitFor(() => {
-      expect(manager.getConversations()[0].messages[1].content).toBeDefined();
+      expect((manager.getConversations()[0].messages[1] as ChatMessage).content).toBeDefined();
     });
 
     expect(() => {

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -26,7 +26,7 @@ import { Messages } from '@shared/Messages';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import type { TaskRegistry } from '../registries/TaskRegistry';
 import type { Task, TaskState } from '@shared/src/models/ITask';
-import { ChatMessage, ErrorMessage } from '@shared/src/models/IPlaygroundMessage';
+import type { ChatMessage, ErrorMessage } from '@shared/src/models/IPlaygroundMessage';
 
 vi.mock('openai', () => ({
   default: vi.fn(),

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -328,7 +328,7 @@ test('error', async () => {
     timestamp: expect.any(Number),
   });
   expect(conversations[0].messages[1]).toStrictEqual({
-    message: 'Please reduce the length of the messages or completion. Note: You should start a new playground.',
+    error: 'Please reduce the length of the messages or completion. Note: You should start a new playground.',
     id: expect.anything(),
     timestamp: expect.any(Number),
   });

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -22,7 +22,13 @@ import type { ChatCompletionChunk, ChatCompletionMessageParam } from 'openai/src
 import type { ModelOptions } from '@shared/src/models/IModelOptions';
 import type { Stream } from 'openai/streaming';
 import { ConversationRegistry } from '../registries/ConversationRegistry';
-import type { Conversation, ErrorMessage, PendingChat, SystemPrompt, UserChat } from '@shared/src/models/IPlaygroundMessage';
+import type {
+  Conversation,
+  ErrorMessage,
+  PendingChat,
+  SystemPrompt,
+  UserChat,
+} from '@shared/src/models/IPlaygroundMessage';
 import { isChatMessage, isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { withDefaultConfiguration } from '../utils/inferenceUtils';
@@ -300,13 +306,15 @@ export class PlaygroundV2Manager implements Disposable {
     const conversation = this.#conversationRegistry.get(conversationId);
     if (!conversation) throw new Error(`conversation with id ${conversationId} does not exist.`);
 
-    return conversation.messages.filter(m => isChatMessage(m)).map(
-      message =>
-        ({
-          name: undefined,
-          ...message,
-        }) as ChatCompletionMessageParam,
-    );
+    return conversation.messages
+      .filter(m => isChatMessage(m))
+      .map(
+        message =>
+          ({
+            name: undefined,
+            ...message,
+          }) as ChatCompletionMessageParam,
+      );
   }
 
   getConversations(): Conversation[] {

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -263,7 +263,7 @@ export class PlaygroundV2Manager implements Disposable {
     this.#conversationRegistry.submit(conversationId, {
       id: messageId,
       timestamp: start,
-      message: errorMessage,
+      error: errorMessage,
     } as ErrorMessage);
   }
 

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -250,7 +250,7 @@ export class PlaygroundV2Manager implements Disposable {
   private async processError(conversationId: string, error: unknown): Promise<void> {
     let errorMessage = String(error);
     if (errorMessage.endsWith('Please reduce the length of the messages or completion.')) {
-      errorMessage += ' Note: You should start a new playground';
+      errorMessage += ' Note: You should start a new playground.';
     }
     const messageId = this.#conversationRegistry.getUniqueId();
     const start = Date.now();

--- a/packages/backend/src/registries/ConversationRegistry.ts
+++ b/packages/backend/src/registries/ConversationRegistry.ts
@@ -22,6 +22,7 @@ import type {
   ChatMessage,
   Choice,
   Conversation,
+  Message,
   PendingChat,
 } from '@shared/src/models/IPlaygroundMessage';
 import type { Disposable, Webview } from '@podman-desktop/api';
@@ -141,7 +142,7 @@ export class ConversationRegistry extends Publisher<Conversation[]> implements D
    * @param conversationId
    * @param message
    */
-  submit(conversationId: string, message: ChatMessage): void {
+  submit(conversationId: string, message: Message): void {
     const conversation = this.#conversations.get(conversationId);
     if (conversation === undefined) throw new Error(`conversation with id ${conversationId} does not exist.`);
 

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { conversations } from '../stores/conversations';
 import { studioClient } from '/@/utils/client';
-import { isAssistantChat, isPendingChat, isUserChat, isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
+import { isAssistantChat, isPendingChat, isUserChat, isSystemPrompt, isChatMessage, isErrorMessage } from '@shared/src/models/IPlaygroundMessage';
 import { catalog } from '../stores/catalog';
 import { afterUpdate } from 'svelte';
 import ContentDetailsLayout from '../lib/ContentDetailsLayout.svelte';
@@ -30,12 +30,16 @@ let max_tokens = -1;
 let top_p = 0.5;
 
 $: conversation = $conversations.find(conversation => conversation.id === playgroundId);
-$: messages = conversation?.messages.filter(message => !isSystemPrompt(message)) ?? [];
+$: messages = conversation?.messages.filter(message => isChatMessage(message)).filter(message => !isSystemPrompt(message)) ?? [];
 $: model = $catalog.models.find(model => model.id === conversation?.modelId);
 $: {
   if (conversation?.messages.length) {
     const latest = conversation.messages[conversation.messages.length - 1];
     if (isSystemPrompt(latest) || (isAssistantChat(latest) && !isPendingChat(latest))) {
+      sendEnabled = true;
+    }
+    if (isErrorMessage(latest)) {
+      errorMsg = latest.message
       sendEnabled = true;
     }
   } else {

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 import { conversations } from '../stores/conversations';
 import { studioClient } from '/@/utils/client';
-import { isAssistantChat, isPendingChat, isUserChat, isSystemPrompt, isChatMessage, isErrorMessage } from '@shared/src/models/IPlaygroundMessage';
+import {
+  isAssistantChat,
+  isPendingChat,
+  isUserChat,
+  isSystemPrompt,
+  isChatMessage,
+  isErrorMessage,
+} from '@shared/src/models/IPlaygroundMessage';
 import { catalog } from '../stores/catalog';
 import { afterUpdate } from 'svelte';
 import ContentDetailsLayout from '../lib/ContentDetailsLayout.svelte';
@@ -30,7 +37,8 @@ let max_tokens = -1;
 let top_p = 0.5;
 
 $: conversation = $conversations.find(conversation => conversation.id === playgroundId);
-$: messages = conversation?.messages.filter(message => isChatMessage(message)).filter(message => !isSystemPrompt(message)) ?? [];
+$: messages =
+  conversation?.messages.filter(message => isChatMessage(message)).filter(message => !isSystemPrompt(message)) ?? [];
 $: model = $catalog.models.find(model => model.id === conversation?.modelId);
 $: {
   if (conversation?.messages.length) {
@@ -39,7 +47,7 @@ $: {
       sendEnabled = true;
     }
     if (isErrorMessage(latest)) {
-      errorMsg = latest.message
+      errorMsg = latest.message;
       sendEnabled = true;
     }
   } else {

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -47,7 +47,7 @@ $: {
       sendEnabled = true;
     }
     if (isErrorMessage(latest)) {
-      errorMsg = latest.message;
+      errorMsg = latest.error;
       sendEnabled = true;
     }
   } else {

--- a/packages/shared/src/models/IPlaygroundMessage.ts
+++ b/packages/shared/src/models/IPlaygroundMessage.ts
@@ -27,9 +27,9 @@ export interface ErrorMessage extends Message {
   message: string;
 }
 
-export interface ChatMessage extends Message {  
+export interface ChatMessage extends Message {
   role: 'system' | 'user' | 'assistant';
-  content?: string;  
+  content?: string;
 }
 
 export interface AssistantChat extends ChatMessage {

--- a/packages/shared/src/models/IPlaygroundMessage.ts
+++ b/packages/shared/src/models/IPlaygroundMessage.ts
@@ -24,7 +24,7 @@ export interface Message {
 }
 
 export interface ErrorMessage extends Message {
-  message: string;
+  error: string;
 }
 
 export interface ChatMessage extends Message {
@@ -64,7 +64,7 @@ export interface Choice {
 }
 
 export function isErrorMessage(msg: Message): msg is ErrorMessage {
-  return 'message' in msg;
+  return 'error' in msg;
 }
 
 export function isChatMessage(msg: Message): msg is ChatMessage {

--- a/packages/shared/src/models/IPlaygroundMessage.ts
+++ b/packages/shared/src/models/IPlaygroundMessage.ts
@@ -18,11 +18,18 @@
 
 import type { ModelOptions } from './IModelOptions';
 
-export interface ChatMessage {
+export interface Message {
   id: string;
-  role: 'system' | 'user' | 'assistant';
-  content?: string;
   timestamp: number;
+}
+
+export interface ErrorMessage extends Message {
+  message: string;
+}
+
+export interface ChatMessage extends Message {  
+  role: 'system' | 'user' | 'assistant';
+  content?: string;  
 }
 
 export interface AssistantChat extends ChatMessage {
@@ -47,7 +54,7 @@ export interface UserChat extends ChatMessage {
 
 export interface Conversation {
   id: string;
-  messages: ChatMessage[];
+  messages: Message[];
   modelId: string;
   name: string;
 }
@@ -56,18 +63,26 @@ export interface Choice {
   content: string;
 }
 
-export function isAssistantChat(msg: ChatMessage): msg is AssistantChat {
-  return msg.role === 'assistant';
+export function isErrorMessage(msg: Message): msg is ErrorMessage {
+  return 'message' in msg;
 }
 
-export function isUserChat(msg: ChatMessage): msg is UserChat {
-  return msg.role === 'user';
+export function isChatMessage(msg: Message): msg is ChatMessage {
+  return 'role' in msg;
 }
 
-export function isPendingChat(msg: ChatMessage): msg is PendingChat {
+export function isAssistantChat(msg: Message): msg is AssistantChat {
+  return isChatMessage(msg) && msg.role === 'assistant';
+}
+
+export function isUserChat(msg: Message): msg is UserChat {
+  return isChatMessage(msg) && msg.role === 'user';
+}
+
+export function isPendingChat(msg: Message): msg is PendingChat {
   return isAssistantChat(msg) && !msg.completed;
 }
 
-export function isSystemPrompt(msg: ChatMessage): msg is SystemPrompt {
-  return msg.role === 'system';
+export function isSystemPrompt(msg: Message): msg is SystemPrompt {
+  return isChatMessage(msg) && msg.role === 'system';
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds capabilities to display error messages during a chat. So far we just printed the errors in the console, but they are useful to guide the user. 

I extended the messages that a conversation includes. So far, we just had ChatMessages, but we could also have ErrorMessages. The only thing i'm not sure about is how to display them, so i chose to use what we have now (just show the newest error message if it's the last message of the conversation), but it could be very easy to display them as part of the conversation so when you scroll up you can see the error you received for an old input. Waiting to hear your preference.

### Screenshot / video of UI

![image](https://github.com/containers/podman-desktop-extension-ai-lab/assets/49404737/76e5251b-9f92-4394-bafc-e17bc46b32b7)

### What issues does this PR fix or reference?

it resolves https://github.com/containers/podman-desktop-extension-ai-lab/issues/1083 and https://github.com/containers/podman-desktop-extension-ai-lab/issues/1021

### How to test this PR?

1. open the playground
2. add a very long text ( > 2k chars), it should error (i used mistral model)