### PR TITLE
feat(ui): create SelectModel component

### DIFF
--- a/packages/frontend/src/lib/ModelSelect.spec.ts
+++ b/packages/frontend/src/lib/ModelSelect.spec.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, test, expect } from 'vitest';
+import { render, fireEvent, within } from '@testing-library/svelte';
+import ModelSelect from '/@/lib/ModelSelect.svelte';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { InferenceType } from '@shared/src/models/IInference';
+
+const fakeRecommendedModel: ModelInfo = {
+  id: 'dummy-model-1',
+  backend: InferenceType.LLAMA_CPP,
+  name: 'Dummy Model 1',
+  file: {
+    file: 'dummy-model-file',
+    path: 'dummy-model-path',
+  },
+} as unknown as ModelInfo;
+
+const fakeRemoteModel: ModelInfo = {
+  id: 'dummy-model-2',
+  backend: InferenceType.LLAMA_CPP,
+  name: 'Dummy Model 2',
+} as unknown as ModelInfo;
+
+beforeEach(() => {
+  // mock scrollIntoView
+  window.HTMLElement.prototype.scrollIntoView = function () {};
+});
+
+test('ModelSelect should list all models provided', async () => {
+  const { container } = render(ModelSelect, {
+    value: undefined,
+    disabled: undefined,
+    models: [fakeRecommendedModel, fakeRemoteModel],
+    recommended: [],
+  });
+
+  // first get the select input
+  const input = within(container).getByLabelText('Select Model');
+  await fireEvent.pointerUp(input); // they are using the pointer up event instead of click.
+
+  // get all options available
+  const items = container.querySelectorAll('div[class~="list-item"]');
+  // ensure we have two options
+  expect(items.length).toBe(2);
+  expect(items[0]).toHaveTextContent(fakeRecommendedModel.name);
+  expect(items[1]).toHaveTextContent(fakeRemoteModel.name);
+});
+
+test('ModelSelect should set star icon next to recommended model', async () => {
+  const { container } = render(ModelSelect, {
+    value: undefined,
+    disabled: undefined,
+    models: [fakeRecommendedModel, fakeRemoteModel],
+    recommended: [fakeRemoteModel.id],
+  });
+
+  // first get the select input
+  const input = within(container).getByLabelText('Select Model');
+  await fireEvent.pointerUp(input); // they are using the pointer up event instead of click.
+
+  // get all options available
+  const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
+  // ensure we have two options
+  expect(items.length).toBe(2);
+  expect(within(items[0]).queryByTitle('Recommended model')).toBeNull();
+  expect(within(items[1]).getByTitle('Recommended model')).toBeDefined();
+});

--- a/packages/frontend/src/lib/ModelSelect.spec.ts
+++ b/packages/frontend/src/lib/ModelSelect.spec.ts
@@ -69,7 +69,7 @@ test('ModelSelect should set star icon next to recommended model', async () => {
     value: undefined,
     disabled: undefined,
     models: [fakeRecommendedModel, fakeRemoteModel],
-    recommended: [fakeRemoteModel.id],
+    recommended: [fakeRecommendedModel.id],
   });
 
   // first get the select input
@@ -80,6 +80,26 @@ test('ModelSelect should set star icon next to recommended model', async () => {
   const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
   // ensure we have two options
   expect(items.length).toBe(2);
-  expect(within(items[0]).queryByTitle('Recommended model')).toBeNull();
-  expect(within(items[1]).getByTitle('Recommended model')).toBeDefined();
+  expect(within(items[0]).getByTitle('Recommended model')).toBeDefined();
+  expect(within(items[1]).queryByTitle('Recommended model')).toBeNull();
+});
+
+test('recommended models should be displayed first', async () => {
+  const { container } = render(ModelSelect, {
+    value: undefined,
+    disabled: undefined,
+    models: [fakeRemoteModel, fakeRecommendedModel],
+    recommended: [fakeRecommendedModel.id],
+  });
+
+  // first get the select input
+  const input = within(container).getByLabelText('Select Model');
+  await fireEvent.pointerUp(input); // they are using the pointer up event instead of click.
+
+  // get all options available
+  const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
+  // ensure we have two options
+  expect(items.length).toBe(2);
+  expect(items[0]).toHaveTextContent(fakeRecommendedModel.name);
+  expect(items[1]).toHaveTextContent(fakeRemoteModel.name);
 });

