### PR TITLE
Extending e2e graphical happy path scenario

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:shared": "vitest run -r packages/shared --passWithNoTests --coverage",
     "test:unit": "npm run test:backend && npm run test:shared && npm run test:frontend",
     "test:e2e": "cd tests/playwright && npm run test:e2e",
+    "test:e2e:watch": "dirname=$(pwd) && cd ${PODMAN_DESKTOP_ARGS} && yarn watch --extension-folder ${dirname}",
     "typecheck:shared": "tsc --noEmit --project packages/shared",
     "typecheck:frontend": "tsc --noEmit --project packages/frontend",
     "typecheck:backend": "tsc --noEmit --project packages/backend",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test:shared": "vitest run -r packages/shared --passWithNoTests --coverage",
     "test:unit": "npm run test:backend && npm run test:shared && npm run test:frontend",
     "test:e2e": "cd tests/playwright && npm run test:e2e",
-    "test:e2e:watch": "dirname=$(pwd) && cd ${PODMAN_DESKTOP_ARGS} && yarn watch --extension-folder ${dirname}",
     "typecheck:shared": "tsc --noEmit --project packages/shared",
     "typecheck:frontend": "tsc --noEmit --project packages/frontend",
     "typecheck:backend": "tsc --noEmit --project packages/backend",

--- a/tests/playwright/src/ai-lab-extension.spec.ts
+++ b/tests/playwright/src/ai-lab-extension.spec.ts
@@ -98,7 +98,11 @@ describe(`AI Lab extension installation and verification`, async () => {
 });
 
 async function handleWebview(): Promise<[Page, Page]> {
-  await navigationBar.navigationLocator.getByLabel(AI_LAB_NAVBAR_EXTENSION_LABEL).click({ timeout: 5_000 });
+  const aiLabPodmanExtensionButton = navigationBar.navigationLocator.getByRole('link', {
+    name: AI_LAB_NAVBAR_EXTENSION_LABEL,
+  });
+  await playExpect(aiLabPodmanExtensionButton).toBeEnabled();
+  await aiLabPodmanExtensionButton.click();
   await page.waitForTimeout(2_000);
 
   const webView = page.getByRole('document', { name: AI_LAB_PAGE_BODY_LABEL });

--- a/tests/playwright/src/ai-lab-extension.spec.ts
+++ b/tests/playwright/src/ai-lab-extension.spec.ts
@@ -16,14 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Locator, Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
 import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
 import type { DashboardPage, ExtensionsPage, RunnerTestContext } from '@podman-desktop/tests-playwright';
 import { NavigationBar, WelcomePage, PodmanDesktopRunner } from '@podman-desktop/tests-playwright';
 import { AILabPage } from './model/ai-lab-page';
+import type { AILabRecipesCatalogPage } from './model/ai-lab-recipes-catalog-page';
+import type { AILabAppDetailsPage } from './model/ai-lab-app-details-page';
 
-const AI_LAB_EXTENSION_OCI_IMAGE: string = process.env.AI_LAB_OCI ?? 'ghcr.io/containers/podman-desktop-extension-ai-lab:nightly';
+const AI_LAB_EXTENSION_OCI_IMAGE: string =
+  process.env.AI_LAB_OCI ?? 'ghcr.io/containers/podman-desktop-extension-ai-lab:nightly';
 const AI_LAB_CATALOG_EXTENSION_LABEL: string = 'redhat.ai-lab';
 const AI_LAB_NAVBAR_EXTENSION_LABEL: string = 'AI Lab';
 const AI_LAB_PAGE_BODY_LABEL: string = 'Webview AI Lab';
@@ -32,6 +35,8 @@ const AI_LAB_AI_APP_NAME: string = 'ChatBot';
 let pdRunner: PodmanDesktopRunner;
 let page: Page;
 let webview: Page;
+let aiLabPage: AILabPage;
+let recipesCatalogPage: AILabRecipesCatalogPage;
 
 let navigationBar: NavigationBar;
 let dashboardPage: DashboardPage;
@@ -65,31 +70,29 @@ describe(`AI Lab extension installation and verification`, async () => {
     test(`Install AI Lab extension`, async () => {
       await extensionsPage.installExtensionFromOCIImage(AI_LAB_EXTENSION_OCI_IMAGE);
       await playExpect
-        .poll(async () => await extensionsPage.extensionIsInstalled(AI_LAB_CATALOG_EXTENSION_LABEL), { timeout: 30000 })
+        .poll(async () => await extensionsPage.extensionIsInstalled(AI_LAB_CATALOG_EXTENSION_LABEL), {
+          timeout: 30_000,
+        })
         .toBeTruthy();
     });
   });
   describe(`AI Lab extension verification`, async () => {
     test(`Verify AI Lab is responsive`, async () => {
       [page, webview] = await handleWebview();
-      const aiLabPage = new AILabPage(page, webview);
-      await aiLabPage.waitForPageLoad();
+      aiLabPage = new AILabPage(page, webview);
+      await aiLabPage.waitForLoad();
     });
     test(`Open Recipes Catalog`, async () => {
-      [page, webview] = await handleWebview();
-      const aiLabPage = new AILabPage(page, webview);
-      await aiLabPage.openRecipesCatalog();
+      recipesCatalogPage = await aiLabPage.navigationBar.openRecipesCatalog();
+      await recipesCatalogPage.waitForLoad();
     });
     test(`Install ChatBot example app`, { timeout: 780_000 }, async () => {
-      [page, webview] = await handleWebview();
-      const aiLabPage = new AILabPage(page, webview);
-      await aiLabPage.openRecipesCatalogApp(aiLabPage.recipesCatalogNaturalLanguageProcessing, AI_LAB_AI_APP_NAME);
-      try {
-        await aiLabPage.tryDeleteOpenApp();
-      } catch(error) {
-        console.warn(`Warning: Could not delete open app, possibly app is not installed.\n${error}`);
-      }
-      await aiLabPage.startOpenApp();
+      const chatBotApp: AILabAppDetailsPage = await recipesCatalogPage.openRecipesCatalogApp(
+        recipesCatalogPage.recipesCatalogNaturalLanguageProcessing,
+        AI_LAB_AI_APP_NAME,
+      );
+      await chatBotApp.waitForLoad();
+      await chatBotApp.startNewDeployment();
     });
   });
 });

