### PR TITLE
feat: create notification on user catalog issue

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,25 @@
+# Migration guide
+
+## ApplicationCatalog
+
+Before **Podman AI Lab** `v1.2.0` the [user-catalog](./PACKAGING-GUIDE.md#applicationcatalog) were not versioned. 
+Started from `v1.2.0` all user-catalog require to have a `version` property.
+
+The list of catalog versions can be found in [packages/backend/src/utils/catalogUtils.ts](https://github.com/containers/podman-desktop-extension-ai-lab/blob/main/packages/backend/src/utils/catalogUtils.ts)
+
+The catalog has its own version number, as we may not require to update it with every update. It will follow semantic versioning convention.
+
+## `None` to Catalog `1.0`
+
+None represents any catalog version prior to the first versioning. 
+
+Version `1.0` of the catalog add an important property to models `backend`, defining the type of framework required by the model to run (E.g. LLamaCPP, WhisperCPP).
+
+### Changelog
+
+- property `backend` on models and recipes. Ref https://github.com/containers/podman-desktop-extension-ai-lab/pull/1186
+- property `models` is now **deprecated** and useless. Ref https://github.com/containers/podman-desktop-extension-ai-lab/pull/1210
+- property `recommended` has been added. Ref https://github.com/containers/podman-desktop-extension-ai-lab/pull/1210
+- optional `chatFormat` added. Ref: https://github.com/containers/podman-desktop-extension-ai-lab/pull/868
+- optional `sha256` property on models. Ref https://github.com/containers/podman-desktop-extension-ai-lab/pull/1078
+

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,7 +3,7 @@
 ## ApplicationCatalog
 
 Before **Podman AI Lab** `v1.2.0` the [user-catalog](./PACKAGING-GUIDE.md#applicationcatalog) were not versioned. 
-Started from `v1.2.0` all user-catalog require to have a `version` property.
+Starting from `v1.2.0` all user-catalog require to have a `version` property.
 
 The list of catalog versions can be found in [packages/backend/src/utils/catalogUtils.ts](https://github.com/containers/podman-desktop-extension-ai-lab/blob/main/packages/backend/src/utils/catalogUtils.ts)
 
@@ -11,9 +11,9 @@ The catalog has its own version number, as we may not require to update it with 
 
 ## `None` to Catalog `1.0`
 
-None represents any catalog version prior to the first versioning. 
+`None` represents any catalog version prior to the first versioning. 
 
-Version `1.0` of the catalog add an important property to models `backend`, defining the type of framework required by the model to run (E.g. LLamaCPP, WhisperCPP).
+Version `1.0` of the catalog adds an important property to models `backend`, defining the type of framework required by the model to run (E.g. LLamaCPP, WhisperCPP).
 
 ### Changelog
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,8 +2,8 @@
 
 ## ApplicationCatalog
 
-Before **Podman AI Lab** `v1.2.0` the [user-catalog](./PACKAGING-GUIDE.md#applicationcatalog) were not versioned. 
-Starting from `v1.2.0` all user-catalog require to have a `version` property.
+Before **Podman AI Lab** `v1.2.0` the [user-catalog](./PACKAGING-GUIDE.md#applicationcatalog) was not versioned. 
+Starting from `v1.2.0` the user-catalog require to have a `version` property.
 
 The list of catalog versions can be found in [packages/backend/src/utils/catalogUtils.ts](https://github.com/containers/podman-desktop-extension-ai-lab/blob/main/packages/backend/src/utils/catalogUtils.ts)
 


### PR DESCRIPTION
### What does this PR do?

Adding notification when the catalog is malformed or wrong version is used.

### Screenshot / video of UI

https://github.com/user-attachments/assets/15004af9-0ceb-4d81-99e9-858c95f39013

**using old catalog version**
![image](https://github.com/user-attachments/assets/e5208818-7b68-427e-b89c-af229b08825f)

**malformed catalog**
![image](https://github.com/user-attachments/assets/903790ec-4e1e-4253-9102-a6062ba1ba0b)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1394

### How to test this PR?
- [x] unit tests has been provided