### PR TITLE
fix: reduce vscode icon size

### DIFF
--- a/packages/frontend/src/lib/images/VSCodeIcon.svelte
+++ b/packages/frontend/src/lib/images/VSCodeIcon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-export let size = '40';
+export let size = '20';
 </script>
 
 <svg


### PR DESCRIPTION
### What does this PR do?

Reduce VSCode icon size

### Screenshot / video of UI

#### Before
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5fab8f38-0277-48db-b45c-77a4409e8b13">

<img width="464" alt="image" src="https://github.com/user-attachments/assets/e26fd1b9-5145-4ad4-bb9f-32626c4bd22e">

#### After

<img width="250" alt="image" src="https://github.com/user-attachments/assets/9258bfc4-a3ac-49bb-a876-07082700467f">

<img width="476" alt="image" src="https://github.com/user-attachments/assets/114f03b1-6249-4910-9d03-dc78d3d6d896">


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->