### PR TITLE
Chore/adding plus icon buttons

### DIFF
--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -5,7 +5,7 @@ import { inferenceServers } from '/@/stores/inferenceServers';
 import ServiceStatus from '/@/lib/table/service/ServiceStatus.svelte';
 import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 import ServiceColumnModelName from '/@/lib/table/service/ServiceColumnModelName.svelte';
-import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
 import { onMount } from 'svelte';
@@ -51,7 +51,7 @@ function createNewService() {
       <Button title="Delete selected items" on:click={deleteSelected} icon={faTrash}
         >Delete {selectedItemsNumber} selected items</Button>
     {/if}
-    <Button icon={faPlus} title="Create a new model service" on:click={() => createNewService()}
+    <Button icon={faPlusCircle} title="Create a new model service" on:click={() => createNewService()}
       >New Model Service</Button>
   </svelte:fragment>
   <svelte:fragment slot="content">

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -5,7 +5,7 @@ import { inferenceServers } from '/@/stores/inferenceServers';
 import ServiceStatus from '/@/lib/table/service/ServiceStatus.svelte';
 import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 import ServiceColumnModelName from '/@/lib/table/service/ServiceColumnModelName.svelte';
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
 import { onMount } from 'svelte';
@@ -51,7 +51,8 @@ function createNewService() {
       <Button title="Delete selected items" on:click={deleteSelected} icon={faTrash}
         >Delete {selectedItemsNumber} selected items</Button>
     {/if}
-    <Button title="Create a new model service" on:click={() => createNewService()}>New Model Service</Button>
+    <Button icon={faPlus} title="Create a new model service" on:click={() => createNewService()}
+      >New Model Service</Button>
   </svelte:fragment>
   <svelte:fragment slot="content">
     <div class="flex min-w-full min-h-full">

--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -8,6 +8,7 @@ import PlaygroundColumnIcon from '/@/lib/table/playground/PlaygroundColumnIcon.s
 import { Button } from '@podman-desktop/ui-svelte';
 import { Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
 import type { Conversation } from '@shared/src/models/IPlaygroundMessage';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
 
 const columns = [
   new TableColumn<{}>('', { width: '40px', renderer: PlaygroundColumnIcon }),
@@ -28,7 +29,7 @@ const openServicesPage = () => {
 
 <NavPage title="Playground Environments" searchEnabled={false}>
   <svelte:fragment slot="additional-actions">
-    <Button on:click={() => createNewPlayground()}>New Playground</Button>
+    <Button icon={faPlus} on:click={() => createNewPlayground()}>New Playground</Button>
   </svelte:fragment>
   <svelte:fragment slot="content">
     <div class="flex min-w-full">

--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -8,7 +8,7 @@ import PlaygroundColumnIcon from '/@/lib/table/playground/PlaygroundColumnIcon.s
 import { Button } from '@podman-desktop/ui-svelte';
 import { Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
 import type { Conversation } from '@shared/src/models/IPlaygroundMessage';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 
 const columns = [
   new TableColumn<{}>('', { width: '40px', renderer: PlaygroundColumnIcon }),
@@ -29,7 +29,7 @@ const openServicesPage = () => {
 
 <NavPage title="Playground Environments" searchEnabled={false}>
   <svelte:fragment slot="additional-actions">
-    <Button icon={faPlus} on:click={() => createNewPlayground()}>New Playground</Button>
+    <Button icon={faPlusCircle} on:click={() => createNewPlayground()}>New Playground</Button>
   </svelte:fragment>
   <svelte:fragment slot="content">
     <div class="flex min-w-full">


### PR DESCRIPTION
### What does this PR do?

Adding `(+)` icon to buttons on Playground and Services page, to match design on `Containers` and `Volumes` page

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/95565788-977a-4683-8ddc-1cfdf28c4d76)

![image](https://github.com/user-attachments/assets/d8a59a62-ad63-48f7-b45d-76ffcf260ad9)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->