### PR TITLE
feat: adding running tab to recipe details

### DIFF
--- a/packages/frontend/src/lib/ApplicationTable.svelte
+++ b/packages/frontend/src/lib/ApplicationTable.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import { applicationStates } from '../stores/application-states';
+import ColumnActions from '../lib/table/application/ColumnActions.svelte';
+import ColumnStatus from '../lib/table/application/ColumnStatus.svelte';
+import ColumnRecipe from '../lib/table/application/ColumnRecipe.svelte';
+import ColumnModel from '../lib/table/application/ColumnModel.svelte';
+import ColumnPod from '../lib/table/application/ColumnPod.svelte';
+import ColumnAge from '../lib/table/application/ColumnAge.svelte';
+import { onMount } from 'svelte';
+import type { ApplicationState } from '@shared/src/models/IApplicationState';
+import { Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+export let filter: ((items: ApplicationState[]) => ApplicationState[]) | undefined = undefined;
+const columns: TableColumn<ApplicationState>[] = [
+  new TableColumn<ApplicationState>('Status', { width: '70px', align: 'center', renderer: ColumnStatus }),
+  new TableColumn<ApplicationState>('Model', { width: '3fr', renderer: ColumnModel }),
+  new TableColumn<ApplicationState>('Recipe', { width: '2fr', renderer: ColumnRecipe }),
+  new TableColumn<ApplicationState>('Pod', { width: '3fr', renderer: ColumnPod }),
+  new TableColumn<ApplicationState>('Age', { width: '2fr', renderer: ColumnAge }),
+  new TableColumn<ApplicationState>('Actions', {
+    align: 'right',
+    width: '120px',
+    renderer: ColumnActions,
+    overflow: true,
+  }),
+];
+const row = new TableRow<ApplicationState>({});
+let data: (ApplicationState & { selected?: boolean })[];
+onMount(() => {
+  return applicationStates.subscribe(items => {
+    data = filter ? filter(items) : items;
+  });
+});
+</script>
+
+{#if data?.length > 0}
+  <Table kind="AI App" data="{data}" columns="{columns}" row="{row}"></Table>
+{:else}
+  <slot name="empty-screen" />
+{/if}

--- a/packages/frontend/src/lib/progress/TasksBanner.spec.ts
+++ b/packages/frontend/src/lib/progress/TasksBanner.spec.ts
@@ -60,7 +60,7 @@ test('expect all tasks to be displayed', () => {
     },
   ]);
 
-  render(TasksBanner, { labels: [], title: 'Tasks list' });
+  render(TasksBanner, { labels: {}, title: 'Tasks list' });
 
   expect(screen.getByText('Task-1')).toBeDefined();
   expect(screen.getByText('Task-2')).toBeDefined();
@@ -82,7 +82,84 @@ test('expect loading tasks to be displayed', () => {
     },
   ]);
 
