### PR TITLE
fix: remove gguf from external rollup

### DIFF
--- a/packages/backend/vite.config.js
+++ b/packages/backend/vite.config.js
@@ -49,7 +49,6 @@ const config = {
     rollupOptions: {
       external: [
         '@podman-desktop/api',
-        '@huggingface/gguf',
         ...builtinModules.flatMap(p => [p, `node:${p}`]),
       ],
       output: {


### PR DESCRIPTION
### What does this PR do?

Remove from the rollup external the gguf library: it lead to `@huggingface/gguf` not found when starting the extension in production.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->