### PR TITLE
chore: adopt EmptyScreen component

### DIFF
--- a/packages/frontend/src/pages/Applications.svelte
+++ b/packages/frontend/src/pages/Applications.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
+import { NavPage, EmptyScreen, Button } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
-import { faRocket } from '@fortawesome/free-solid-svg-icons';
+import { faServer } from '@fortawesome/free-solid-svg-icons';
 import TasksBanner from '/@/lib/progress/TasksBanner.svelte';
 import ApplicationTable from '/@/lib/table/application/ApplicationTable.svelte';
 
@@ -21,10 +21,13 @@ const openApplicationCatalog = () => {
       <ApplicationTable>
         <svelte:fragment slot="empty-screen">
           <EmptyScreen
-            icon={faRocket}
+            icon={faServer}
             title="No application running"
-            message="There is no AI App running"
-            onClick={openApplicationCatalog} />
+            message="There is no AI App running. You can go to Recipes page to start an application.">
+            <div class="flex gap-2 justify-center">
+              <Button type="link" on:click={() => openApplicationCatalog()}>Recipes</Button>
+            </div>
+          </EmptyScreen>
         </svelte:fragment>
       </ApplicationTable>
     </div>

--- a/packages/frontend/src/pages/InferenceServers.spec.ts
+++ b/packages/frontend/src/pages/InferenceServers.spec.ts
@@ -54,10 +54,8 @@ beforeEach(() => {
 
 test('no inference servers should display a status message', async () => {
   render(InferenceServers);
-  const status = screen.getByRole('status');
-  expect(status).toBeInTheDocument();
-  expect(status.textContent).toContain('There is no model service. ');
-
+  const title = screen.getByText('No model service running');
+  expect(title).toBeInTheDocument();
   const table = screen.queryByRole('table');
   expect(table).toBeNull();
 });

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -5,12 +5,12 @@ import { inferenceServers } from '/@/stores/inferenceServers';
 import ServiceStatus from '/@/lib/table/service/ServiceStatus.svelte';
 import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 import ServiceColumnModelName from '/@/lib/table/service/ServiceColumnModelName.svelte';
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faRocket, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
 import { onMount } from 'svelte';
 import { Button } from '@podman-desktop/ui-svelte';
-import { Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
+import { Table, TableColumn, TableRow, NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
 
 const columns: TableColumn<InferenceServer>[] = [
   new TableColumn<InferenceServer>('Status', { width: '70px', renderer: ServiceStatus, align: 'center' }),
@@ -58,23 +58,14 @@ function createNewService() {
       {#if data?.length > 0}
         <Table kind="service" data={data} columns={columns} row={row} bind:selectedItemsNumber={selectedItemsNumber} />
       {:else}
-        <div class="text-[var(--pd-details-body-text)]">
-          <div role="status">
-            There is no model service. You can <a
-              href={'javascript:void(0);'}
-              class="underline"
-              role="button"
-              title="Create a new Model Service"
-              on:click={createNewService}>create one now</a
-            >.
+        <EmptyScreen
+          icon={faRocket}
+          title="No model service running"
+          message="A model service offers a configurable endpoint via an OpenAI-compatible web server, facilitating a seamless integration of AI capabilities into existing applications. Upon initialization, effortlessly access detailed service information and generate code snippets in multiple programming languages to ease application integration.">
+          <div class="flex gap-2 justify-center">
+            <Button type="link" on:click={() => createNewService()}>Create service</Button>
           </div>
-          <p>
-            A model service offers a configurable endpoint via an OpenAI-compatible web server, facilitating a seamless
-            integration of AI capabilities into existing applications. Upon initialization, effortlessly access detailed
-            service information and generate code snippets in multiple programming languages to ease application
-            integration.
-          </p>
-        </div>
+        </EmptyScreen>
       {/if}
     </div>
   </svelte:fragment>

--- a/packages/frontend/src/pages/Playgrounds.spec.ts
+++ b/packages/frontend/src/pages/Playgrounds.spec.ts
@@ -83,8 +83,8 @@ test('should display There is no playground yet', async () => {
   mocks.conversationSubscribeMock.mockResolvedValue([]);
   render(Playgrounds);
 
-  const status = screen.getByRole('status');
-  expect(status).toBeDefined();
+  const title = screen.getByText('No Playground Environment');
+  expect(title).toBeDefined();
 });
 
 test('should display one model', async () => {

--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -5,9 +5,10 @@ import PlaygroundColumnName from '../lib/table/playground/PlaygroundColumnName.s
 import ConversationColumnAction from '/@/lib/table/playground/ConversationColumnAction.svelte';
 import { conversations } from '/@/stores/conversations';
 import PlaygroundColumnIcon from '/@/lib/table/playground/PlaygroundColumnIcon.svelte';
-import { Button } from '@podman-desktop/ui-svelte';
+import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
 import { Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
 import type { Conversation } from '@shared/src/models/IPlaygroundMessage';
+import { faMessage } from '@fortawesome/free-solid-svg-icons';
 
 const columns = [
   new TableColumn<{}>('', { width: '40px', renderer: PlaygroundColumnIcon }),
@@ -20,10 +21,6 @@ const row = new TableRow<Conversation>({});
 function createNewPlayground() {
   router.goto('/playground/create');
 }
-
-const openServicesPage = () => {
-  router.goto('/services');
-};
 </script>
 
 <NavPage title="Playground Environments" searchEnabled={false}>
@@ -35,30 +32,14 @@ const openServicesPage = () => {
       {#if $conversations.length > 0}
         <Table kind="playground" data={$conversations} columns={columns} row={row}></Table>
       {:else}
-        <div class="mt-4 px-5 text-[var(--pd-details-body-text)]">
-          <div role="status">
-            There is no playground environment. You can <a
-              href={'javascript:void(0);'}
-              class="underline"
-              role="button"
-              title="Create a new Playground environment"
-              on:click={createNewPlayground}>create one now</a
-            >.
+        <EmptyScreen
+          icon={faMessage}
+          title="No Playground Environment"
+          message="Playground environments allow for experimenting with available models in a local environment. An intuitive user prompt helps in exploring the capabilities and accuracy of various models and aids in finding the best model for the use case at hand.">
+          <div class="flex gap-2 justify-center">
+            <Button type="link" on:click={() => createNewPlayground()}>Create playground</Button>
           </div>
-          <p>
-            Playground environments allow for experimenting with available models in a local environment. An intuitive
-            user prompt helps in exploring the capabilities and accuracy of various models and aids in finding the best
-            model for the use case at hand.
-          </p>
-          <p>
-            Once started, each playground ships with a generic chat client to interact with the model service. The <button
-              class="underline"
-              title="Open the Services page"
-              on:click={openServicesPage}>Services</button>
-            page allows for accessing running model services and provides further details and code snippets to interact with
-            them.
-          </p>
-        </div>
+        </EmptyScreen>
       {/if}
     </div>
   </svelte:fragment>


### PR DESCRIPTION
### What does this PR do?

Improve the consistency of the the `Applications`, `Models` and `Playgrounds` page when none are available.

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/7331ee39-9b26-4238-8eb4-ccd31c04a58d) | ![image](https://github.com/user-attachments/assets/e733d4f4-7a1d-4b41-a8f0-222d852ff2cb) |
| ![image](https://github.com/user-attachments/assets/3e1c0fc8-421e-400c-a6d0-41f95b759fb8) | ![image](https://github.com/user-attachments/assets/4358b712-ea80-4b62-871b-d0ed87f8e4f0) |
| ![image](https://github.com/user-attachments/assets/6deee296-07e5-4295-8bc8-4055bef85bc1) | ![image](https://github.com/user-attachments/assets/2127ea2d-ca37-445a-9d67-0f553355a869) |

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/271

### How to test this PR?

<!-- Please explain steps to reproduce -->