### PR TITLE
feat: showing models metadata

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -55,6 +55,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
+    "@huggingface/gguf": "^0.1.7",
     "isomorphic-git": "^1.26.5",
     "mustache": "^4.2.0",
     "openai": "^4.52.3",

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -29,7 +29,8 @@ import * as utils from '../utils/utils';
 import { TaskRegistry } from '../registries/TaskRegistry';
 import type { CancellationTokenRegistry } from '../registries/CancellationTokenRegistry';
 import * as sha from '../utils/sha';
-import { gguf, GGUFParseOutput } from '@huggingface/gguf';
+import type { GGUFParseOutput } from '@huggingface/gguf';
+import { gguf } from '@huggingface/gguf';
 
 const mocks = vi.hoisted(() => {
   return {

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -29,6 +29,7 @@ import * as utils from '../utils/utils';
 import { TaskRegistry } from '../registries/TaskRegistry';
 import type { CancellationTokenRegistry } from '../registries/CancellationTokenRegistry';
 import * as sha from '../utils/sha';
+import { gguf, GGUFParseOutput } from '@huggingface/gguf';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -44,6 +45,10 @@ const mocks = vi.hoisted(() => {
     getPodmanCliMock: vi.fn(),
   };
 });
+
+vi.mock('@huggingface/gguf', () => ({
+  gguf: vi.fn(),
+}));
 
 vi.mock('../utils/podman', () => ({
   getFirstRunningMachineName: mocks.getFirstRunningMachineNameMock,
@@ -833,5 +838,101 @@ describe('downloadModel', () => {
     // Only called once
     expect(mocks.performDownloadMock).toHaveBeenCalledTimes(1);
     expect(mocks.onEventDownloadMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getModelMetadata', () => {
+  test('unknown model', async () => {
+    const manager = new ModelsManager(
+      'appdir',
+      {} as Webview,
+      {
+        getModels: (): ModelInfo[] => [],
+      } as CatalogManager,
+      telemetryLogger,
+      taskRegistry,
+      cancellationTokenRegistryMock,
+    );
+
+    await expect(() => manager.getModelMetadata('unknown-model-id')).rejects.toThrowError(
+      'model with id unknown-model-id does not exists.',
+    );
+  });
+
+  test('remote model', async () => {
+    const manager = new ModelsManager(
+      'appdir',
+      {} as Webview,
+      {
+        getModels: (): ModelInfo[] => [
+          {
+            id: 'test-model-id',
+            url: 'dummy-url',
+            file: undefined,
+          } as unknown as ModelInfo,
+        ],
+        onCatalogUpdate: vi.fn(),
+      } as unknown as CatalogManager,
+      telemetryLogger,
+      taskRegistry,
+      cancellationTokenRegistryMock,
+    );
+
+    manager.init();
+
+    const fakeMetadata: Record<string, string> = {
+      hello: 'world',
+    };
+
+    vi.mocked(gguf).mockResolvedValue({
+      metadata: fakeMetadata,
+    } as unknown as GGUFParseOutput & { parameterCount: number });
+
+    const result = await manager.getModelMetadata('test-model-id');
+    expect(result).toStrictEqual(fakeMetadata);
+
+    expect(gguf).toHaveBeenCalledWith('dummy-url');
+  });
+
+  test('local model', async () => {
+    const manager = new ModelsManager(
+      'appdir',
+      {
+        postMessage: vi.fn(),
+      } as unknown as Webview,
+      {
+        getModels: (): ModelInfo[] => [
+          {
+            id: 'test-model-id',
+            url: 'dummy-url',
+            file: {
+              file: 'random',
+              path: 'dummy-path',
+            },
+          } as unknown as ModelInfo,
+        ],
+        onCatalogUpdate: vi.fn(),
+      } as unknown as CatalogManager,
+      telemetryLogger,
+      taskRegistry,
+      cancellationTokenRegistryMock,
+    );
+
+    manager.init();
+
+    const fakeMetadata: Record<string, string> = {
+      hello: 'world',
+    };
+
+    vi.mocked(gguf).mockResolvedValue({
+      metadata: fakeMetadata,
+    } as unknown as GGUFParseOutput & { parameterCount: number });
+
+    const result = await manager.getModelMetadata('test-model-id');
+    expect(result).toStrictEqual(fakeMetadata);
+
+    expect(gguf).toHaveBeenCalledWith(path.join('dummy-path', 'random'), {
+      allowLocalFile: true,
+    });
   });
 });

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -34,7 +34,8 @@ import { deleteRemoteModel, getLocalModelFile, isModelUploaded } from '../utils/
 import { getFirstRunningMachineName } from '../utils/podman';
 import type { CancellationTokenRegistry } from '../registries/CancellationTokenRegistry';
 import { hasValidSha } from '../utils/sha';
-import { gguf, GGUFParseOutput } from '@huggingface/gguf';
+import type { GGUFParseOutput } from '@huggingface/gguf';
+import { gguf } from '@huggingface/gguf';
 
 export class ModelsManager implements Disposable {
   #models: Map<string, ModelInfo>;
@@ -430,16 +431,16 @@ export class ModelsManager implements Disposable {
 
     const before = performance.now();
     const data: Record<string, unknown> = {
-      'model-id': model.url?modelId:'imported', // filter imported models
+      'model-id': model.url ? modelId : 'imported', // filter imported models
     };
 
     try {
       let result: GGUFParseOutput<{ strict: false }>;
-      if(this.isModelOnDisk(modelId)) {
+      if (this.isModelOnDisk(modelId)) {
         const modelPath = path.normalize(getLocalModelFile(model));
         console.debug(`[getModelMetadata] reading model ${modelPath}`);
         result = await gguf(modelPath, { allowLocalFile: true });
-      } else if(model.url) {
+      } else if (model.url) {
         result = await gguf(model.url);
       } else {
         throw new Error('cannot get model metadata');

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { LocalModelInfo } from '@shared/src/models/ILocalModelInfo';
-import fs from 'fs';
+import fs from 'node:fs';
 import * as path from 'node:path';
 import { type Webview, fs as apiFs, type Disposable, env } from '@podman-desktop/api';
 import { Messages } from '@shared/Messages';
@@ -34,6 +34,7 @@ import { deleteRemoteModel, getLocalModelFile, isModelUploaded } from '../utils/
 import { getFirstRunningMachineName } from '../utils/podman';
 import type { CancellationTokenRegistry } from '../registries/CancellationTokenRegistry';
 import { hasValidSha } from '../utils/sha';
+import { gguf, GGUFParseOutput } from '@huggingface/gguf';
 
 export class ModelsManager implements Disposable {
   #models: Map<string, ModelInfo>;
@@ -421,5 +422,37 @@ export class ModelsManager implements Disposable {
 
     // perform download
     return uploader.perform(model.id);
+  }
+
+  async getModelMetadata(modelId: string): Promise<Record<string, unknown>> {
+    const model = this.#models.get(modelId);
+    if (!model) throw new Error(`model with id ${modelId} does not exists.`);
+
+    const before = performance.now();
+    const data: Record<string, unknown> = {
+      'model-id': model.url?modelId:'imported', // filter imported models
+    };
+
+    try {
+      let result: GGUFParseOutput<{ strict: false }>;
+      if(this.isModelOnDisk(modelId)) {
+        const modelPath = path.normalize(getLocalModelFile(model));
+        console.debug(`[getModelMetadata] reading model ${modelPath}`);
+        result = await gguf(modelPath, { allowLocalFile: true });
+      } else if(model.url) {
+        result = await gguf(model.url);
+      } else {
+        throw new Error('cannot get model metadata');
+      }
+      console.log('result', result);
+      return result.metadata;
+    } catch (err: unknown) {
+      data['error'] = err;
+      console.error(err);
+      throw err;
+    } finally {
+      data['duration'] = performance.now() - before;
+      this.telemetry.logUsage('get-metadata');
+    }
   }
 }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -507,6 +507,10 @@ export class StudioApiImpl implements StudioAPI {
     return podmanDesktopApi.env.clipboard.writeText(content);
   }
 
+  getModelMetadata(modelId: string): Promise<Record<string, unknown>> {
+    return this.modelsManager.getModelMetadata(modelId);
+  }
+
   async checkContainerConnectionStatusAndResources(modelInfo: ModelCheckerInfo): Promise<ContainerConnectionInfo> {
     return checkContainerConnectionStatusAndResources(modelInfo);
   }

--- a/packages/backend/vite.config.js
+++ b/packages/backend/vite.config.js
@@ -49,6 +49,7 @@ const config = {
     rollupOptions: {
       external: [
         '@podman-desktop/api',
+        '@huggingface/gguf',
         ...builtinModules.flatMap(p => [p, `node:${p}`]),
       ],
       output: {

--- a/packages/frontend/src/pages/Model.svelte
+++ b/packages/frontend/src/pages/Model.svelte
@@ -6,6 +6,7 @@ import { router } from 'tinro';
 import { Tab } from '@podman-desktop/ui-svelte';
 import Route from '/@/Route.svelte';
 import ModelInspect from '/@/pages/ModelInspect.svelte';
+import { InferenceType } from '@shared/src/models/IInference';
 
 export let modelId: string;
 
@@ -24,8 +25,10 @@ export function goToUpPage(): void {
   on:close="{goToUpPage}"
   on:breadcrumbClick="{goToUpPage}">
   <svelte:fragment slot="tabs">
-    <Tab title="Summary" url="/model/{modelId}" selected="{$router.path === `/model/${modelId}`}" />
-    <Tab title="Inspect" url="/model/{modelId}/inspect" selected="{$router.path === `/model/${modelId}/inspect`}" />
+    {#if model?.backend === InferenceType.LLAMA_CPP}
+      <Tab title="Summary" url="/model/{modelId}" selected="{$router.path === `/model/${modelId}`}" />
+      <Tab title="Inspect" url="/model/{modelId}/inspect" selected="{$router.path === `/model/${modelId}/inspect`}" />
+    {/if}
   </svelte:fragment>
   <svelte:fragment slot="content">
       <div class="flex flex-row w-full h-full bg-[var(--pd-content-bg)] overflow-y-auto">

--- a/packages/frontend/src/pages/Model.svelte
+++ b/packages/frontend/src/pages/Model.svelte
@@ -31,15 +31,15 @@ export function goToUpPage(): void {
     {/if}
   </svelte:fragment>
   <svelte:fragment slot="content">
-      <div class="flex flex-row w-full h-full bg-[var(--pd-content-bg)] overflow-y-auto">
-        <Route path="/">
-          <div class="flex-grow p-5">
-            <MarkdownRenderer source="{model?.description}" />
-          </div>
-        </Route>
-        <Route path="/inspect">
-          <ModelInspect modelId="{modelId}"/>
-        </Route>
-      </div>
+    <div class="flex flex-row w-full h-full bg-[var(--pd-content-bg)] overflow-y-auto">
+      <Route path="/">
+        <div class="flex-grow p-5">
+          <MarkdownRenderer source="{model?.description}" />
+        </div>
+      </Route>
+      <Route path="/inspect">
+        <ModelInspect modelId="{modelId}" />
+      </Route>
+    </div>
   </svelte:fragment>
 </DetailsPage>

--- a/packages/frontend/src/pages/Model.svelte
+++ b/packages/frontend/src/pages/Model.svelte
@@ -3,6 +3,9 @@ import MarkdownRenderer from '/@/lib/markdown/MarkdownRenderer.svelte';
 import { catalog } from '/@/stores/catalog';
 import { DetailsPage } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
+import { Tab } from '@podman-desktop/ui-svelte';
+import Route from '/@/Route.svelte';
+import ModelInspect from '/@/pages/ModelInspect.svelte';
 
 export let modelId: string;
 
@@ -20,11 +23,20 @@ export function goToUpPage(): void {
   breadcrumbTitle="Go back to Models"
   on:close="{goToUpPage}"
   on:breadcrumbClick="{goToUpPage}">
+  <svelte:fragment slot="tabs">
+    <Tab title="Summary" url="/model/{modelId}" selected="{$router.path === `/model/${modelId}`}" />
+    <Tab title="Inspect" url="/model/{modelId}/inspect" selected="{$router.path === `/model/${modelId}/inspect`}" />
+  </svelte:fragment>
   <svelte:fragment slot="content">
-    <div class="flex flex-row w-full h-full bg-[var(--pd-content-bg)] overflow-y-auto">
-      <div class="flex-grow p-5">
-        <MarkdownRenderer source="{model?.description}" />
+      <div class="flex flex-row w-full h-full bg-[var(--pd-content-bg)] overflow-y-auto">
+        <Route path="/">
+          <div class="flex-grow p-5">
+            <MarkdownRenderer source="{model?.description}" />
+          </div>
+        </Route>
+        <Route path="/inspect">
+          <ModelInspect modelId="{modelId}"/>
+        </Route>
       </div>
-    </div>
   </svelte:fragment>
 </DetailsPage>

--- a/packages/frontend/src/pages/ModelInspect.spec.ts
+++ b/packages/frontend/src/pages/ModelInspect.spec.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { vi, test, expect, beforeEach } from 'vitest';
+import { render, within } from '@testing-library/svelte';
+import ModelInspect from '/@/pages/ModelInspect.svelte';
+import { studioClient } from '/@/utils/client';
+
+const mocks = vi.hoisted(() => ({
+  getModelsMetataStoreContent: vi.fn(),
+  modelsMetadataStoreMock: {
+    subscribe: (f: (msg: any) => void) => {
+      f(mocks.getModelsMetataStoreContent());
+      return () => {};
+    },
+  },
+}));
+
+vi.mock('../utils/client', async () => {
+  return {
+    studioClient: {
+      getModelMetadata: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../stores/modelsMetadata', async () => {
+  return {
+    modelsMetadata: mocks.modelsMetadataStoreMock,
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('empty store should fetch metadata', async () => {
+  mocks.getModelsMetataStoreContent.mockReturnValue({});
+  vi.mocked(studioClient.getModelMetadata).mockResolvedValue({});
+
+  render(ModelInspect, {
+    modelId: 'dummy-model-id',
+  });
+
+  await vi.waitFor(() => {
+    expect(studioClient.getModelMetadata).toHaveBeenCalledWith('dummy-model-id');
+  });
+});
+
+test('store with existing metadata should use it', async () => {
+  mocks.getModelsMetataStoreContent.mockReturnValue({
+    'dummy-model-id': {},
+  });
+
+  const { container } = render(ModelInspect, {
+    modelId: 'dummy-model-id',
+  });
+
+  await vi.waitFor(() => {
+    expect(within(container).queryByRole('progressbar')).toBeNull();
+  });
+
+  expect(studioClient.getModelMetadata).not.toHaveBeenCalled();
+});
+
+test('api error should be displayed', async () => {
+  mocks.getModelsMetataStoreContent.mockReturnValue({});
+
+  vi.mocked(studioClient.getModelMetadata).mockRejectedValue(new Error('dummy test error'));
+  const { container } = render(ModelInspect, {
+    modelId: 'dummy-model-id',
+  });
+
+  await vi.waitFor(() => {
+    expect(within(container).getByRole('alert').textContent).toBe(
+      'Something went wrong while fetching model metadata: Error: dummy test error',
+    );
+  });
+});

--- a/packages/frontend/src/pages/ModelInspect.svelte
+++ b/packages/frontend/src/pages/ModelInspect.svelte
@@ -41,8 +41,6 @@ const row = new TableRow<Item>({});
 
 onMount(() => {
   return modelsMetadata.subscribe(metadatas => {
-    console.log('[ModelInspect] metadatas', metadatas);
-
     const records = metadatas[modelId];
     if (records) {
       items = Object.entries(records).map(([key, value]) => ({

--- a/packages/frontend/src/pages/ModelInspect.svelte
+++ b/packages/frontend/src/pages/ModelInspect.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { modelsMetadata } from '/@/stores/modelsMetadata';
+import { Table, TableRow, TableColumn, TableSimpleColumn, ErrorMessage, LinearProgress } from '@podman-desktop/ui-svelte';
+import { studioClient } from '/@/utils/client';
+
+export let modelId: string;
+
+type Item = {
+  name: string,
+  value: string;
+};
+
+let items: Item[] = [];
+$: items;
+
+let loading: boolean = true;
+$: loading;
+
+let error: string | undefined = undefined;
+$: error;
+
+const columns = [
+  new TableColumn<Item, string>('property', {
+    renderMapping: item => String(item.name),
+    renderer: TableSimpleColumn,
+  }),
+  new TableColumn<Item, string>('value', {
+    renderMapping: item => String(item.value),
+    renderer: TableSimpleColumn,
+  }),
+];
+const row = new TableRow<Item>({});
+
+onMount(() => {
+  return modelsMetadata.subscribe((metadatas) => {
+    console.log('[ModelInspect] metadatas', metadatas);
+
+    const records = metadatas[modelId];
+    if(records) {
+      items = Object.entries(records).map(([key, value]) => ({
+        name: key,
+        value: String(value),
+      }));
+      console.log(`found ${items.length} items`);
+      loading = false;
+      error = undefined;
+    } else {
+      studioClient.getModelMetadata(modelId).then((result) => {
+        modelsMetadata.set({
+          ...metadatas,
+          [modelId]: result,
+        });
+      }).catch((err: unknown) => {
+        loading = false;
+        error = `Something went wrong while fetching model metadata: ${err}`;
+      });
+    }
+  });
+});
+
+</script>
+
+<div class="flex flex-col grow min-h-full">
+  <div class="w-full h-full flex flex-col flex-1">
+    {#if loading}
+      <LinearProgress/>
+    {/if}
+    {#if error}
+      <ErrorMessage error="{error}"/>
+    {/if}
+    <Table kind="model" data="{items}" columns="{columns}" row="{row}"/>
+  </div>
+</div>
+

--- a/packages/frontend/src/pages/ModelInspect.svelte
+++ b/packages/frontend/src/pages/ModelInspect.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { modelsMetadata } from '/@/stores/modelsMetadata';
-import { Table, TableRow, TableColumn, TableSimpleColumn, ErrorMessage, LinearProgress } from '@podman-desktop/ui-svelte';
+import {
+  Table,
+  TableRow,
+  TableColumn,
+  TableSimpleColumn,
+  ErrorMessage,
+  LinearProgress,
+} from '@podman-desktop/ui-svelte';
 import { studioClient } from '/@/utils/client';
 
 export let modelId: string;
 
 type Item = {
-  name: string,
+  name: string;
   value: string;
 };
 
@@ -33,11 +40,11 @@ const columns = [
 const row = new TableRow<Item>({});
 
 onMount(() => {
-  return modelsMetadata.subscribe((metadatas) => {
+  return modelsMetadata.subscribe(metadatas => {
     console.log('[ModelInspect] metadatas', metadatas);
 
     const records = metadatas[modelId];
-    if(records) {
+    if (records) {
       items = Object.entries(records).map(([key, value]) => ({
         name: key,
         value: String(value),
@@ -46,30 +53,31 @@ onMount(() => {
       loading = false;
       error = undefined;
     } else {
-      studioClient.getModelMetadata(modelId).then((result) => {
-        modelsMetadata.set({
-          ...metadatas,
-          [modelId]: result,
+      studioClient
+        .getModelMetadata(modelId)
+        .then(result => {
+          modelsMetadata.set({
+            ...metadatas,
+            [modelId]: result,
+          });
+        })
+        .catch((err: unknown) => {
+          loading = false;
+          error = `Something went wrong while fetching model metadata: ${err}`;
         });
-      }).catch((err: unknown) => {
-        loading = false;
-        error = `Something went wrong while fetching model metadata: ${err}`;
-      });
     }
   });
 });
-
 </script>
 
 <div class="flex flex-col grow min-h-full">
   <div class="w-full h-full flex flex-col flex-1">
     {#if loading}
-      <LinearProgress/>
+      <LinearProgress />
     {/if}
     {#if error}
-      <ErrorMessage error="{error}"/>
+      <ErrorMessage error="{error}" />
     {/if}
-    <Table kind="model" data="{items}" columns="{columns}" row="{row}"/>
+    <Table kind="model" data="{items}" columns="{columns}" row="{row}" />
   </div>
 </div>
-

--- a/packages/frontend/src/stores/modelsMetadata.ts
+++ b/packages/frontend/src/stores/modelsMetadata.ts
@@ -1,0 +1,3 @@
+import { type Writable, writable } from 'svelte/store';
+
+export const modelsMetadata: Writable<Record<string, Record<string, unknown>>> = writable({});

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -204,6 +204,8 @@ export abstract class StudioAPI {
    */
   abstract copyToClipboard(content: string): Promise<void>;
 
+  abstract getModelMetadata(modelId: string): Promise<Record<string, unknown>>;
+
   /**
    * Check if the running podman machine is running and has enough resources to execute task
    * @param modelInfo object containing info about the model to check

--- a/packages/shared/src/messages/NoTimeoutChannels.ts
+++ b/packages/shared/src/messages/NoTimeoutChannels.ts
@@ -16,4 +16,4 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const noTimeoutChannels: string[] = ['openDialog'];
+export const noTimeoutChannels: string[] = ['openDialog', 'getModelMetadata'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,6 +276,11 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.5.2"
 
+"@huggingface/gguf@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@huggingface/gguf/-/gguf-0.1.7.tgz#0f5afab60f182cf27341738bff794750cacb5876"
+  integrity sha512-RQN1WwuusLjiBTNFuAJCUlhRejIhKt395ywnTmc+Jy8dajGwk8k7EsfgtxVqkBSTWy9D55XzCII7jUjkHEv3JA==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
@@ -4176,16 +4181,7 @@ std-env@^3.5.0:
   resolved "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4237,14 +4233,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4864,16 +4853,7 @@ winreg@^1.2.5:
   resolved "https://registry.yarnpkg.com/winreg/-/winreg-1.2.5.tgz#b650383e89278952494b5d113ba049a5a4fa96d8"
   integrity sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
### What does this PR do?

Adding a Tab in the model detail page for GGUF models.

If the model is already downloaded, using it, otherwise using download url to fetch metadata.

This is possible thanks to the amazing library [@huggingface/gguf](https://www.npmjs.com/package/@huggingface/gguf)

### Screenshot / video of UI

https://github.com/containers/podman-desktop-extension-ai-lab/assets/42176370/c7449021-e428-4202-bbc1-bd693afa0344

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1344

### How to test this PR?

- [x] unit tests has been provided