### PR TITLE
feature: adding versioning to the catalog

### DIFF
--- a/PACKAGING-GUIDE.md
+++ b/PACKAGING-GUIDE.md
@@ -14,6 +14,10 @@ Any change done to this file will also be automatically loaded by AI Lab.
 The catalog file has three main elements: categories, models and recipes. Each of these elements is
 represented in the JSON file as an array.
 
+The catalog is `versioned`. Current version can be found in [ai.json](https://github.com/containers/podman-desktop-extension-ai-lab/blob/main/packages/backend/src/assets/ai.json#L2).
+
+> :warning:when the version of the catalog is undefined or different from the current, the user-catalog will be ignored.
+
 #### Categories
 
 This is the top level construct of the catalog UI. Recipes are grouped into categories. A category

--- a/PACKAGING-GUIDE.md
+++ b/PACKAGING-GUIDE.md
@@ -16,7 +16,7 @@ represented in the JSON file as an array.
 
 The catalog is `versioned`. Current version can be found in [ai.json](https://github.com/containers/podman-desktop-extension-ai-lab/blob/main/packages/backend/src/assets/ai.json#L2).
 
-> :warning:when the version of the catalog is undefined or different from the current, the user-catalog will be ignored.
+> :warning: when the version of the catalog is undefined or different from the current, the user-catalog will be ignored.
 
 #### Categories
 

--- a/packages/backend/src/assets/ai.json
+++ b/packages/backend/src/assets/ai.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0",
   "recipes": [
     {
       "id": "chatbot",

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -99,7 +99,12 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
     }
 
     // merging default catalog with user catalog
-    this.catalog = merge(sanitize(defaultCatalog), sanitize({ ...content, version: userCatalogFormat }));
+    try {
+      this.catalog = merge(sanitize(defaultCatalog), sanitize({ ...content, version: userCatalogFormat }));
+    } catch (err: unknown) {
+      console.warn(err);
+      this.loadDefaultCatalog();
+    }
 
     this.notify();
   }

--- a/packages/backend/src/tests/ai-test.json
+++ b/packages/backend/src/tests/ai-test.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0",
   "recipes": [
     {
       "id": "chatbot",
@@ -11,7 +12,7 @@
       ],
       "basedir": "chatbot",
       "readme": "# Locallm\n\nThis repo contains artifacts that can be used to build and run LLM (Large Language Model) services locally on your Mac using podman. These containerized LLM services can be used to help developers quickly prototype new LLM based applications, without the need for relying on any other externally hosted services. Since they are already containerized, it also helps developers move from their prototype to production quicker.     \n\n## Current Locallm Services: \n\n* [Chatbot](#chatbot)\n* [Text Summarization](#text-summarization)\n* [Fine-tuning](#fine-tuning)\n\n### Chatbot\n\nA simple chatbot using the gradio UI. Learn how to build and run this model service here: [Chatbot](/chatbot/).\n\n### Text Summarization\n\nAn LLM app that can summarize arbitrarily long text inputs. Learn how to build and run this model service here: [Text Summarization](/summarizer/).\n\n### Fine Tuning \n\nThis application allows a user to select a model and a data set they'd like to fine-tune that model on. Once the application finishes, it outputs a new fine-tuned model for the user to apply to other LLM services. Learn how to build and run this model training job here: [Fine-tuning](/finetune/).\n\n## Architecture\n![](https://raw.githubusercontent.com/MichaelClifford/locallm/main/assets/arch.jpg)\n\nThe diagram above indicates the general architecture for each of the individual model services contained in this repo. The core code available here is the \"LLM Task Service\" and the \"API Server\", bundled together under `model_services`. With an appropriately chosen model downloaded onto your host, `model_services/builds` contains the Containerfiles required to build an ARM or an x86 (with CUDA) image depending on your need. These model services are intended to be light-weight and run with smaller hardware footprints (given the Locallm name), but they can be run on any hardware that supports containers and scaled up if needed.\n\nWe also provide demo \"AI Applications\" under `ai_applications` for each model service to provide an example of how a developers could interact with the model service for their own needs. ",
-      "models": [
+      "recommended": [
         "llama-2-7b-chat.Q5_K_S",
         "albedobase-xl-1.3",
         "sdxl-turbo"

--- a/packages/backend/src/tests/ai-user-test.json
+++ b/packages/backend/src/tests/ai-user-test.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0",
   "recipes": [
     {
       "id": "recipe 1",
@@ -11,7 +12,7 @@
       ],
       "basedir": "chatbot",
       "readme": "Readme for recipe 1",
-      "models": [
+      "recommended": [
         "model1",
         "model2"
       ]

--- a/packages/backend/src/utils/catalogUtils.spec.ts
+++ b/packages/backend/src/utils/catalogUtils.spec.ts
@@ -1,0 +1,150 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { test, expect, describe } from 'vitest';
+import { CatalogFormat, isNonNullObject, merge, sanitizeCategory, sanitizeModel, sanitizeRecipe } from './catalogUtils';
+
+// Dummy data for testing
+const validModel = {
+  id: 'model-1',
+  name: 'Test Model',
+  description: 'A test model',
+  hw: 'hardware',
+};
+
+const validRecipe = {
+  id: 'recipe-1',
+  name: 'Test Recipe',
+  categories: ['category-1'],
+  description: 'A test recipe',
+  repository: 'http://example.com',
+  readme: 'Readme content',
+};
+
+const validCategory = {
+  id: 'category-1',
+  name: 'Test Category',
+  description: 'A test category',
+};
+
+describe('merge', () => {
+  test('should merge catalogs correctly', () => {
+    const catalogA = {
+      version: CatalogFormat.CURRENT,
+      models: [{ id: 'model-1', name: 'Model A', description: 'Description A', hw: 'HW A' }],
+      recipes: [
+        {
+          id: 'recipe-1',
+          name: 'Recipe A',
+          categories: ['cat-1'],
+          description: 'Desc A',
+          repository: 'repo',
+          readme: 'readme',
+        },
+      ],
+      categories: [{ id: 'cat-1', name: 'Category A', description: 'Desc A' }],
+    };
+
+    const catalogB = {
+      version: CatalogFormat.CURRENT,
+      models: [{ id: 'model-2', name: 'Model B', description: 'Description B', hw: 'HW B' }],
+      recipes: [
+        {
+          id: 'recipe-2',
+          name: 'Recipe B',
+          categories: ['cat-2'],
+          description: 'Desc B',
+          repository: 'repo',
+          readme: 'readme',
+        },
+      ],
+      categories: [{ id: 'cat-2', name: 'Category B', description: 'Desc B' }],
+    };
+
+    const merged = merge(catalogA, catalogB);
+
+    expect(merged.models).toHaveLength(2);
+    expect(merged.recipes).toHaveLength(2);
+    expect(merged.categories).toHaveLength(2);
+  });
+
+  test('should throw error on incompatible versions', () => {
+    const catalogA = { version: CatalogFormat.CURRENT, models: [], recipes: [], categories: [] };
+    const catalogB = { version: CatalogFormat.UNKNOWN, models: [], recipes: [], categories: [] };
+
+    expect(() => merge(catalogA, catalogB)).toThrowError('cannot merge incompatible application catalog format.');
+  });
+});
+
+describe('isNonNullObject', () => {
+  test('should return true for non-null objects', () => {
+    expect(isNonNullObject({})).toBe(true);
+    expect(isNonNullObject({ key: 'value' })).toBe(true);
+  });
+
+  test('should return false for null or non-object values', () => {
+    expect(isNonNullObject(undefined)).toBe(false);
+    expect(isNonNullObject('string')).toBe(false);
+    expect(isNonNullObject(123)).toBe(false);
+  });
+});
+
+describe('sanitizeRecipe', () => {
+  test('undefined object', () => {
+    expect(() => sanitizeRecipe(undefined)).toThrowError('invalid recipe format');
+  });
+
+  test('valid recipe object', () => {
+    expect(sanitizeRecipe(validRecipe)).toEqual(validRecipe);
+  });
+
+  test('missing mandatory fields', () => {
+    const invalidRecipe = { ...validRecipe, id: undefined };
+    expect(() => sanitizeRecipe(invalidRecipe)).toThrowError('invalid recipe format');
+  });
+});
+
+describe('sanitizeModel', () => {
+  test('undefined object', () => {
+    expect(() => sanitizeModel(undefined)).toThrowError('invalid model format');
+  });
+
+  test('valid model object', () => {
+    expect(sanitizeModel(validModel)).toEqual(validModel);
+  });
+
+  test('missing mandatory fields', () => {
+    const invalidModel = { ...validModel, id: undefined };
+    expect(() => sanitizeModel(invalidModel)).toThrowError('invalid model format');
+  });
+});
+
+describe('sanitizeCategory', () => {
+  test('undefined object', () => {
+    expect(() => sanitizeCategory(undefined)).toThrowError('invalid category format');
+  });
+
+  test('valid category object', () => {
+    expect(sanitizeCategory(validCategory)).toEqual(validCategory);
+  });
+
+  test('missing mandatory fields', () => {
+    const invalidCategory = { ...validCategory, id: undefined };
+    expect(() => sanitizeCategory(invalidCategory)).toThrowError('invalid category format');
+  });
+});

--- a/packages/backend/src/utils/catalogUtils.ts
+++ b/packages/backend/src/utils/catalogUtils.ts
@@ -1,0 +1,178 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ApplicationCatalog } from '@shared/src/models/IApplicationCatalog';
+import type { Recipe } from '@shared/src/models/IRecipe';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import type { Category } from '@shared/src/models/ICategory';
+import type { LocalModelInfo } from '@shared/src/models/ILocalModelInfo';
+
+export enum CatalogFormat {
+  CURRENT = '1.0',
+  UNKNOWN = 'unknown',
+}
+
+export function sanitize(raw: object & { version: string }): ApplicationCatalog {
+  // ensure version is valid
+  if (raw.version !== CatalogFormat.CURRENT) throw new Error('the catalog is using an invalid version');
+
+  return {
+    version: raw.version,
+    recipes: 'recipes' in raw && Array.isArray(raw.recipes) ? raw.recipes.map(recipe => sanitizeRecipe(recipe)) : [],
+    models: 'models' in raw && Array.isArray(raw.models) ? raw.models.map(model => sanitizeModel(model)) : [],
+    categories:
+      'categories' in raw && Array.isArray(raw.categories)
+        ? raw.categories.map(category => sanitizeCategory(category))
+        : [],
+  };
+}
+
+/**
+ * This method merge catalog A and B, and let the b overwrite a on conflict
+ * @param a
+ * @param b
+ */
+export function merge(a: ApplicationCatalog, b: ApplicationCatalog): ApplicationCatalog {
+  if (a.version !== b.version) {
+    throw new Error('cannot merge incompatible application catalog format.');
+  }
+
+  return {
+    version: a.version,
+    models: [...a.models.filter(model => !b.models.some(mModel => model.id === mModel.id)), ...b.models] as ModelInfo[],
+    recipes: [...a.recipes.filter(recipe => !b.recipes.some(mRecipe => recipe.id === mRecipe.id)), ...b.recipes],
+    categories: [
+      ...a.categories.filter(category => !b.categories.some(mCategory => category.id === mCategory.id)),
+      ...b.categories,
+    ],
+  };
+}
+
+export function isNonNullObject(obj: unknown): obj is object {
+  return !!obj && typeof obj === 'object';
+}
+
+export function isStringRecord(obj: unknown): obj is Record<string, string> {
+  return (
+    isNonNullObject(obj) &&
+    Object.entries(obj).every(([key, value]) => typeof key === 'string' && typeof value === 'string')
+  );
+}
+
+export function isStringArray(obj: unknown): obj is Array<string> {
+  return Array.isArray(obj) && obj.every(item => typeof item === 'string');
+}
+
+export function sanitizeRecipe(recipe: unknown): Recipe {
+  if (
+    isNonNullObject(recipe) &&
+    'id' in recipe &&
+    typeof recipe.id === 'string' &&
+    'name' in recipe &&
+    typeof recipe.name === 'string' &&
+    'categories' in recipe &&
+    isStringArray(recipe.categories) &&
+    'description' in recipe &&
+    typeof recipe.description === 'string' &&
+    'repository' in recipe &&
+    typeof recipe.repository === 'string' &&
+    'readme' in recipe &&
+    typeof recipe.readme === 'string'
+  )
+    return {
+      // mandatory fields
+      id: recipe.id,
+      name: recipe.name,
+      categories: recipe.categories,
+      description: recipe.description,
+      repository: recipe.repository,
+      readme: recipe.readme,
+      // optional fields
+      ref: 'ref' in recipe && typeof recipe.ref === 'string' ? recipe.ref : undefined,
+      icon: 'icon' in recipe && typeof recipe.icon === 'string' ? recipe.icon : undefined,
+      basedir: 'basedir' in recipe && typeof recipe.basedir === 'string' ? recipe.basedir : undefined,
+      recommended: 'recommended' in recipe && isStringArray(recipe.recommended) ? recipe.recommended : undefined,
+      backend: 'backend' in recipe && typeof recipe.backend === 'string' ? recipe.backend : undefined,
+    };
+  throw new Error('invalid recipe format');
+}
+
+export function isLocalModelInfo(obj: unknown): obj is LocalModelInfo {
+  return (
+    isNonNullObject(obj) &&
+    'file' in obj &&
+    typeof obj.file === 'string' &&
+    'path' in obj &&
+    typeof obj.path === 'string'
+  );
+}
+
+export function sanitizeModel(model: unknown): ModelInfo {
+  if (
+    isNonNullObject(model) &&
+    'id' in model &&
+    typeof model.id === 'string' &&
+    'name' in model &&
+    typeof model.name === 'string' &&
+    'description' in model &&
+    typeof model.description === 'string' &&
+    'hw' in model &&
+    typeof model.hw === 'string'
+  )
+    return {
+      // mandatory fields
+      id: model.id,
+      name: model.name,
+      description: model.description,
+      hw: model.hw,
+      // optional fields
+      registry: 'registry' in model && typeof model.registry === 'string' ? model.registry : undefined,
+      license: 'license' in model && typeof model.license === 'string' ? model.license : undefined,
+      url: 'url' in model && typeof model.url === 'string' ? model.url : undefined,
+      memory: 'memory' in model && typeof model.memory === 'number' ? model.memory : undefined,
+      properties: 'properties' in model && isStringRecord(model.properties) ? model.properties : undefined,
+      sha256: 'sha256' in model && typeof model.sha256 === 'string' ? model.sha256 : undefined,
+      backend: 'backend' in model && typeof model.backend === 'string' ? model.backend : undefined,
+      file:
+        'file' in model && isLocalModelInfo(model.file)
+          ? {
+              ...model.file,
+              creation: new Date(model.file.creation ?? 0),
+            }
+          : undefined,
+    };
+  throw new Error('invalid model format');
+}
+
+export function sanitizeCategory(category: unknown): Category {
+  if (
+    isNonNullObject(category) &&
+    'id' in category &&
+    typeof category.id === 'string' &&
+    'name' in category &&
+    typeof category.name === 'string' &&
+    'description' in category &&
+    typeof category.description === 'string'
+  )
+    return {
+      // mandatory fields
+      id: category.id,
+      name: category.name,
+      description: category.description,
+    };
+  throw new Error('invalid category format');
+}

--- a/packages/shared/src/models/IApplicationCatalog.ts
+++ b/packages/shared/src/models/IApplicationCatalog.ts
@@ -21,7 +21,7 @@ import type { ModelInfo } from './IModelInfo';
 import type { Recipe } from './IRecipe';
 
 export interface ApplicationCatalog {
-  version: string;
+  version?: string;
   recipes: Recipe[];
   models: ModelInfo[];
   categories: Category[];

--- a/packages/shared/src/models/IApplicationCatalog.ts
+++ b/packages/shared/src/models/IApplicationCatalog.ts
@@ -21,6 +21,7 @@ import type { ModelInfo } from './IModelInfo';
 import type { Recipe } from './IRecipe';
 
 export interface ApplicationCatalog {
+  version: string;
   recipes: Recipe[];
   models: ModelInfo[];
   categories: Category[];


### PR DESCRIPTION
### What does this PR do?

This PR set a version to the catalog, current `1.0`. When undefined or different, the user-catalog will not be loaded and a warning will be logged.

To ensure the user-catalog respect the format, the `CatalogUtils` file has been created, which will properly check for all the fields.

### Screenshot / video of UI

https://github.com/user-attachments/assets/744cc19d-bbea-4b46-a814-1da62b540684

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/59

### How to test this PR?

- [x] unit tests has been provided

Reproduce video above