--- a/packages/frontend/src/lib/ModelSelect.spec.ts
+++ b/packages/frontend/src/lib/ModelSelect.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { beforeEach, test, expect } from 'vitest';
+import { beforeEach, vi, test, expect } from 'vitest';
 import { render, fireEvent, within } from '@testing-library/svelte';
 import ModelSelect from '/@/lib/ModelSelect.svelte';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
@@ -39,9 +39,15 @@ const fakeRemoteModel: ModelInfo = {
   name: 'Dummy Model 2',
 } as unknown as ModelInfo;
 
+const fakeRecommendedRemoteModel: ModelInfo = {
+  id: 'dummy-model-3',
+  backend: InferenceType.LLAMA_CPP,
+  name: 'Dummy Model 3',
+} as unknown as ModelInfo;
+
 beforeEach(() => {
   // mock scrollIntoView
-  window.HTMLElement.prototype.scrollIntoView = function () {};
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 test('ModelSelect should list all models provided', async () => {
@@ -84,12 +90,12 @@ test('ModelSelect should set star icon next to recommended model', async () => {
   expect(within(items[1]).queryByTitle('Recommended model')).toBeNull();
 });
 
-test('recommended models should be displayed first', async () => {
+test('models should be sorted', async () => {
   const { container } = render(ModelSelect, {
     value: undefined,
     disabled: undefined,
-    models: [fakeRemoteModel, fakeRecommendedModel],
-    recommended: [fakeRecommendedModel.id],
+    models: [fakeRemoteModel, fakeRecommendedRemoteModel, fakeRecommendedModel],
+    recommended: [fakeRecommendedModel.id, fakeRecommendedRemoteModel.id],
   });
 
   // first get the select input
@@ -99,7 +105,8 @@ test('recommended models should be displayed first', async () => {
   // get all options available
   const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
   // ensure we have two options
-  expect(items.length).toBe(2);
+  expect(items.length).toBe(3);
   expect(items[0]).toHaveTextContent(fakeRecommendedModel.name);
-  expect(items[1]).toHaveTextContent(fakeRemoteModel.name);
+  expect(items[1]).toHaveTextContent(fakeRecommendedRemoteModel.name);
+  expect(items[2]).toHaveTextContent(fakeRemoteModel.name);
 });

--- a/packages/frontend/src/lib/ModelSelect.svelte
+++ b/packages/frontend/src/lib/ModelSelect.svelte
@@ -15,15 +15,11 @@ export let recommended: string[] | undefined = undefined;
  */
 export let models: ModelInfo[];
 
-let sorted: ModelInfo[];
-
-/**
- * Put the recommended models at the top
- */
-$: {
-  sorted = models.toSorted((a, b) => {
-    return (recommended?.includes(a.id) ? 0 : 1) - (recommended?.includes(b.id) ? 0 : 1);
-  });
+function getModelSortingScore(modelInfo: ModelInfo): number {
+  let score: number = 0;
+  if (modelInfo.file) score -= 1;
+  if (recommended?.includes(modelInfo.id)) score -= 1;
+  return score;
 }
 
 /**
@@ -63,7 +59,9 @@ $: {
   --border-focused="var(--pd-input-field-focused-bg)"
   placeholder="Select model to use"
   class="!bg-[var(--pd-content-bg)] !text-[var(--pd-content-card-text)]"
-  items={sorted.map(model => ({ ...model, value: model.id, label: model.name }))}
+  items={models
+    .toSorted((a, b) => getModelSortingScore(a) - getModelSortingScore(b))
+    .map(model => ({ ...model, value: model.id, label: model.name }))}
   showChevron>
   <div slot="item" let:item>
     <div class="flex items-center">

--- a/packages/frontend/src/lib/ModelSelect.svelte
+++ b/packages/frontend/src/lib/ModelSelect.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+import { faCheckCircle, faDownload } from '@fortawesome/free-solid-svg-icons';
+import Select from 'svelte-select';
+import Fa from 'svelte-fa';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+
+export let disabled: boolean = false;
+/**
+ * Recommended model ids
+ */
+export let recommended: string[] | undefined = undefined;
+
+/**
+ * List of models
+ */
+export let models: ModelInfo[];
+
+/**
+ * Current value selected
+ */
+export let value: ModelInfo | undefined = undefined;
+
+/**
+ * Handy mechanism to provide the mandatory property `label` and `value` to the Select component
+ */
+let selected: (ModelInfo & { label: string; value: string }) | undefined = undefined;
+$: {
+  // let's select a default model
+  if (value) {
+    selected = { ...value, label: value.name, value: value.id };
+  }
+}
+</script>
+
+<Select
+  inputAttributes={{ 'aria-label': 'Select Model' }}
+  name="select-model"
+  disabled={disabled}
+  value={selected}
+  on:change={e => (value = e.detail)}
+  --item-color={'var(--pd-dropdown-item-text)'}
+  --item-is-active-color={'var(--pd-dropdown-item-text)'}
+  --item-hover-color="var(--pd-dropdown-item-hover-text)"
+  --item-active-background="var(--pd-input-field-hover-stroke)"
+  --item-is-active-bg="var(--pd-input-field-hover-stroke)"
+  --background={'var(--pd-dropdown-bg)'}
+  --list-background={'var(--pd-dropdown-bg)'}
+  --item-hover-bg="var(--pd-dropdown-item-hover-bg)"
+  --border="1px solid var(--pd-input-field-focused-bg)"
+  --border-hover="1px solid var(--pd-input-field-hover-stroke)"
+  --list-border="1px solid var(--pd-input-field-focused-bg)"
+  --border-focused="var(--pd-input-field-focused-bg)"
+  placeholder="Select model to use"
+  class="!bg-[var(--pd-content-bg)] !text-[var(--pd-content-card-text)]"
+  items={models.map(model => ({ ...model, value: model.id, label: model.name }))}
+  showChevron>
+  <div slot="item" let:item>
+    <div class="flex items-center">
+      <div class="grow">
+        <span>{item.name}</span>
+        {#if recommended?.includes(item.id)}
+          <i class="fas fa-star fa-xs" title="Recommended model"></i>
+        {/if}
+      </div>
+
+      {#if item.file !== undefined}
+        <Fa icon={faCheckCircle} />
+      {:else}
+        <Fa icon={faDownload} />
+      {/if}
+    </div>
+  </div>
+</Select>

--- a/packages/frontend/src/lib/ModelSelect.svelte
+++ b/packages/frontend/src/lib/ModelSelect.svelte
@@ -15,6 +15,17 @@ export let recommended: string[] | undefined = undefined;
  */
 export let models: ModelInfo[];
 
+let sorted: ModelInfo[];
+
+/**
+ * Put the recommended models at the top
+ */
+$: {
+  sorted = models.toSorted((a, b) => {
+    return (recommended?.includes(a.id) ? 0 : 1) - (recommended?.includes(b.id) ? 0 : 1);
+  });
+}
+
 /**
  * Current value selected
  */
@@ -52,7 +63,7 @@ $: {
   --border-focused="var(--pd-input-field-focused-bg)"
   placeholder="Select model to use"
   class="!bg-[var(--pd-content-bg)] !text-[var(--pd-content-card-text)]"
-  items={models.map(model => ({ ...model, value: model.id, label: model.name }))}
+  items={sorted.map(model => ({ ...model, value: model.id, label: model.name }))}
   showChevron>
   <div slot="item" let:item>
     <div class="flex items-center">

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -92,6 +92,8 @@ beforeEach(() => {
   mocks.getInferenceServersMock.mockReturnValue([
     { container: { containerId: 'dummyContainerId' } } as InferenceServer,
   ]);
+
+  window.HTMLElement.prototype.scrollIntoView = function () {};
 });
 
 test('create button should be disabled when no model id provided', async () => {
@@ -240,9 +242,6 @@ test('form should be disabled when loading', async () => {
   ]);
 
   await vi.waitFor(() => {
-    const select = screen.getByRole('combobox', { name: 'Model select' });
-    expect(select).toBeDisabled();
-
     const input = screen.getByRole('textbox', { name: 'Port input' });
     expect(input).toBeDisabled();
   });

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -93,7 +93,7 @@ beforeEach(() => {
     { container: { containerId: 'dummyContainerId' } } as InferenceServer,
   ]);
 
-  window.HTMLElement.prototype.scrollIntoView = function () {};
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 test('create button should be disabled when no model id provided', async () => {

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -167,8 +167,7 @@ export function goToUpPage(): void {
       <div class="bg-[var(--pd-content-card-bg)] m-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg h-fit">
         <div class="w-full">
           <!-- model input -->
-          <label for="model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
-            >Model</label>
+          <label for="model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]">Model</label>
           <ModelSelect models={localModels} disabled={loading} bind:value={model} />
           {#if localModels.length === 0}
             <div class="text-red-500 p-1 flex flex-row items-center">

--- a/packages/frontend/src/pages/PlaygroundCreate.spec.ts
+++ b/packages/frontend/src/pages/PlaygroundCreate.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
-import { expect, test, vi } from 'vitest';
+import { expect, test, vi, beforeEach } from 'vitest';
 import { studioClient } from '../utils/client';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { writable } from 'svelte/store';
@@ -53,6 +53,10 @@ vi.mock('/@/stores/modelsInfo', async () => {
   return {
     modelsInfo: vi.fn(),
   };
+});
+
+beforeEach(() => {
+  window.HTMLElement.prototype.scrollIntoView = function () {};
 });
 
 test('should display error message if createPlayground fails', async () => {

--- a/packages/frontend/src/pages/PlaygroundCreate.spec.ts
+++ b/packages/frontend/src/pages/PlaygroundCreate.spec.ts
@@ -56,7 +56,7 @@ vi.mock('/@/stores/modelsInfo', async () => {
 });
 
 beforeEach(() => {
-  window.HTMLElement.prototype.scrollIntoView = function () {};
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 test('should display error message if createPlayground fails', async () => {

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -12,11 +12,12 @@ import { tasks } from '../stores/tasks';
 import { filterByLabel } from '../utils/taskUtils';
 import type { Unsubscriber } from 'svelte/store';
 import { Button, ErrorMessage, FormPage, Input } from '@podman-desktop/ui-svelte';
+import ModelSelect from '/@/lib/ModelSelect.svelte';
 
 let localModels: ModelInfo[];
 $: localModels = $modelsInfo.filter(model => model.file);
 $: availModels = $modelsInfo.filter(model => !model.file);
-let modelId: string | undefined = undefined;
+let model: ModelInfo | undefined = undefined;
 let submitted: boolean = false;
 let playgroundName: string;
 let errorMsg: string | undefined = undefined;
@@ -29,8 +30,8 @@ let trackingId: string | undefined = undefined;
 let trackedTasks: Task[] = [];
 
 $: {
-  if (!modelId && localModels.length > 0) {
-    modelId = localModels[0].id;
+  if (!model && localModels.length > 0) {
+    model = localModels[0];
   }
 }
 
@@ -49,7 +50,6 @@ function onNameInput(event: Event) {
 
 async function submit() {
   errorMsg = undefined;
-  const model: ModelInfo | undefined = localModels.find(model => model.id === modelId);
   if (model === undefined) throw new Error('model id not valid.');
   // disable submit button
   submitted = true;
@@ -145,18 +145,9 @@ export function goToUpPage(): void {
             aria-label="playgroundName" />
 
           <!-- model input -->
-          <label for="model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]">Model</label>
-          <select
-            required
-            disabled={submitted}
-            id="providerChoice"
-            bind:value={modelId}
-            class="border rounded-lg w-full focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-charcoal-900 border-charcoal-900 placeholder-gray-700 text-white"
-            name="providerChoice">
-            {#each localModels as model}
-              <option class="my-1" value={model.id}>{model.name}</option>
-            {/each}
-          </select>
+          <label for="model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
+            >Model</label>
+          <ModelSelect models={localModels} disabled={submitted} bind:value={model} />
           {#if localModels.length === 0}
             <div class="text-red-500 p-1 flex flex-row items-center">
               <Fa size="1.1x" class="cursor-pointer text-red-500" icon={faExclamationCircle} />
@@ -192,7 +183,7 @@ export function goToUpPage(): void {
               title="Create playground"
               inProgress={submitted}
               on:click={submit}
-              disabled={!modelId}
+              disabled={!model}
               icon={faPlusCircle}>
               Create playground
             </Button>

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -145,8 +145,7 @@ export function goToUpPage(): void {
             aria-label="playgroundName" />
 
           <!-- model input -->
-          <label for="model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
-            >Model</label>
+          <label for="model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]">Model</label>
           <ModelSelect models={localModels} disabled={submitted} bind:value={model} />
           {#if localModels.length === 0}
             <div class="text-red-500 p-1 flex flex-row items-center">

--- a/packages/frontend/src/pages/StartRecipe.spec.ts
+++ b/packages/frontend/src/pages/StartRecipe.spec.ts
@@ -145,7 +145,7 @@ beforeEach(() => {
   vi.mocked(studioClient.requestPullApplication).mockResolvedValue('fake-tracking-id');
 
   // mock scrollIntoView
-  window.HTMLElement.prototype.scrollIntoView = function () {};
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 test('Recipe name should be visible', async () => {

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -1,19 +1,11 @@
 <script lang="ts">
-import {
-  faCheckCircle,
-  faDownload,
-  faFolder,
-  faRocket,
-  faUpRightFromSquare,
-  faWarning,
-} from '@fortawesome/free-solid-svg-icons';
+import { faFolder, faRocket, faUpRightFromSquare, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { catalog } from '/@/stores/catalog';
 import Fa from 'svelte-fa';
 import type { Recipe } from '@shared/src/models/IRecipe';
 import type { LocalRepository } from '@shared/src/models/ILocalRepository';
 import { findLocalRepositoryByRecipeId } from '/@/utils/localRepositoriesUtils';
 import { localRepositories } from '/@/stores/localRepositories';
-import Select from 'svelte-select';
 import { modelsInfo } from '/@/stores/modelsInfo';
 import { Button, FormPage } from '@podman-desktop/ui-svelte';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -188,7 +188,7 @@ export function goToUpPage(): void {
 
             <!-- model form -->
             <label for="select-model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
-            >Model</label>
+              >Model</label>
             <ModelSelect
               bind:value={value}
               disabled={loading}

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -28,6 +28,7 @@ import { router } from 'tinro';
 import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 import { checkContainerConnectionStatus } from '/@/utils/connectionUtils';
 import ContainerConnectionStatusInfo from '/@/lib/notification/ContainerConnectionStatusInfo.svelte';
+import ModelSelect from '/@/lib/ModelSelect.svelte';
 
 export let recipeId: string;
 
@@ -195,49 +196,12 @@ export function goToUpPage(): void {
 
             <!-- model form -->
             <label for="select-model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
-              >Model</label>
-            <Select
-              inputAttributes={{ 'aria-label': 'Select Model' }}
-              name="select-model"
+            >Model</label>
+            <ModelSelect
+              bind:value={value}
               disabled={loading}
-              value={value}
-              on:change={e => (value = e.detail)}
-              --item-color={'var(--pd-dropdown-item-text)'}
-              --item-is-active-color={'var(--pd-dropdown-item-text)'}
-              --item-hover-color="var(--pd-dropdown-item-hover-text)"
-              --item-active-background="var(--pd-input-field-hover-stroke)"
-              --item-is-active-bg="var(--pd-input-field-hover-stroke)"
-              --background={'var(--pd-dropdown-bg)'}
-              --list-background={'var(--pd-dropdown-bg)'}
-              --item-hover-bg="var(--pd-dropdown-item-hover-bg)"
-              --border="1px solid var(--pd-input-field-focused-bg)"
-              --border-hover="1px solid var(--pd-input-field-hover-stroke)"
-              --list-border="1px solid var(--pd-input-field-focused-bg)"
-              --border-focused="var(--pd-input-field-focused-bg)"
-              --font-size="12px"
-              --clear-icon-width="16px"
-              --chevron-icon-width="16px"
-              placeholder="Select model to use"
-              class="!bg-[var(--pd-content-bg)] !text-[var(--pd-content-card-text)]"
-              items={models.map(model => ({ ...model, value: model.id, label: model.name }))}
-              showChevron>
-              <div slot="item" let:item>
-                <div class="flex items-center">
-                  <div class="grow">
-                    <span>{item.name}</span>
-                    {#if recipe.recommended?.includes(item.id)}
-                      <i class="fas fa-star fa-xs" title="Recommended model"></i>
-                    {/if}
-                  </div>
-
-                  {#if item.file !== undefined}
-                    <Fa icon={faCheckCircle} />
-                  {:else}
-                    <Fa icon={faDownload} />
-                  {/if}
-                </div>
-              </div>
-            </Select>
+              recommended={recipe.recommended}
+              models={models.map(model => ({ ...model, value: model.id, label: model.name }))} />
             {#if value && value.file === undefined}
               <div class="text-gray-800 text-sm flex items-center">
                 <Fa class="mr-2" icon={faWarning} />


### PR DESCRIPTION
### What does this PR do?

We are offering a Select form in `CreateInference`, `CreatePlayground` and `Start Recipe` page, let's create a single component, easier to style for light mode.

> :warning: I did not change the styling made to the component that were used for StartRecipe. 

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/2759ed59-ca02-4ba7-9995-aec80dc2641b)

![image](https://github.com/user-attachments/assets/3c8215a6-6249-4997-abfb-241802efdebf)

![image](https://github.com/user-attachments/assets/8a629852-8751-417a-8a8f-21bd50571e93)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

- [x] unit tests has been provided