### PR TITLE
feat: makes inference server details link clickable

### DIFF
--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -175,6 +175,8 @@ describe('perform', () => {
       },
       labels: {
         [LABEL_INFERENCE_SERVER]: `["${DummyModel.id}"]`,
+        api: 'http://localhost:8888/v1',
+        docs: 'http://localhost:8888/docs',
       },
       models: [DummyModel],
       status: 'running',
@@ -218,7 +220,9 @@ describe('perform', () => {
       },
       Image: DummyImageInfo.Id,
       Labels: {
-        'ai-lab-inference-server': `["${DummyModel.id}"]`,
+        [LABEL_INFERENCE_SERVER]: `["${DummyModel.id}"]`,
+        api: 'http://localhost:8888/v1',
+        docs: 'http://localhost:8888/docs',
       },
     });
   });

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -149,6 +149,10 @@ export class LlamaCppPython extends InferenceProvider {
       }
     }
 
+    // adding labels to inference server
+    labels['docs'] = `http://localhost:${config.port}/docs`;
+    labels['api'] = `http://localhost:${config.port}/v1`;
+
     return {
       Image: imageInfo.Id,
       Detach: true,

--- a/packages/frontend/src/lib/button/CopyButton.spec.ts
+++ b/packages/frontend/src/lib/button/CopyButton.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { expect, test, vi, beforeEach } from 'vitest';
+
+import { render, within, fireEvent, waitFor } from '@testing-library/svelte';
+import CopyButton from '/@/lib/button/CopyButton.svelte';
+import { studioClient } from '/@/utils/client';
+
+vi.mock('../../utils/client', async () => ({
+  studioClient: {
+    copyToClipboard: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(studioClient.copyToClipboard).mockResolvedValue(undefined);
+});
+
+test('clicking on the content should call copyToClipboard', async () => {
+  const { container } = render(CopyButton, {
+    content: 'dummy-content',
+  });
+
+  const cpyButton = within(container).getByRole('button');
+  expect(cpyButton).toBeDefined();
+
+  await fireEvent.click(cpyButton);
+
+  await waitFor(() => {
+    expect(studioClient.copyToClipboard).toHaveBeenCalledWith('dummy-content');
+  });
+});

--- a/packages/frontend/src/lib/button/CopyButton.svelte
+++ b/packages/frontend/src/lib/button/CopyButton.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+import { Tooltip } from '@podman-desktop/ui-svelte';
+import { studioClient } from '/@/utils/client';
+import type { Snippet } from 'svelte';
+
+let {
+  content,
+  class: classes,
+  children,
+}: { class: string | undefined; content: string; children: Snippet | undefined } = $props();
+let status: 'idle' | 'copied' = $state('idle');
+
+function copy(content: string): void {
+  if (status !== 'idle') return;
+  studioClient
+    .copyToClipboard(content)
+    .then(() => {
+      status = 'copied';
+    })
+    .catch((err: unknown) => {
+      console.error(err);
+    });
+}
+
+function reset(): void {
+  status = 'idle';
+}
+</script>
+
+<Tooltip bottom tip={status === 'idle' ? 'Copy' : 'Copied'}>
+  <button onmouseleave={reset} onclick={() => copy(content)} class={`${classes} cursor-copy`}>
+    {#if children}
+      {@render children()}
+    {/if}
+  </button>
+</Tooltip>

--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -54,6 +54,7 @@ vi.mock('../stores/snippetLanguages', () => ({
 vi.mock('../utils/client', () => {
   return {
     studioClient: {
+      openURL: vi.fn(),
       createSnippet: vi.fn(),
       copyToClipboard: vi.fn(),
       telemetryLogUsage: vi.fn(),
@@ -123,8 +124,12 @@ test('ensure address is displayed', async () => {
     containerId: 'dummyContainerId',
   });
 
-  const address = screen.getByText('http://localhost:9999/v1');
+  const address = screen.getByText('http://localhost:9999/docs');
   expect(address).toBeDefined();
+
+  await fireEvent.click(address);
+
+  expect(studioClient.openURL).toHaveBeenCalledWith('http://localhost:9999/docs');
 });
 
 test('language select must have the mocked snippet languages', async () => {

--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -119,7 +119,15 @@ beforeEach(() => {
   mocks.getInferenceServersMock.mockReturnValue([inferenceServerMock]);
 });
 
-test('ensure address is displayed', async () => {
+test('ensure documentation url is displayed', async () => {
+  mocks.getInferenceServersMock.mockReturnValue([
+    {
+      ...inferenceServerMock,
+      labels: {
+        docs: 'http://localhost:9999/docs',
+      },
+    },
+  ]);
   render(InferenceServerDetails, {
     containerId: 'dummyContainerId',
   });
@@ -130,6 +138,27 @@ test('ensure address is displayed', async () => {
   await fireEvent.click(address);
 
   expect(studioClient.openURL).toHaveBeenCalledWith('http://localhost:9999/docs');
+});
+
+test('ensure api url is displayed', async () => {
+  mocks.getInferenceServersMock.mockReturnValue([
+    {
+      ...inferenceServerMock,
+      labels: {
+        api: 'http://localhost:9999/v1',
+      },
+    },
+  ]);
+  render(InferenceServerDetails, {
+    containerId: 'dummyContainerId',
+  });
+
+  const address = screen.getByText('http://localhost:9999/v1');
+  expect(address).toBeDefined();
+
+  await fireEvent.click(address);
+
+  expect(studioClient.openURL).toHaveBeenCalledWith('http://localhost:9999/v1');
 });
 
 test('language select must have the mocked snippet languages', async () => {

--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -140,27 +140,6 @@ test('ensure documentation url is displayed', async () => {
   expect(studioClient.openURL).toHaveBeenCalledWith('http://localhost:9999/docs');
 });
 
-test('ensure api url is displayed', async () => {
-  mocks.getInferenceServersMock.mockReturnValue([
-    {
-      ...inferenceServerMock,
-      labels: {
-        api: 'http://localhost:9999/v1',
-      },
-    },
-  ]);
-  render(InferenceServerDetails, {
-    containerId: 'dummyContainerId',
-  });
-
-  const address = screen.getByText('http://localhost:9999/v1');
-  expect(address).toBeDefined();
-
-  await fireEvent.click(address);
-
-  expect(studioClient.openURL).toHaveBeenCalledWith('http://localhost:9999/v1');
-});
-
 test('language select must have the mocked snippet languages', async () => {
   render(InferenceServerDetails, {
     containerId: 'dummyContainerId',

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -201,7 +201,7 @@ export function goToUpPage(): void {
                     <button
                       on:click={() =>
                         service && studioClient.openURL(`http://localhost:${service.connection.port}/docs`)}
-                      class="bg-charcoal-600 rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center underline">
+                      class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center underline">
                       http://localhost:{service.connection.port}/docs
                       <Fa class="ml-2" icon={faArrowUpRightFromSquare} />
                     </button>

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -199,12 +199,11 @@ export function goToUpPage(): void {
                 <div class="flex flex-row gap-4">
                   {#if service.status === 'running' && service.type === InferenceType.LLAMA_CPP}
                     <button
-                      on:click="{() =>
-                        service &&
-                        studioClient.openURL(`http://localhost:${service.connection.port}/docs`)}"
+                      on:click={() =>
+                        service && studioClient.openURL(`http://localhost:${service.connection.port}/docs`)}
                       class="bg-charcoal-600 rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center underline">
                       http://localhost:{service.connection.port}/docs
-                      <Fa class="ml-2" icon="{faArrowUpRightFromSquare}" />
+                      <Fa class="ml-2" icon={faArrowUpRightFromSquare} />
                     </button>
                   {/if}
 

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -4,7 +4,6 @@ import ServiceStatus from '/@/lib/table/service/ServiceStatus.svelte';
 import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 import Fa from 'svelte-fa';
 import {
-  faArrowUpRightFromSquare,
   faBook,
   faBuildingColumns,
   faCheck,
@@ -14,7 +13,7 @@ import {
   faPlug,
   faScaleBalanced,
 } from '@fortawesome/free-solid-svg-icons';
-import type { InferenceServer, InferenceType } from '@shared/src/models/IInference';
+import type { InferenceServer } from '@shared/src/models/IInference';
 import { snippetLanguages } from '/@/stores/snippetLanguages';
 import type { LanguageVariant } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -5,14 +5,16 @@ import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 import Fa from 'svelte-fa';
 import {
   faArrowUpRightFromSquare,
+  faBook,
   faBuildingColumns,
   faCheck,
   faCopy,
   faFan,
   faMicrochip,
+  faPlug,
   faScaleBalanced,
 } from '@fortawesome/free-solid-svg-icons';
-import type { InferenceServer, InferenceType  } from '@shared/src/models/IInference';
+import type { InferenceServer, InferenceType } from '@shared/src/models/IInference';
 import { snippetLanguages } from '/@/stores/snippetLanguages';
 import type { LanguageVariant } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
@@ -20,6 +22,7 @@ import { onMount } from 'svelte';
 import { router } from 'tinro';
 import { Button, DetailsPage } from '@podman-desktop/ui-svelte';
 import { Tooltip } from '@podman-desktop/ui-svelte';
+import CopyButton from '/@/lib/button/CopyButton.svelte';
 
 export let containerId: string | undefined = undefined;
 
@@ -197,16 +200,27 @@ export function goToUpPage(): void {
               <div class="bg-[var(--pd-content-card-bg)] rounded-md w-full px-4 pt-2 pb-4 mt-2">
                 <span class="text-sm text-[var(--pd-content-card-text)]">Server</span>
                 <div class="flex flex-row gap-4">
-                  {#if service.status === 'running' && service.type === InferenceType.LLAMA_CPP}
-                    <button
-                      on:click={() =>
-                        service && studioClient.openURL(`http://localhost:${service.connection.port}/docs`)}
-                      class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center underline">
-                      http://localhost:{service.connection.port}/docs
-                      <Fa class="ml-2" icon={faArrowUpRightFromSquare} />
-                    </button>
-                  {/if}
+                  {#if service.status === 'running'}
+                    {#if 'docs' in service.labels}
+                      <Tooltip tip="Open swagger documentation">
+                        <button
+                          on:click={() => service && studioClient.openURL(service.labels['docs'])}
+                          class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center underline">
+                          {service.labels['docs']}
+                          <Fa class="ml-2" icon={faBook} />
+                        </button>
+                      </Tooltip>
+                    {/if}
 
+                    {#if 'api' in service.labels}
+                      <CopyButton
+                        class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center"
+                        content={service.labels['api']}>
+                        {service.labels['api']}
+                        <Fa class="ml-2" icon={faPlug} />
+                      </CopyButton>
+                    {/if}
+                  {/if}
 
                   {#if 'gpu' in service.labels}
                     <Tooltip tip={service.labels['gpu']}>

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -4,6 +4,7 @@ import ServiceStatus from '/@/lib/table/service/ServiceStatus.svelte';
 import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 import Fa from 'svelte-fa';
 import {
+  faArrowUpRightFromSquare,
   faBuildingColumns,
   faCheck,
   faCopy,
@@ -11,7 +12,7 @@ import {
   faMicrochip,
   faScaleBalanced,
 } from '@fortawesome/free-solid-svg-icons';
-import type { InferenceServer } from '@shared/src/models/IInference';
+import type { InferenceServer, InferenceType  } from '@shared/src/models/IInference';
 import { snippetLanguages } from '/@/stores/snippetLanguages';
 import type { LanguageVariant } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
@@ -196,10 +197,18 @@ export function goToUpPage(): void {
               <div class="bg-[var(--pd-content-card-bg)] rounded-md w-full px-4 pt-2 pb-4 mt-2">
                 <span class="text-sm text-[var(--pd-content-card-text)]">Server</span>
                 <div class="flex flex-row gap-4">
-                  <div
-                    class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center">
-                    http://localhost:{service.connection.port}/v1
-                  </div>
+                  {#if service.status === 'running' && service.type === InferenceType.LLAMA_CPP}
+                    <button
+                      on:click="{() =>
+                        service &&
+                        studioClient.openURL(`http://localhost:${service.connection.port}/docs`)}"
+                      class="bg-charcoal-600 rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center underline">
+                      http://localhost:{service.connection.port}/docs
+                      <Fa class="ml-2" icon="{faArrowUpRightFromSquare}" />
+                    </button>
+                  {/if}
+
+
                   {#if 'gpu' in service.labels}
                     <Tooltip tip={service.labels['gpu']}>
                       <div


### PR DESCRIPTION
### What does this PR do?

When the service is running, makes the url link clickable. It will open the default browser 

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/f86f3ed7-1e4c-4a46-b70d-7c3698218208)

https://github.com/user-attachments/assets/fc160c27-cbaa-4682-8165-1d21f2d38300

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1213

### How to test this PR?

- [x] unit tests has been provided

**manually**

Go to inference service details, click on the link