### PR TITLE
fix: handle vmtype check on Linux

### DIFF
--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -146,10 +146,21 @@ describe('getVMType', () => {
     } as unknown as RunResult);
 
     const manager = new PodmanConnection();
-    await expect(() => manager.getVMType()).rejects.toThrowError('podman machine list provided an empty array');
+    await expect(() => manager.getVMType('machine')).rejects.toThrowError(
+      'podman machine list provided an empty array',
+    );
   });
 
-  test('malformed response should return UNKNOWN', async () => {
+  test('empty array should return UNKNOWN when no name is provided', async () => {
+    vi.mocked(process.exec).mockResolvedValue({
+      stdout: '[]',
+    } as unknown as RunResult);
+
+    const manager = new PodmanConnection();
+    expect(await manager.getVMType()).toBe(VMType.UNKNOWN);
+  });
+
+  test('malformed response should throw an error', async () => {
     vi.mocked(process.exec).mockResolvedValue({
       stdout: '{}',
     } as unknown as RunResult);

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -110,7 +110,9 @@ export class PodmanConnection implements Disposable {
 
     const parsed: unknown = JSON.parse(stdout);
     if (!Array.isArray(parsed)) throw new Error('podman machine list provided a malformed response');
-    if (parsed.length === 0) throw new Error('podman machine list provided an empty array');
+    if (parsed.length === 0 && name) throw new Error('podman machine list provided an empty array');
+    // On Linux we might not have any machine
+    if (parsed.length === 0) return VMType.UNKNOWN;
     if (parsed.length > 1 && !name)
       throw new Error('name need to be provided when more than one podman machine is configured.');
 


### PR DESCRIPTION
### What does this PR do?

On Linux machine, we may not have podman machine configured. The getVMType expect at least one machine, with this fix, we handle the case where we have none, and return UNKNOWN.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1406

### How to test this PR?

- [x] unit test has been provided

**Manually**
Start a recipe