-  render(TasksBanner, { labels: [], title: 'Tasks list' });
+  render(TasksBanner, { labels: {}, title: 'Tasks list' });
+
+  expect(screen.getByText('Task-1')).toBeDefined();
+  expect(screen.queryByText('Task-2')).toBeNull();
+});
+
+test('expect tasks with specified labels to be displayed', () => {
+  mocks.getTasksMock.mockReturnValue([
+    {
+      state: 'loading',
+      labels: {
+        hello: 'world',
+      },
+      name: 'Task-1',
+      id: 'task-1',
+    },
+    {
+      state: 'loading',
+      labels: {},
+      name: 'Task-2',
+      id: 'task-2',
+    },
+  ]);
+
+  render(TasksBanner, { labels: { hello: undefined }, title: 'Tasks list' });
+
+  expect(screen.getByText('Task-1')).toBeDefined();
+  expect(screen.queryByText('Task-2')).toBeNull();
+});
+
+test('expect tasks with specified pair label/value to be displayed', () => {
+  mocks.getTasksMock.mockReturnValue([
+    {
+      state: 'loading',
+      labels: {
+        hello: 'saturn',
+      },
+      name: 'Task-1',
+      id: 'task-1',
+    },
+    {
+      state: 'loading',
+      labels: {
+        hello: 'world',
+      },
+      name: 'Task-2',
+      id: 'task-2',
+    },
+  ]);
+
+  render(TasksBanner, { labels: { hello: 'world' }, title: 'Tasks list' });
+
+  expect(screen.queryByText('Task-1')).toBeNull();
+  expect(screen.getByText('Task-2')).toBeDefined();
+});
+
+test('expect tasks with specified pairs labels/values to be displayed', () => {
+  mocks.getTasksMock.mockReturnValue([
+    {
+      state: 'loading',
+      labels: {
+        hello: 'saturn',
+        dummy: 'hello',
+      },
+      name: 'Task-1',
+      id: 'task-1',
+    },
+    {
+      state: 'loading',
+      labels: {
+        hello: 'saturn',
+      },
+      name: 'Task-2',
+      id: 'task-2',
+    },
+  ]);
+
+  render(TasksBanner, { labels: { hello: 'saturn', dummy: 'hello' }, title: 'Tasks list' });
 
   expect(screen.getByText('Task-1')).toBeDefined();
   expect(screen.queryByText('Task-2')).toBeNull();

--- a/packages/frontend/src/lib/progress/TasksBanner.svelte
+++ b/packages/frontend/src/lib/progress/TasksBanner.svelte
@@ -5,16 +5,41 @@ import Card from '/@/lib/Card.svelte';
 import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
 import { onMount } from 'svelte';
 
-export let labels: string[] = [];
+/**
+ * labels that should be matching on tasks
+ * @example
+ * labels: { 'hello': undefined }
+ * will match any tasks with the `hello` label, regardless of the value of the labels
+ *
+ * @example
+ * labels: { 'hello': 'world' }
+ * will match tasks with the `hello` label, and the `world` value
+ */
+export let labels: Record<string, string | undefined> = {};
 export let title: string;
 
 let loadingTasks: Task[] = [];
 
 onMount(() => {
-  return tasks.subscribe(value => {
-    loadingTasks = value.filter(
-      task => task.state !== 'success' && labels.every(label => label in (task.labels ?? {})),
-    );
+  const entries: [string, string | undefined][] = Object.entries(labels);
+  return tasks.subscribe(items => {
+    loadingTasks = items.reduce((output, task) => {
+      // only display failed / loading tasks
+      if (task.state === 'success') return output;
+
+      const taskLabels = task.labels ?? {};
+      for (const [key, value] of entries) {
+        // ensure the label requested is in the task labels
+        if (!(key in taskLabels)) return output;
+
+        // if we defined a value for the label, remove any value not matching
+        if (value && taskLabels[key] !== value) return output;
+      }
+
+      output.push(task);
+
+      return output;
+    }, [] as Task[]);
   });
 });
 </script>

--- a/packages/frontend/src/lib/table/application/ApplicationTable.spec.ts
+++ b/packages/frontend/src/lib/table/application/ApplicationTable.spec.ts
@@ -1,0 +1,157 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, test, expect, vi } from 'vitest';
+import { render, within } from '@testing-library/svelte';
+import type { ApplicationState } from '@shared/src/models/IApplicationState';
+import ApplicationTable from '/@/lib/table/application/ApplicationTable.svelte';
+import type { ApplicationCatalog } from '@shared/src/models/IApplicationCatalog';
+
+const mocks = vi.hoisted(() => ({
+  getApplicationStates: vi.fn<() => ApplicationState[]>(),
+}));
+
+vi.mock('../../../stores/application-states', () => ({
+  applicationStates: {
+    subscribe: (fn: (items: ApplicationState[]) => void) => {
+      fn(mocks.getApplicationStates());
+      return vi.fn();
+    },
+  },
+}));
+
+vi.mock('../../../stores/catalog', () => ({
+  catalog: {
+    subscribe: (fn: (item: ApplicationCatalog) => void) => {
+      fn({ categories: [], models: [], recipes: [] });
+      return vi.fn();
+    },
+  },
+}));
+
+vi.mock('../../../utils/client', async () => ({
+  studioClient: {},
+}));
+
+beforeEach(() => {
+  mocks.getApplicationStates.mockReturnValue([]);
+});
+
+test('expect pod to be displayed', async () => {
+  mocks.getApplicationStates.mockReturnValue([
+    {
+      appPorts: [],
+      health: 'healthy',
+      modelId: 'model-id-1',
+      modelPorts: [],
+      pod: {
+        engineId: 'dummy-engine-id',
+        Id: 'pod-id-1',
+        Status: 'Running',
+        Name: 'Test Pod 1',
+      },
+      recipeId: 'recipe-id-1',
+    } as unknown as ApplicationState,
+  ]);
+
+  const { container } = render(ApplicationTable);
+
+  const div = within(container).getByText('Test Pod 1');
+  expect(div).toBeDefined();
+});
+
+test('expect all pods to be displayed', async () => {
+  mocks.getApplicationStates.mockReturnValue([
+    {
+      appPorts: [],
+      health: 'healthy',
+      modelId: 'model-id-1',
+      modelPorts: [],
+      pod: {
+        engineId: 'dummy-engine-id',
+        Id: 'pod-id-1',
+        Status: 'Running',
+        Name: 'Test Pod 1',
+      },
+      recipeId: 'recipe-id-1',
+    } as unknown as ApplicationState,
+    {
+      appPorts: [],
+      health: 'healthy',
+      modelId: 'model-id-2',
+      modelPorts: [],
+      pod: {
+        engineId: 'dummy-engine-id',
+        Id: 'pod-id-2',
+        Status: 'Running',
+        Name: 'Test Pod 2',
+      },
+      recipeId: 'recipe-id-1',
+    } as unknown as ApplicationState,
+  ]);
+
+  const { container } = render(ApplicationTable);
+
+  const pod1 = within(container).getByText('Test Pod 1');
+  expect(pod1).toBeDefined();
+
+  const pod2 = within(container).getByText('Test Pod 2');
+  expect(pod2).toBeDefined();
+});
+
+test('expect filter to work as expected', async () => {
+  mocks.getApplicationStates.mockReturnValue([
+    {
+      appPorts: [],
+      health: 'healthy',
+      modelId: 'model-id-1',
+      modelPorts: [],
+      pod: {
+        engineId: 'dummy-engine-id',
+        Id: 'pod-id-1',
+        Status: 'Running',
+        Name: 'Test Pod 1',
+      },
+      recipeId: 'recipe-id-1',
+    } as unknown as ApplicationState,
+    {
+      appPorts: [],
+      health: 'healthy',
+      modelId: 'model-id-2',
+      modelPorts: [],
+      pod: {
+        engineId: 'dummy-engine-id',
+        Id: 'pod-id-2',
+        Status: 'Running',
+        Name: 'Test Pod 2',
+      },
+      recipeId: 'recipe-id-2',
+    } as unknown as ApplicationState,
+  ]);
+
+  const { container } = render(ApplicationTable, {
+    filter: items => items.filter(item => item.recipeId !== 'recipe-id-2'),
+  });
+
+  const pod1 = within(container).getByText('Test Pod 1');
+  expect(pod1).toBeDefined();
+
+  const pod2 = within(container).queryByText('Test Pod 2');
+  expect(pod2).toBeNull();
+});

--- a/packages/frontend/src/lib/table/application/ApplicationTable.spec.ts
+++ b/packages/frontend/src/lib/table/application/ApplicationTable.spec.ts
@@ -146,7 +146,7 @@ test('expect filter to work as expected', async () => {
   ]);
 
   const { container } = render(ApplicationTable, {
-    filter: items => items.filter(item => item.recipeId !== 'recipe-id-2'),
+    filter: (items: ApplicationState[]) => items.filter((item: ApplicationState) => item.recipeId !== 'recipe-id-2'),
   });
 
   const pod1 = within(container).getByText('Test Pod 1');

--- a/packages/frontend/src/lib/table/application/ApplicationTable.svelte
+++ b/packages/frontend/src/lib/table/application/ApplicationTable.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-import { applicationStates } from '../stores/application-states';
-import ColumnActions from '../lib/table/application/ColumnActions.svelte';
-import ColumnStatus from '../lib/table/application/ColumnStatus.svelte';
-import ColumnRecipe from '../lib/table/application/ColumnRecipe.svelte';
-import ColumnModel from '../lib/table/application/ColumnModel.svelte';
-import ColumnPod from '../lib/table/application/ColumnPod.svelte';
-import ColumnAge from '../lib/table/application/ColumnAge.svelte';
+import { applicationStates } from '/@/stores/application-states';
+import ColumnActions from './ColumnActions.svelte';
+import ColumnStatus from './ColumnStatus.svelte';
+import ColumnRecipe from './ColumnRecipe.svelte';
+import ColumnModel from './ColumnModel.svelte';
+import ColumnPod from './ColumnPod.svelte';
+import ColumnAge from './ColumnAge.svelte';
 import { onMount } from 'svelte';
 import type { ApplicationState } from '@shared/src/models/IApplicationState';
 import { Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';

--- a/packages/frontend/src/pages/Applications.svelte
+++ b/packages/frontend/src/pages/Applications.svelte
@@ -14,7 +14,7 @@ const openApplicationCatalog = () => {
   <div slot="content" class="flex flex-col min-w-full min-h-full">
     <div class="min-w-full min-h-full flex-1">
       <!-- showing running tasks -->
-      <TasksBanner title="Pulling recipes" labels="{['recipe-pulling']}" />
+      <TasksBanner title="Pulling recipes" labels="{{ 'recipe-pulling': undefined }}" />
 
       <ApplicationTable>
         <svelte:fragment slot="empty-screen">

--- a/packages/frontend/src/pages/Applications.svelte
+++ b/packages/frontend/src/pages/Applications.svelte
@@ -1,68 +1,30 @@
 <script lang="ts">
-import { applicationStates } from '../stores/application-states';
-import ColumnActions from '../lib/table/application/ColumnActions.svelte';
-import ColumnStatus from '../lib/table/application/ColumnStatus.svelte';
-import ColumnRecipe from '../lib/table/application/ColumnRecipe.svelte';
-import ColumnModel from '../lib/table/application/ColumnModel.svelte';
-import ColumnPod from '../lib/table/application/ColumnPod.svelte';
-import ColumnAge from '../lib/table/application/ColumnAge.svelte';
+import { NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
+import ApplicationTable from '/@/lib/ApplicationTable.svelte';
 import { router } from 'tinro';
-import { onMount } from 'svelte';
-import type { ApplicationState } from '@shared/src/models/IApplicationState';
-import { Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
+import { faRocket } from '@fortawesome/free-solid-svg-icons';
 import TasksBanner from '/@/lib/progress/TasksBanner.svelte';
-
-const columns: TableColumn<ApplicationState>[] = [
-  new TableColumn<ApplicationState>('Status', { width: '70px', align: 'center', renderer: ColumnStatus }),
-  new TableColumn<ApplicationState>('Model', { width: '3fr', renderer: ColumnModel }),
-  new TableColumn<ApplicationState>('Recipe', { width: '2fr', renderer: ColumnRecipe }),
-  new TableColumn<ApplicationState>('Pod', { width: '3fr', renderer: ColumnPod }),
-  new TableColumn<ApplicationState>('Age', { width: '2fr', renderer: ColumnAge }),
-  new TableColumn<ApplicationState>('Actions', {
-    align: 'right',
-    width: '120px',
-    renderer: ColumnActions,
-    overflow: true,
-  }),
-];
-const row = new TableRow<ApplicationState>({});
 
 const openApplicationCatalog = () => {
   router.goto('/recipes');
 };
-
-let data: (ApplicationState & { selected?: boolean })[];
-
-onMount(() => {
-  return applicationStates.subscribe(items => {
-    data = items;
-  });
-});
 </script>
 
 <NavPage title="AI Apps" searchEnabled="{false}">
   <div slot="content" class="flex flex-col min-w-full min-h-full">
     <div class="min-w-full min-h-full flex-1">
-      <div class="mt-4 px-5 space-y-5">
-        <!-- showing running tasks -->
-        <TasksBanner title="Pulling recipes" labels="{['recipe-pulling']}" />
+      <!-- showing running tasks -->
+      <TasksBanner title="Pulling recipes" labels="{['recipe-pulling']}" />
 
-        {#if data?.length > 0}
-          <Table kind="AI App" data="{data}" columns="{columns}" row="{row}"></Table>
-        {:else}
-          <div class="w-full flex items-center justify-center text-[var(--pd-content-text)]">
-            <div role="status">
-              There is no AI App running. You may run a new AI App via the <a
-                href="{'javascript:void(0);'}"
-                class="underline"
-                role="button"
-                title="Open the catalog page"
-                on:click="{openApplicationCatalog}">Recipes Catalog</a
-              >.
-            </div>
-          </div>
-        {/if}
-      </div>
+      <ApplicationTable>
+        <svelte:fragment slot="empty-screen">
+          <EmptyScreen
+            icon="{faRocket}"
+            title="No application running"
+            message="There is no AI App running"
+            onClick="{openApplicationCatalog}" />
+        </svelte:fragment>
+      </ApplicationTable>
     </div>
   </div>
 </NavPage>

--- a/packages/frontend/src/pages/Applications.svelte
+++ b/packages/frontend/src/pages/Applications.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import { NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
-import ApplicationTable from '/@/lib/ApplicationTable.svelte';
 import { router } from 'tinro';
 import { faRocket } from '@fortawesome/free-solid-svg-icons';
 import TasksBanner from '/@/lib/progress/TasksBanner.svelte';
+import ApplicationTable from '/@/lib/table/application/ApplicationTable.svelte';
 
 const openApplicationCatalog = () => {
   router.goto('/recipes');

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { studioClient } from '/@/utils/client';
-import { DetailsPage } from '@podman-desktop/ui-svelte';
+import { DetailsPage, Tab } from '@podman-desktop/ui-svelte';
 import Card from '/@/lib/Card.svelte';
 import MarkdownRenderer from '/@/lib/markdown/MarkdownRenderer.svelte';
 import { getIcon } from '/@/utils/categoriesUtils';
@@ -9,8 +9,10 @@ import RecipeDetails from '/@/lib/RecipeDetails.svelte';
 import ContentDetailsLayout from '../lib/ContentDetailsLayout.svelte';
 import { router } from 'tinro';
 import { faRocket } from '@fortawesome/free-solid-svg-icons';
-import { Button } from '@podman-desktop/ui-svelte';
+import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
+import Route from '/@/Route.svelte';
+import ApplicationTable from '/@/lib/ApplicationTable.svelte';
 
 export let recipeId: string;
 
@@ -42,20 +44,33 @@ export function goToUpPage(): void {
       <Fa size="1.125x" class="text-[var(--pd-content-header-icon)]" icon="{getIcon(recipe?.icon)}" />
     </div>
   </svelte:fragment>
+  <svelte:fragment slot="tabs">
+    <Tab title="Summary" url="/recipe/{recipeId}" selected="{$router.path === `/recipe/${recipeId}`}" />
+    <Tab title="Running" url="/recipe/{recipeId}/running" selected="{$router.path === `/recipe/${recipeId}/running`}" />
+  </svelte:fragment>
   <svelte:fragment slot="actions">
     <Button on:click="{() => router.goto(`/recipe/${recipeId}/start`)}" icon="{faRocket}" aria-label="Start recipe"
       >Start</Button>
   </svelte:fragment>
   <svelte:fragment slot="content">
     <div class="bg-[var(--pd-content-bg)] h-full overflow-y-auto">
-      <ContentDetailsLayout detailsTitle="AI App Details" detailsLabel="application details">
-        <svelte:fragment slot="content">
-          <MarkdownRenderer source="{recipe?.readme}" />
-        </svelte:fragment>
-        <svelte:fragment slot="details">
-          <RecipeDetails recipeId="{recipeId}" />
-        </svelte:fragment>
-      </ContentDetailsLayout>
+      <Route path="/">
+        <ContentDetailsLayout detailsTitle="AI App Details" detailsLabel="application details">
+          <svelte:fragment slot="content">
+            <MarkdownRenderer source="{recipe?.readme}" />
+          </svelte:fragment>
+          <svelte:fragment slot="details">
+            <RecipeDetails recipeId="{recipeId}" />
+          </svelte:fragment>
+        </ContentDetailsLayout>
+      </Route>
+      <Route path="/running">
+        <ApplicationTable filter="{items => items.filter(item => item.recipeId === recipeId)}">
+          <svelte:fragment slot="empty-screen">
+            <EmptyScreen icon="{faRocket}" title="No application running" message="There is no AI App running" />
+          </svelte:fragment>
+        </ApplicationTable>
+      </Route>
     </div>
   </svelte:fragment>
   <svelte:fragment slot="subtitle">

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -12,7 +12,7 @@ import { faRocket } from '@fortawesome/free-solid-svg-icons';
 import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 import Route from '/@/Route.svelte';
-import ApplicationTable from '/@/lib/ApplicationTable.svelte';
+import ApplicationTable from '/@/lib/table/application/ApplicationTable.svelte';
 
 export let recipeId: string;
 

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -13,6 +13,7 @@ import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 import Route from '/@/Route.svelte';
 import ApplicationTable from '/@/lib/table/application/ApplicationTable.svelte';
+import TasksBanner from '/@/lib/progress/TasksBanner.svelte';
 
 export let recipeId: string;
 
@@ -65,6 +66,7 @@ export function goToUpPage(): void {
         </ContentDetailsLayout>
       </Route>
       <Route path="/running">
+        <TasksBanner title="Pulling recipes" labels="{{ 'recipe-pulling': recipeId }}" />
         <ApplicationTable filter="{items => items.filter(item => item.recipeId === recipeId)}">
           <svelte:fragment slot="empty-screen">
             <EmptyScreen icon="{faRocket}" title="No application running" message="There is no AI App running" />

--- a/packages/frontend/src/pages/StartRecipe.spec.ts
+++ b/packages/frontend/src/pages/StartRecipe.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 import { vi, beforeEach, test, expect } from 'vitest';
 import { studioClient } from '/@/utils/client';
-import { render, screen, fireEvent } from '@testing-library/svelte';
+import { render, screen, fireEvent, within } from '@testing-library/svelte';
 import StartRecipe from '/@/pages/StartRecipe.svelte';
 import type { Recipe } from '@shared/src/models/IRecipe';
 import { InferenceType } from '@shared/src/models/IInference';
@@ -32,7 +32,7 @@ const mocks = vi.hoisted(() => {
     // models store
     getModelsInfoMock: vi.fn(),
     // tasks store
-    getTasksMock: vi.fn(),
+    getTasksMock: vi.fn<() => Task[]>(),
     // local repository mock
     getLocalRepositoriesMock: vi.fn(),
     // catalog store
@@ -318,6 +318,30 @@ test('Loading task should make the submit button disabled', async () => {
 
   await vi.waitFor(() => {
     expect(button).toBeDefined();
+  });
+});
+
+test('Completed task should make the open details button visible', async () => {
+  mocks.getTasksMock.mockReturnValue([
+    {
+      id: 'dummy-task-id',
+      name: 'Dummy task',
+      state: 'success',
+      labels: {
+        trackingId: 'fake-tracking-id',
+        recipeId: 'dummy-recipe-id',
+      },
+    } as Task,
+  ]);
+
+  router.location.query.set('trackingId', 'fake-tracking-id');
+
+  const { container } = render(StartRecipe, {
+    recipeId: 'dummy-recipe-id',
+  });
+
+  await vi.waitFor(() => {
+    expect(within(container).getByTitle('Open details')).toBeDefined();
   });
 });
 

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -244,8 +244,8 @@ export function goToUpPage(): void {
           <footer>
             <div class="w-full flex flex-col">
               {#if completed}
-                <Button icon="{faUpRightFromSquare}" on:click="{() => router.goto('/applications')}">
-                  Navigate to applications
+                <Button icon="{faUpRightFromSquare}" on:click="{() => router.goto(`/recipe/${recipeId}/running`)}">
+                  Open details
                 </Button>
               {:else}
                 <Button

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -244,7 +244,10 @@ export function goToUpPage(): void {
           <footer>
             <div class="w-full flex flex-col">
               {#if completed}
-                <Button icon="{faUpRightFromSquare}" on:click="{() => router.goto(`/recipe/${recipeId}/running`)}">
+                <Button
+                  icon="{faUpRightFromSquare}"
+                  title="Open details"
+                  on:click="{() => router.goto(`/recipe/${recipeId}/running`)}">
                   Open details
                 </Button>
               {:else}


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/containers/podman-desktop-extension-ai-lab/pull/1227. This PR add a `Running` tab in the RecipeDetails. 

This has been made to ease the understanding of the relation between Recipe and Applications. Discussed with @slemeur and @jeffmaury in https://github.com/containers/podman-desktop-extension-ai-lab/issues/1360.

### Notable change

- Creating a `ApplicationTable.svelte` component to avoid duplicating code between `/applications` and `/recipe/{recipeId}/running` page.
- The `StartRecipe.svelte` component redirect to the `/recipe/{recipeId}/running` page on completion (button click)

### Screenshot / video of UI

https://github.com/user-attachments/assets/99b2993d-2f9f-4f0e-944c-89c92464f72b

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1360

Require https://github.com/containers/podman-desktop-extension-ai-lab/pull/1227 and rebase done

### How to test this PR?

- [x] unit tests has been added

**Manually**

- (1) Go to recipe details
- (2) See nothing running in `Running` tab
- (3) Start a recipe
- (4) Click on `Open details` once the recipe is started