### PR TITLE
fix: racing condition catalog loading

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -88,7 +88,7 @@ const inferenceProviderRegistryMock = {
 } as unknown as InferenceProviderRegistry;
 
 const catalogManager = {
-  onCatalogUpdate: vi.fn(),
+  onUpdate: vi.fn(),
 } as unknown as CatalogManager;
 
 const getInitializedInferenceManager = async (): Promise<InferenceManager> => {

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -61,7 +61,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     this.podmanConnection.onMachineStart(this.watchMachineEvent.bind(this, 'start'));
     this.podmanConnection.onMachineStop(this.watchMachineEvent.bind(this, 'stop'));
     this.containerRegistry.onStartContainerEvent(this.watchContainerStart.bind(this));
-    this.catalogManager.onCatalogUpdate(() => {
+    this.catalogManager.onUpdate(() => {
       this.retryableRefresh(1);
     });
     this.retryableRefresh(3);

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -21,9 +21,9 @@ import os from 'os';
 import fs, { type Stats, type PathLike } from 'node:fs';
 import path from 'node:path';
 import { ModelsManager } from './modelsManager';
-import { env, process as coreProcess, Disposable } from '@podman-desktop/api';
+import { env, process as coreProcess } from '@podman-desktop/api';
 import type { RunResult, TelemetryLogger, Webview } from '@podman-desktop/api';
-import type { CatalogManager, catalogUpdateHandle } from './catalogManager';
+import type { CatalogManager } from './catalogManager';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import * as utils from '../utils/utils';
 import { TaskRegistry } from '../registries/TaskRegistry';
@@ -178,10 +178,8 @@ test('getModelsInfo should get models in local directory', async () => {
           { id: 'model-id-2', name: 'model-id-2-model' } as ModelInfo,
         ];
       },
-      onCatalogUpdate(_listener: catalogUpdateHandle): Disposable {
-        return Disposable.create(() => {});
-      },
-    } as CatalogManager,
+      onUpdate: vi.fn(),
+    } as unknown as CatalogManager,
     telemetryLogger,
     taskRegistry,
     cancellationTokenRegistryMock,
@@ -229,10 +227,8 @@ test('getModelsInfo should return an empty array if the models folder does not e
       getModels(): ModelInfo[] {
         return [];
       },
-      onCatalogUpdate(_listener: catalogUpdateHandle): Disposable {
-        return Disposable.create(() => {});
-      },
-    } as CatalogManager,
+      onUpdate: vi.fn(),
+    } as unknown as CatalogManager,
     telemetryLogger,
     taskRegistry,
     cancellationTokenRegistryMock,
@@ -271,10 +267,8 @@ test('getLocalModelsFromDisk should return undefined Date and size when stat fai
       getModels(): ModelInfo[] {
         return [{ id: 'model-id-1', name: 'model-id-1-model' } as ModelInfo];
       },
-      onCatalogUpdate(_listener: catalogUpdateHandle): Disposable {
-        return Disposable.create(() => {});
-      },
-    } as CatalogManager,
+      onUpdate: vi.fn(),
+    } as unknown as CatalogManager,
     telemetryLogger,
     taskRegistry,
     cancellationTokenRegistryMock,
@@ -331,10 +325,8 @@ test('getLocalModelsFromDisk should skip folders containing tmp files', async ()
       getModels(): ModelInfo[] {
         return [{ id: 'model-id-1', name: 'model-id-1-model' } as ModelInfo];
       },
-      onCatalogUpdate(_listener: catalogUpdateHandle): Disposable {
-        return Disposable.create(() => {});
-      },
-    } as CatalogManager,
+      onUpdate: vi.fn(),
+    } as unknown as CatalogManager,
     telemetryLogger,
     taskRegistry,
     cancellationTokenRegistryMock,
@@ -373,10 +365,8 @@ test('loadLocalModels should post a message with the message on disk and on cata
           },
         ] as ModelInfo[];
       },
-      onCatalogUpdate(_listener: catalogUpdateHandle): Disposable {
-        return Disposable.create(() => {});
-      },
-    } as CatalogManager,
+      onUpdate: vi.fn(),
+    } as unknown as CatalogManager,
     telemetryLogger,
     taskRegistry,
     cancellationTokenRegistryMock,
@@ -425,10 +415,8 @@ test('deleteModel deletes the model folder', async () => {
           },
         ] as ModelInfo[];
       },
-      onCatalogUpdate(_listener: catalogUpdateHandle): Disposable {
-        return Disposable.create(() => {});
-      },
-    } as CatalogManager,
+      onUpdate: vi.fn(),
+    } as unknown as CatalogManager,
     telemetryLogger,
     taskRegistry,
     cancellationTokenRegistryMock,
@@ -491,10 +479,8 @@ describe('deleting models', () => {
             },
           ] as ModelInfo[];
         },
-        onCatalogUpdate(_listener: catalogUpdateHandle): Disposable {
-          return Disposable.create(() => {});
-        },
-      } as CatalogManager,
+        onUpdate: vi.fn(),
+      } as unknown as CatalogManager,
       telemetryLogger,
       taskRegistry,
       cancellationTokenRegistryMock,
@@ -870,7 +856,7 @@ describe('getModelMetadata', () => {
             file: undefined,
           } as unknown as ModelInfo,
         ],
-        onCatalogUpdate: vi.fn(),
+        onUpdate: vi.fn(),
       } as unknown as CatalogManager,
       telemetryLogger,
       taskRegistry,
@@ -910,7 +896,7 @@ describe('getModelMetadata', () => {
             },
           } as unknown as ModelInfo,
         ],
-        onCatalogUpdate: vi.fn(),
+        onUpdate: vi.fn(),
       } as unknown as CatalogManager,
       telemetryLogger,
       taskRegistry,

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -57,7 +57,7 @@ export class ModelsManager implements Disposable {
   }
 
   init() {
-    const disposable = this.catalogManager.onCatalogUpdate(() => {
+    const disposable = this.catalogManager.onUpdate(() => {
       this.loadLocalModels().catch((err: unknown) => {
         console.error(`Something went wrong when loading local models`, err);
       });

--- a/packages/backend/src/registries/LocalRepositoryRegistry.ts
+++ b/packages/backend/src/registries/LocalRepositoryRegistry.ts
@@ -45,9 +45,11 @@ export class LocalRepositoryRegistry extends Publisher<LocalRepository[]> implem
   }
 
   init(): void {
-    this.#catalogEventDisposable = this.catalogManager.onCatalogUpdate(() => {
-      this.loadLocalRecipeRepositories(this.catalogManager.getRecipes());
+    this.#catalogEventDisposable = this.catalogManager.onUpdate(({ recipes }) => {
+      this.loadLocalRecipeRepositories(recipes);
     });
+
+    this.loadLocalRecipeRepositories(this.catalogManager.getRecipes());
   }
 
   register(localRepository: LocalRepository): Disposable {


### PR DESCRIPTION
### What does this PR do?

To avoid racing issue, in the `init` function of the `LocalRepositoryRegistry` we will list the recipes. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

FIxes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1408

### How to test this PR?

- [x] unit tests has been added

**manually**

Stop and Start AI-Lab, you should always see the recipes already clone indicated in the recipes page