--- a/tests/playwright/src/model/ai-lab-app-details-page.ts
+++ b/tests/playwright/src/model/ai-lab-app-details-page.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect as playExpect } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
+import { handleConfirmationDialog } from '@podman-desktop/tests-playwright';
+
+export class AILabAppDetailsPage {
+  readonly page: Page;
+  readonly webview: Page;
+  readonly appName: string;
+  readonly heading: Locator;
+
+  readonly startRecipeButton: Locator;
+  readonly confirmStartRecipeButton: Locator;
+  readonly recipeStatus: Locator;
+
+  readonly applicationDetailsPanel: Locator;
+  readonly openAIAppButton: Locator;
+  readonly deleteAIAppButton: Locator;
+
+  constructor(page: Page, webview: Page, appName: string) {
+    this.page = page;
+    this.webview = webview;
+    this.appName = appName;
+    this.heading = webview.getByRole('heading', { name: this.appName });
+
+    this.startRecipeButton = this.webview.getByRole('button', { name: 'Start recipe' });
+    this.confirmStartRecipeButton = this.webview.getByRole('button', { name: /Start(\s+([A-Za-z]+\s+)+)recipe/i });
+    this.recipeStatus = this.webview.getByRole('status');
+
+    this.applicationDetailsPanel = webview.getByLabel('application details panel');
+    this.openAIAppButton = this.applicationDetailsPanel.getByRole('button', { name: 'Open AI App' });
+    this.deleteAIAppButton = this.applicationDetailsPanel.getByRole('button', { name: 'Delete AI App' });
+  }
+
+  async waitForLoad(): Promise<void> {
+    await playExpect(this.heading).toBeVisible();
+  }
+
+  async startNewDeployment(): Promise<void> {
+    await playExpect(this.startRecipeButton).toBeEnabled();
+    await this.startRecipeButton.click();
+    await playExpect(this.confirmStartRecipeButton).toBeEnabled();
+    await this.confirmStartRecipeButton.click();
+    try {
+      await handleConfirmationDialog(this.page, 'Podman AI Lab', true, 'Reset');
+    } catch (error) {
+      console.warn(`Warning: Could not reset the app, repository probably clean.\n\t${error}`);
+    }
+    await playExpect(this.recipeStatus).toContainText('AI App is running', { timeout: 720_000 });
+  }
+
+  async openRunningApps(): Promise<void> {
+    console.error('Not implemented');
+  }
+
+  async deleteRunningApp(_containerName: string): Promise<void> {
+    console.error('Not implemented');
+  }
+
+  /**
+   * @deprecated Use `deleteRunningApp(containerName: string)` instead
+   * @throws {Error} If the app details are not visible or Delete AI App button is not visible
+   */
+  async tryDeleteOpenApp(): Promise<void> {
+    await playExpect(this.applicationDetailsPanel).toBeVisible();
+    await this.deleteAIAppButton.click();
+    try {
+      await handleConfirmationDialog(this.page, 'Podman AI Lab', true, 'Confirm');
+    } catch (error) {
+      console.warn(
+        `Warning: Delete app confirmation dialog interaction failed, possibly app is not installed.\n\t${error}`,
+      );
+    }
+    await playExpect(this.applicationDetailsPanel).toContainText('AI App Removed', { timeout: 30_000 });
+    await playExpect(this.startRecipeButton).toBeVisible();
+  }
+}

--- a/tests/playwright/src/model/ai-lab-app-details-page.ts
+++ b/tests/playwright/src/model/ai-lab-app-details-page.ts
@@ -28,7 +28,7 @@ export class AILabAppDetailsPage extends AILabBasePage {
   constructor(page: Page, webview: Page, appName: string) {
     super(page, webview);
     this.appName = appName;
-    this.heading = webview.getByRole('heading', { name: this.appName });
+    this.heading = this.webview.getByRole('heading', { name: this.appName });
 
     this.startRecipeButton = this.webview.getByRole('button', { name: 'Start recipe' });
   }

--- a/tests/playwright/src/model/ai-lab-app-details-page.ts
+++ b/tests/playwright/src/model/ai-lab-app-details-page.ts
@@ -26,10 +26,8 @@ export class AILabAppDetailsPage extends AILabBasePage {
   readonly startRecipeButton: Locator;
 
   constructor(page: Page, webview: Page, appName: string) {
-    super(page, webview);
+    super(page, webview, appName);
     this.appName = appName;
-    this.heading = this.webview.getByRole('heading', { name: this.appName });
-
     this.startRecipeButton = this.webview.getByRole('button', { name: 'Start recipe' });
   }
 

--- a/tests/playwright/src/model/ai-lab-base-page.ts
+++ b/tests/playwright/src/model/ai-lab-base-page.ts
@@ -18,20 +18,16 @@
 
 import type { Locator, Page } from '@playwright/test';
 
-export class AILabBasePage {
+export abstract class AILabBasePage {
   readonly page: Page;
   readonly webview: Page;
   heading: Locator;
 
-  constructor(page: Page, webview: Page) {
+  constructor(page: Page, webview: Page, heading: string | undefined) {
     this.page = page;
     this.webview = webview;
-    this.heading = webview.getByRole('heading', { name: 'Welcome to Podman AI Lab' });
+    this.heading = webview.getByRole('heading', { name: heading });
   }
 
-  // This method should be overridden in derived classes
-  async waitForLoad(): Promise<void> {
-    // Default implementation (can be empty or throw an error)
-    throw new Error('Method not implemented.');
-  }
+  abstract waitForLoad(): Promise<void>;
 }

--- a/tests/playwright/src/model/ai-lab-base-page.ts
+++ b/tests/playwright/src/model/ai-lab-base-page.ts
@@ -16,22 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Page } from '@playwright/test';
-import { expect as playExpect } from '@playwright/test';
-import { AILabBasePage } from './ai-lab-base-page';
-import { AILabNavigationBar } from './ai-lab-navigation-bar';
+import type { Locator, Page } from '@playwright/test';
 
-export class AILabPage extends AILabBasePage {
-  readonly navigationBar: AILabNavigationBar;
+export class AILabBasePage {
+  readonly page: Page;
+  readonly webview: Page;
+  heading: Locator;
 
   constructor(page: Page, webview: Page) {
-    super(page, webview);
-    this.heading = webview.getByLabel('Welcome to Podman AI Lab');
-    this.navigationBar = new AILabNavigationBar(this.page, this.webview);
+    this.page = page;
+    this.webview = webview;
+    this.heading = webview.getByRole('heading', { name: 'Welcome to Podman AI Lab' });
   }
 
+  // This method should be overridden in derived classes
   async waitForLoad(): Promise<void> {
-    await playExpect(this.heading).toBeVisible();
-    await this.navigationBar.waitForLoad();
+    // Default implementation (can be empty or throw an error)
+    throw new Error('Method not implemented.');
   }
 }

--- a/tests/playwright/src/model/ai-lab-navigation-bar.ts
+++ b/tests/playwright/src/model/ai-lab-navigation-bar.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect as playExpect } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
+import { AILabRecipesCatalogPage } from './ai-lab-recipes-catalog-page';
+
+export class AILabNavigationBar {
+  readonly page: Page;
+  readonly webview: Page;
+  readonly navigationBar: Locator;
+
+  readonly recipesCatalogButton: Locator;
+  readonly runningAppsButton: Locator;
+  readonly catalogButton: Locator;
+  readonly servicesButton: Locator;
+  readonly playgroundsButton: Locator;
+
+  constructor(page: Page, webview: Page) {
+    this.page = page;
+    this.webview = webview;
+    this.navigationBar = webview.getByLabel('PreferencesNavigation');
+
+    this.recipesCatalogButton = this.navigationBar.getByLabel('Recipes Catalog', { exact: true });
+    this.runningAppsButton = this.navigationBar.getByLabel('Running');
+    this.catalogButton = this.navigationBar.getByLabel('Catalog', { exact: true });
+    this.servicesButton = this.navigationBar.getByLabel('Services');
+    this.playgroundsButton = this.navigationBar.getByLabel('Playgrounds');
+  }
+
+  async waitForLoad(): Promise<void> {
+    await playExpect(this.navigationBar).toBeVisible();
+  }
+
+  async openRecipesCatalog(): Promise<AILabRecipesCatalogPage> {
+    await playExpect(this.recipesCatalogButton).toBeVisible();
+    await playExpect(this.recipesCatalogButton).toBeEnabled();
+    await this.recipesCatalogButton.click();
+    return new AILabRecipesCatalogPage(this.page, this.webview);
+  }
+}

--- a/tests/playwright/src/model/ai-lab-navigation-bar.ts
+++ b/tests/playwright/src/model/ai-lab-navigation-bar.ts
@@ -36,11 +36,11 @@ export class AILabNavigationBar {
     this.webview = webview;
     this.navigationBar = webview.getByLabel('PreferencesNavigation');
 
-    this.recipesCatalogButton = this.navigationBar.getByLabel('Recipes Catalog', { exact: true });
-    this.runningAppsButton = this.navigationBar.getByLabel('Running');
-    this.catalogButton = this.navigationBar.getByLabel('Catalog', { exact: true });
-    this.servicesButton = this.navigationBar.getByLabel('Services');
-    this.playgroundsButton = this.navigationBar.getByLabel('Playgrounds');
+    this.recipesCatalogButton = this.navigationBar.getByRole('link', { name: 'Recipes Catalog', exact: true });
+    this.runningAppsButton = this.navigationBar.getByRole('link', { name: 'Running' });
+    this.catalogButton = this.navigationBar.getByRole('link', { name: 'Catalog', exact: true });
+    this.servicesButton = this.navigationBar.getByRole('link', { name: 'Services' });
+    this.playgroundsButton = this.navigationBar.getByRole('link', { name: 'Playgrounds' });
   }
 
   async waitForLoad(): Promise<void> {
@@ -48,7 +48,6 @@ export class AILabNavigationBar {
   }
 
   async openRecipesCatalog(): Promise<AILabRecipesCatalogPage> {
-    await playExpect(this.recipesCatalogButton).toBeVisible();
     await playExpect(this.recipesCatalogButton).toBeEnabled();
     await this.recipesCatalogButton.click();
     return new AILabRecipesCatalogPage(this.page, this.webview);

--- a/tests/playwright/src/model/ai-lab-navigation-bar.ts
+++ b/tests/playwright/src/model/ai-lab-navigation-bar.ts
@@ -18,13 +18,11 @@
 
 import { expect as playExpect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
+import { AILabBasePage } from './ai-lab-base-page';
 import { AILabRecipesCatalogPage } from './ai-lab-recipes-catalog-page';
 
-export class AILabNavigationBar {
-  readonly page: Page;
-  readonly webview: Page;
+export class AILabNavigationBar extends AILabBasePage {
   readonly navigationBar: Locator;
-
   readonly recipesCatalogButton: Locator;
   readonly runningAppsButton: Locator;
   readonly catalogButton: Locator;
@@ -32,10 +30,8 @@ export class AILabNavigationBar {
   readonly playgroundsButton: Locator;
 
   constructor(page: Page, webview: Page) {
-    this.page = page;
-    this.webview = webview;
-    this.navigationBar = webview.getByLabel('PreferencesNavigation');
-
+    super(page, webview);
+    this.navigationBar = webview.getByRole('navigation', { name: 'PreferencesNavigation' });
     this.recipesCatalogButton = this.navigationBar.getByRole('link', { name: 'Recipes Catalog', exact: true });
     this.runningAppsButton = this.navigationBar.getByRole('link', { name: 'Running' });
     this.catalogButton = this.navigationBar.getByRole('link', { name: 'Catalog', exact: true });

--- a/tests/playwright/src/model/ai-lab-navigation-bar.ts
+++ b/tests/playwright/src/model/ai-lab-navigation-bar.ts
@@ -31,7 +31,7 @@ export class AILabNavigationBar extends AILabBasePage {
 
   constructor(page: Page, webview: Page) {
     super(page, webview);
-    this.navigationBar = webview.getByRole('navigation', { name: 'PreferencesNavigation' });
+    this.navigationBar = this.webview.getByRole('navigation', { name: 'PreferencesNavigation' });
     this.recipesCatalogButton = this.navigationBar.getByRole('link', { name: 'Recipes Catalog', exact: true });
     this.runningAppsButton = this.navigationBar.getByRole('link', { name: 'Running' });
     this.catalogButton = this.navigationBar.getByRole('link', { name: 'Catalog', exact: true });

--- a/tests/playwright/src/model/ai-lab-navigation-bar.ts
+++ b/tests/playwright/src/model/ai-lab-navigation-bar.ts
@@ -30,7 +30,7 @@ export class AILabNavigationBar extends AILabBasePage {
   readonly playgroundsButton: Locator;
 
   constructor(page: Page, webview: Page) {
-    super(page, webview);
+    super(page, webview, undefined);
     this.navigationBar = this.webview.getByRole('navigation', { name: 'PreferencesNavigation' });
     this.recipesCatalogButton = this.navigationBar.getByRole('link', { name: 'Recipes Catalog', exact: true });
     this.runningAppsButton = this.navigationBar.getByRole('link', { name: 'Running' });

--- a/tests/playwright/src/model/ai-lab-page.ts
+++ b/tests/playwright/src/model/ai-lab-page.ts
@@ -26,7 +26,7 @@ export class AILabPage extends AILabBasePage {
 
   constructor(page: Page, webview: Page) {
     super(page, webview);
-    this.heading = webview.getByLabel('Welcome to Podman AI Lab');
+    this.heading = this.webview.getByLabel('Welcome to Podman AI Lab');
     this.navigationBar = new AILabNavigationBar(this.page, this.webview);
   }
 

--- a/tests/playwright/src/model/ai-lab-page.ts
+++ b/tests/playwright/src/model/ai-lab-page.ts
@@ -25,8 +25,7 @@ export class AILabPage extends AILabBasePage {
   readonly navigationBar: AILabNavigationBar;
 
   constructor(page: Page, webview: Page) {
-    super(page, webview);
-    this.heading = this.webview.getByLabel('Welcome to Podman AI Lab');
+    super(page, webview, 'Welcome to Podman AI Lab');
     this.navigationBar = new AILabNavigationBar(this.page, this.webview);
   }
 

--- a/tests/playwright/src/model/ai-lab-page.ts
+++ b/tests/playwright/src/model/ai-lab-page.ts
@@ -18,113 +18,23 @@
 
 import type { Locator, Page } from '@playwright/test';
 import { expect as playExpect } from '@playwright/test';
-import { handleConfirmationDialog } from '@podman-desktop/tests-playwright';
+import { AILabNavigationBar } from './ai-lab-navigation-bar';
 
 export class AILabPage {
   readonly page: Page;
   readonly webview: Page;
   readonly heading: Locator;
-  readonly navigationBar: Locator;
-
-  readonly recipesCatalogButton: Locator;
-  readonly runningAppsButton: Locator;
-  readonly catalogButton: Locator;
-  readonly servicesButton: Locator;
-  readonly playgroundsButton: Locator;
-
-  readonly recipesCatalogPage: Locator;
-  readonly recipesCatalogContent: Locator;
-  readonly recipesCatalogNaturalLanguageProcessing: Locator;
-  readonly recipesCatalogAudio: Locator;
-  readonly recipesCatalogComputerVision: Locator;
-
-  readonly startRecipeButton: Locator;
-  readonly confirmStartRecipeButton: Locator;
-  readonly recipeStatus: Locator;
-
-  readonly applicationDetailsPanel: Locator;
-  readonly openAIAppButton: Locator;
-  readonly deleteAIAppButton: Locator;
+  readonly navigationBar: AILabNavigationBar;
 
   constructor(page: Page, webview: Page) {
     this.page = page;
     this.webview = webview;
     this.heading = webview.getByLabel('Welcome to Podman AI Lab');
-    this.navigationBar = webview.getByLabel('PreferencesNavigation');
-
-    this.recipesCatalogButton = this.navigationBar.getByLabel('Recipes Catalog', { exact: true });
-    this.runningAppsButton = this.navigationBar.getByLabel('Running');
-    this.catalogButton = this.navigationBar.getByLabel('Catalog', { exact: true });
-    this.servicesButton = this.navigationBar.getByLabel('Services');
-    this.playgroundsButton = this.navigationBar.getByLabel('Playgrounds');
-
-    this.recipesCatalogPage = webview.getByRole('region', { name: 'Recipe Catalog' })
-    this.recipesCatalogContent = this.recipesCatalogPage.getByRole('region', { name: 'content', exact: true }).first();
-    this.recipesCatalogNaturalLanguageProcessing = this.recipesCatalogContent.getByRole('region', { name: 'Natural Language Processing', exact: true });
-    this.recipesCatalogAudio = this.recipesCatalogContent.getByRole('region', { name: 'Audio', exact: true });
-    this.recipesCatalogComputerVision = this.recipesCatalogContent.getByRole('region', { name: 'Computer Vision', exact: true });
-
-    this.startRecipeButton = this.webview.getByRole('button', { name: 'Start recipe' });
-    this.confirmStartRecipeButton = this.webview.getByRole('button', { name: /Start(\s+([A-Za-z]+\s+)+)recipe/i });
-    this.recipeStatus = this.webview.getByRole('status');
-
-    this.applicationDetailsPanel = webview.getByLabel('application details panel');
-    this.openAIAppButton = this.applicationDetailsPanel.getByRole('button', { name: 'Open AI App' });
-    this.deleteAIAppButton = this.applicationDetailsPanel.getByRole('button', { name: 'Delete AI App' });
+    this.navigationBar = new AILabNavigationBar(page, webview);
   }
 
-  async waitForPageLoad(): Promise<void> {
+  async waitForLoad(): Promise<void> {
     await playExpect(this.heading).toBeVisible();
-    await playExpect(this.navigationBar).toBeVisible();
-    await playExpect(this.recipesCatalogButton).toBeVisible();
-    await playExpect(this.runningAppsButton).toBeVisible();
-    await playExpect(this.catalogButton).toBeVisible();
-    await playExpect(this.servicesButton).toBeVisible();
-    await playExpect(this.playgroundsButton).toBeVisible();
-  }
-
-  async openRecipesCatalog(): Promise<void> {
-    await playExpect(this.recipesCatalogButton).toBeVisible();
-    await this.recipesCatalogButton.click();
-    await this.page.waitForTimeout(2000);
-    await playExpect(this.recipesCatalogPage).toBeVisible();
-    await playExpect(this.recipesCatalogContent).toBeVisible();
-    await playExpect(this.recipesCatalogNaturalLanguageProcessing).toBeVisible();
-    await playExpect(this.recipesCatalogAudio).toBeVisible();
-    await playExpect(this.recipesCatalogComputerVision).toBeVisible();
-  }
-
-  async openRecipesCatalogApp(category: Locator, appName: string): Promise<void> {
-    await this.openRecipesCatalog();
-    await category.getByRole('region', { name: 'content', exact: true }).first().getByRole('region', { name: appName, exact: true }).getByRole('button', { name: 'More details' }).click({ timeout: 5_000 });
-    await playExpect(this.webview.getByRole('heading', { name: appName })).toBeVisible();
-  }
-
-  /**
-   * @throws {Error} If the app details are not visible or Delete AI App button is not visible
-   */
-  async tryDeleteOpenApp(): Promise<void> {
-    await playExpect(this.applicationDetailsPanel).toBeVisible();
-    await this.deleteAIAppButton.click({ timeout: 5_000 });
-    try {
-      await playExpect(this.page.getByRole('dialog', { name: 'Podman AI Lab' })).toBeVisible();
-      await handleConfirmationDialog(this.page, 'Confirm');
-    } catch(error) {
-      console.warn(`Warning: Delete app confirmation dialog interaction failed, possibly app is not installed.\n\t${error}`);
-    }
-    await playExpect(this.applicationDetailsPanel).toContainText('AI App Removed', { timeout: 30_000 });
-    await playExpect(this.startRecipeButton).toBeVisible();
-  }
-
-  async startOpenApp(): Promise<void> {
-    await this.startRecipeButton.click({ timeout: 5_000 });
-    await this.confirmStartRecipeButton.click({ timeout: 5_000 });
-    try {
-      await playExpect(this.page.getByRole('dialog', { name: 'Podman AI Lab' })).toBeVisible();
-      await handleConfirmationDialog(this.page, 'Reset');
-    } catch (error) {
-      console.warn(`Warning: Could not reset the app, repository probably clean.\n\t${error}`);
-    }
-    await playExpect(this.recipeStatus).toContainText('AI App is running', { timeout: 720_000 });
+    await this.navigationBar.waitForLoad();
   }
 }

--- a/tests/playwright/src/model/ai-lab-page.ts
+++ b/tests/playwright/src/model/ai-lab-page.ts
@@ -1,0 +1,130 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+import { expect as playExpect } from '@playwright/test';
+import { handleConfirmationDialog } from '@podman-desktop/tests-playwright';
+
+export class AILabPage {
+  readonly page: Page;
+  readonly webview: Page;
+  readonly heading: Locator;
+  readonly navigationBar: Locator;
+
+  readonly recipesCatalogButton: Locator;
+  readonly runningAppsButton: Locator;
+  readonly catalogButton: Locator;
+  readonly servicesButton: Locator;
+  readonly playgroundsButton: Locator;
+
+  readonly recipesCatalogPage: Locator;
+  readonly recipesCatalogContent: Locator;
+  readonly recipesCatalogNaturalLanguageProcessing: Locator;
+  readonly recipesCatalogAudio: Locator;
+  readonly recipesCatalogComputerVision: Locator;
+
+  readonly startRecipeButton: Locator;
+  readonly confirmStartRecipeButton: Locator;
+  readonly recipeStatus: Locator;
+
+  readonly applicationDetailsPanel: Locator;
+  readonly openAIAppButton: Locator;
+  readonly deleteAIAppButton: Locator;
+
+  constructor(page: Page, webview: Page) {
+    this.page = page;
+    this.webview = webview;
+    this.heading = webview.getByLabel('Welcome to Podman AI Lab');
+    this.navigationBar = webview.getByLabel('PreferencesNavigation');
+
+    this.recipesCatalogButton = this.navigationBar.getByLabel('Recipes Catalog', { exact: true });
+    this.runningAppsButton = this.navigationBar.getByLabel('Running');
+    this.catalogButton = this.navigationBar.getByLabel('Catalog', { exact: true });
+    this.servicesButton = this.navigationBar.getByLabel('Services');
+    this.playgroundsButton = this.navigationBar.getByLabel('Playgrounds');
+
+    this.recipesCatalogPage = webview.getByRole('region', { name: 'Recipe Catalog' })
+    this.recipesCatalogContent = this.recipesCatalogPage.getByRole('region', { name: 'content', exact: true }).first();
+    this.recipesCatalogNaturalLanguageProcessing = this.recipesCatalogContent.getByRole('region', { name: 'Natural Language Processing', exact: true });
+    this.recipesCatalogAudio = this.recipesCatalogContent.getByRole('region', { name: 'Audio', exact: true });
+    this.recipesCatalogComputerVision = this.recipesCatalogContent.getByRole('region', { name: 'Computer Vision', exact: true });
+
+    this.startRecipeButton = this.webview.getByRole('button', { name: 'Start recipe' });
+    this.confirmStartRecipeButton = this.webview.getByRole('button', { name: /Start(\s+([A-Za-z]+\s+)+)recipe/i });
+    this.recipeStatus = this.webview.getByRole('status');
+
+    this.applicationDetailsPanel = webview.getByLabel('application details panel');
+    this.openAIAppButton = this.applicationDetailsPanel.getByRole('button', { name: 'Open AI App' });
+    this.deleteAIAppButton = this.applicationDetailsPanel.getByRole('button', { name: 'Delete AI App' });
+  }
+
+  async waitForPageLoad(): Promise<void> {
+    await playExpect(this.heading).toBeVisible();
+    await playExpect(this.navigationBar).toBeVisible();
+    await playExpect(this.recipesCatalogButton).toBeVisible();
+    await playExpect(this.runningAppsButton).toBeVisible();
+    await playExpect(this.catalogButton).toBeVisible();
+    await playExpect(this.servicesButton).toBeVisible();
+    await playExpect(this.playgroundsButton).toBeVisible();
+  }
+
+  async openRecipesCatalog(): Promise<void> {
+    await playExpect(this.recipesCatalogButton).toBeVisible();
+    await this.recipesCatalogButton.click();
+    await this.page.waitForTimeout(2000);
+    await playExpect(this.recipesCatalogPage).toBeVisible();
+    await playExpect(this.recipesCatalogContent).toBeVisible();
+    await playExpect(this.recipesCatalogNaturalLanguageProcessing).toBeVisible();
+    await playExpect(this.recipesCatalogAudio).toBeVisible();
+    await playExpect(this.recipesCatalogComputerVision).toBeVisible();
+  }
+
+  async openRecipesCatalogApp(category: Locator, appName: string): Promise<void> {
+    await this.openRecipesCatalog();
+    await category.getByRole('region', { name: 'content', exact: true }).first().getByRole('region', { name: appName, exact: true }).getByRole('button', { name: 'More details' }).click({ timeout: 5_000 });
+    await playExpect(this.webview.getByRole('heading', { name: appName })).toBeVisible();
+  }
+
+  /**
+   * @throws {Error} If the app details are not visible or Delete AI App button is not visible
+   */
+  async tryDeleteOpenApp(): Promise<void> {
+    await playExpect(this.applicationDetailsPanel).toBeVisible();
+    await this.deleteAIAppButton.click({ timeout: 5_000 });
+    try {
+      await playExpect(this.page.getByRole('dialog', { name: 'Podman AI Lab' })).toBeVisible();
+      await handleConfirmationDialog(this.page, 'Confirm');
+    } catch(error) {
+      console.warn(`Warning: Delete app confirmation dialog interaction failed, possibly app is not installed.\n\t${error}`);
+    }
+    await playExpect(this.applicationDetailsPanel).toContainText('AI App Removed', { timeout: 30_000 });
+    await playExpect(this.startRecipeButton).toBeVisible();
+  }
+
+  async startOpenApp(): Promise<void> {
+    await this.startRecipeButton.click({ timeout: 5_000 });
+    await this.confirmStartRecipeButton.click({ timeout: 5_000 });
+    try {
+      await playExpect(this.page.getByRole('dialog', { name: 'Podman AI Lab' })).toBeVisible();
+      await handleConfirmationDialog(this.page, 'Reset');
+    } catch (error) {
+      console.warn(`Warning: Could not reset the app, repository probably clean.\n\t${error}`);
+    }
+    await playExpect(this.recipeStatus).toContainText('AI App is running', { timeout: 720_000 });
+  }
+}

--- a/tests/playwright/src/model/ai-lab-recipes-catalog-page.ts
+++ b/tests/playwright/src/model/ai-lab-recipes-catalog-page.ts
@@ -18,12 +18,10 @@
 
 import { expect as playExpect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
+import { AILabBasePage } from './ai-lab-base-page';
 import { AILabAppDetailsPage } from './ai-lab-app-details-page';
 
-export class AILabRecipesCatalogPage {
-  readonly page: Page;
-  readonly webview: Page;
-
+export class AILabRecipesCatalogPage extends AILabBasePage {
   readonly recipesCatalogPage: Locator;
   readonly recipesCatalogContent: Locator;
   readonly recipesCatalogNaturalLanguageProcessing: Locator;
@@ -31,9 +29,8 @@ export class AILabRecipesCatalogPage {
   readonly recipesCatalogComputerVision: Locator;
 
   constructor(page: Page, webview: Page) {
-    this.page = page;
-    this.webview = webview;
-
+    super(page, webview);
+    this.heading = webview.getByRole('heading', { name: 'Recipe Catalog' });
     this.recipesCatalogPage = webview.getByRole('region', { name: 'Recipe Catalog' });
     this.recipesCatalogContent = this.recipesCatalogPage.getByRole('region', { name: 'content', exact: true }).first();
     this.recipesCatalogNaturalLanguageProcessing = this.recipesCatalogContent.getByRole('region', {
@@ -48,6 +45,7 @@ export class AILabRecipesCatalogPage {
   }
 
   async waitForLoad(): Promise<void> {
+    await playExpect(this.heading).toBeVisible();
     await playExpect(this.recipesCatalogPage).toBeVisible();
   }
 

--- a/tests/playwright/src/model/ai-lab-recipes-catalog-page.ts
+++ b/tests/playwright/src/model/ai-lab-recipes-catalog-page.ts
@@ -30,8 +30,8 @@ export class AILabRecipesCatalogPage extends AILabBasePage {
 
   constructor(page: Page, webview: Page) {
     super(page, webview);
-    this.heading = webview.getByRole('heading', { name: 'Recipe Catalog' });
-    this.recipesCatalogPage = webview.getByRole('region', { name: 'Recipe Catalog' });
+    this.heading = this.webview.getByRole('heading', { name: 'Recipe Catalog' });
+    this.recipesCatalogPage = this.webview.getByRole('region', { name: 'Recipe Catalog' });
     this.recipesCatalogContent = this.recipesCatalogPage.getByRole('region', { name: 'content', exact: true }).first();
     this.recipesCatalogNaturalLanguageProcessing = this.recipesCatalogContent.getByRole('region', {
       name: 'Natural Language Processing',

--- a/tests/playwright/src/model/ai-lab-recipes-catalog-page.ts
+++ b/tests/playwright/src/model/ai-lab-recipes-catalog-page.ts
@@ -29,8 +29,7 @@ export class AILabRecipesCatalogPage extends AILabBasePage {
   readonly recipesCatalogComputerVision: Locator;
 
   constructor(page: Page, webview: Page) {
-    super(page, webview);
-    this.heading = this.webview.getByRole('heading', { name: 'Recipe Catalog' });
+    super(page, webview, 'Recipe Catalog');
     this.recipesCatalogPage = this.webview.getByRole('region', { name: 'Recipe Catalog' });
     this.recipesCatalogContent = this.recipesCatalogPage.getByRole('region', { name: 'content', exact: true }).first();
     this.recipesCatalogNaturalLanguageProcessing = this.recipesCatalogContent.getByRole('region', {

--- a/tests/playwright/src/model/ai-lab-recipes-catalog-page.ts
+++ b/tests/playwright/src/model/ai-lab-recipes-catalog-page.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect as playExpect } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
+import { AILabAppDetailsPage } from './ai-lab-app-details-page';
+
+export class AILabRecipesCatalogPage {
+  readonly page: Page;
+  readonly webview: Page;
+
+  readonly recipesCatalogPage: Locator;
+  readonly recipesCatalogContent: Locator;
+  readonly recipesCatalogNaturalLanguageProcessing: Locator;
+  readonly recipesCatalogAudio: Locator;
+  readonly recipesCatalogComputerVision: Locator;
+
+  constructor(page: Page, webview: Page) {
+    this.page = page;
+    this.webview = webview;
+
+    this.recipesCatalogPage = webview.getByRole('region', { name: 'Recipe Catalog' });
+    this.recipesCatalogContent = this.recipesCatalogPage.getByRole('region', { name: 'content', exact: true }).first();
+    this.recipesCatalogNaturalLanguageProcessing = this.recipesCatalogContent.getByRole('region', {
+      name: 'Natural Language Processing',
+      exact: true,
+    });
+    this.recipesCatalogAudio = this.recipesCatalogContent.getByRole('region', { name: 'Audio', exact: true });
+    this.recipesCatalogComputerVision = this.recipesCatalogContent.getByRole('region', {
+      name: 'Computer Vision',
+      exact: true,
+    });
+  }
+
+  async waitForLoad(): Promise<void> {
+    await playExpect(this.recipesCatalogPage).toBeVisible();
+  }
+
+  async openRecipesCatalogApp(category: Locator, appName: string): Promise<AILabAppDetailsPage> {
+    await playExpect(category).toBeVisible();
+    await playExpect(this.getAppDetailsLocator(appName)).toBeEnabled();
+    await this.getAppDetailsLocator(appName).click();
+    return new AILabAppDetailsPage(this.page, this.webview, appName);
+  }
+
+  private getAppDetailsLocator(appName: string): Locator {
+    return this.recipesCatalogContent
+      .getByRole('region', { name: appName, exact: true })
+      .getByRole('button', { name: 'More details' });
+  }
+}

--- a/tests/playwright/src/model/ai-lab-start-recipe-page.ts
+++ b/tests/playwright/src/model/ai-lab-start-recipe-page.ts
@@ -29,8 +29,7 @@ export class AILabStartRecipePage extends AILabBasePage {
   readonly deleteAIAppButton: Locator;
 
   constructor(page: Page, webview: Page) {
-    super(page, webview);
-    this.heading = this.webview.getByLabel('Start Recipe');
+    super(page, webview, 'Start Recipe');
     this.recipeStatus = this.webview.getByRole('status');
     this.applicationDetailsPanel = this.webview.getByLabel('application details panel');
     this.startRecipeButton = this.webview.getByRole('button', { name: /Start(\s+([A-Za-z]+\s+)+)recipe/i });

--- a/tests/playwright/src/model/ai-lab-start-recipe-page.ts
+++ b/tests/playwright/src/model/ai-lab-start-recipe-page.ts
@@ -30,9 +30,9 @@ export class AILabStartRecipePage extends AILabBasePage {
 
   constructor(page: Page, webview: Page) {
     super(page, webview);
-    this.heading = webview.getByLabel('Start Recipe');
+    this.heading = this.webview.getByLabel('Start Recipe');
     this.recipeStatus = this.webview.getByRole('status');
-    this.applicationDetailsPanel = webview.getByLabel('application details panel');
+    this.applicationDetailsPanel = this.webview.getByLabel('application details panel');
     this.startRecipeButton = this.webview.getByRole('button', { name: /Start(\s+([A-Za-z]+\s+)+)recipe/i });
     this.openAIAppButton = this.applicationDetailsPanel.getByRole('button', { name: 'Open AI App' });
     this.deleteAIAppButton = this.applicationDetailsPanel.getByRole('button', { name: 'Delete AI App' });


### PR DESCRIPTION
### What does this PR do?
* Implements AI Lab Page
* Extends ai-lab-extension.spec.ts test

### Screenshot / video of UI
N/A
<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#978 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
* cd `<podman-desktop-repo>`
* git pull --all
* yarn install
* yarn test:e2e:build
* cd `<podman-desktop-extension-ai-lab-repo>/tests/playwright`
* `yarn add -D @podman-desktop/tests-playwright@next`
* cd ../../
* export PODMAN_DESKTOP_ARGS=<podman-desktop-repo>; yarn test:e2e
<!-- Please explain steps to reproduce -->