### PR TITLE
feature: adding stop button playground

### DIFF
--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -27,6 +27,7 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import type { TaskRegistry } from '../registries/TaskRegistry';
 import type { Task, TaskState } from '@shared/src/models/ITask';
 import type { ChatMessage, ErrorMessage } from '@shared/src/models/IPlaygroundMessage';
+import type { CancellationTokenRegistry } from '../registries/CancellationTokenRegistry';
 
 vi.mock('openai', () => ({
   default: vi.fn(),
@@ -54,6 +55,11 @@ const telemetryMock = {
   logError: vi.fn(),
 } as unknown as TelemetryLogger;
 
+const cancellationTokenRegistryMock = {
+  createCancellationTokenSource: vi.fn(),
+  delete: vi.fn(),
+} as unknown as CancellationTokenRegistry;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(webviewMock.postMessage).mockResolvedValue(true);
@@ -65,7 +71,13 @@ afterEach(() => {
 });
 
 test('manager should be properly initialized', () => {
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   expect(manager.getConversations().length).toBe(0);
 });
 
@@ -80,7 +92,13 @@ test('submit should throw an error if the server is stopped', async () => {
       ],
     } as unknown as InferenceServer,
   ]);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground('playground 1', { id: 'model1' } as ModelInfo, 'tracking-1');
 
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
@@ -113,7 +131,13 @@ test('submit should throw an error if the server is unhealthy', async () => {
       ],
     } as unknown as InferenceServer,
   ]);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground('p1', { id: 'model1' } as ModelInfo, 'tracking-1');
   const playgroundId = manager.getConversations()[0].id;
   await expect(manager.submit(playgroundId, 'dummyUserInput')).rejects.toThrowError(
@@ -138,7 +162,13 @@ test('create playground should create conversation.', async () => {
       ],
     } as unknown as InferenceServer,
   ]);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   expect(manager.getConversations().length).toBe(0);
   await manager.createPlayground('playground 1', { id: 'model-1' } as ModelInfo, 'tracking-1');
 
@@ -175,7 +205,13 @@ test('valid submit should create IPlaygroundMessage and notify the webview', asy
     },
   } as unknown as OpenAI);
 
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, 'tracking-1');
 
   const date = new Date(2000, 1, 1, 13);
@@ -216,6 +252,8 @@ test('valid submit should create IPlaygroundMessage and notify the webview', asy
 });
 
 test('submit should send options', async () => {
+  vi.mocked(cancellationTokenRegistryMock.createCancellationTokenSource).mockReturnValue(55);
+
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
     {
       status: 'running',
@@ -244,11 +282,22 @@ test('submit should send options', async () => {
     },
   } as unknown as OpenAI);
 
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, 'tracking-1');
 
   const playgrounds = manager.getConversations();
-  await manager.submit(playgrounds[0].id, 'dummyUserInput', { temperature: 0.123, max_tokens: 45, top_p: 0.345 });
+  const cancellationId = await manager.submit(playgrounds[0].id, 'dummyUserInput', {
+    temperature: 0.123,
+    max_tokens: 45,
+    top_p: 0.345,
+  });
+  expect(cancellationId).toBe(55);
 
   const messages: unknown[] = [
     {
@@ -263,13 +312,22 @@ test('submit should send options', async () => {
       },
     },
   ];
-  expect(createMock).toHaveBeenCalledWith({
-    messages,
-    model: 'dummyModelFile',
-    stream: true,
-    temperature: 0.123,
-    max_tokens: 45,
-    top_p: 0.345,
+  expect(createMock).toHaveBeenCalledWith(
+    {
+      messages,
+      model: 'dummyModelFile',
+      stream: true,
+      temperature: 0.123,
+      max_tokens: 45,
+      top_p: 0.345,
+    },
+    {
+      signal: expect.anything(),
+    },
+  );
+  // at the end the token must be deleted once the request is complete
+  await vi.waitFor(() => {
+    expect(cancellationTokenRegistryMock.delete).toHaveBeenCalledWith(55);
   });
 });
 
@@ -302,7 +360,13 @@ test('error', async () => {
     },
   } as unknown as OpenAI);
 
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, 'tracking-1');
 
   const date = new Date(2000, 1, 1, 13);
@@ -341,7 +405,13 @@ test('error', async () => {
 
 test('creating a new playground should send new playground to frontend', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground(
     'a name',
     {
@@ -365,7 +435,13 @@ test('creating a new playground should send new playground to frontend', async (
 
 test('creating a new playground with no name should send new playground to frontend with generated name', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground(
     '',
     {
@@ -390,7 +466,13 @@ test('creating a new playground with no name should send new playground to front
 test('creating a new playground with no model served should start an inference server', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
   const createInferenceServerMock = vi.mocked(inferenceManagerMock.createInferenceServer);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground(
     'a name',
     {
@@ -427,7 +509,13 @@ test('creating a new playground with the model already served should not start a
     },
   ] as InferenceServer[]);
   const createInferenceServerMock = vi.mocked(inferenceManagerMock.createInferenceServer);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground(
     'a name',
     {
@@ -455,7 +543,13 @@ test('creating a new playground with the model server stopped should start the i
   ] as InferenceServer[]);
   const createInferenceServerMock = vi.mocked(inferenceManagerMock.createInferenceServer);
   const startInferenceServerMock = vi.mocked(inferenceManagerMock.startInferenceServer);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground(
     'a name',
     {
@@ -471,7 +565,13 @@ test('creating a new playground with the model server stopped should start the i
 test('delete conversation should delete the conversation', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
 
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   expect(manager.getConversations().length).toBe(0);
   await manager.createPlayground(
     'a name',
@@ -491,7 +591,13 @@ test('delete conversation should delete the conversation', async () => {
 
 test('creating a new playground with an existing name shoud fail', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   await manager.createPlayground(
     'a name',
     {
@@ -514,7 +620,13 @@ test('creating a new playground with an existing name shoud fail', async () => {
 
 test('requestCreatePlayground should call createPlayground and createTask, then updateTask', async () => {
   vi.useRealTimers();
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   const createTaskMock = vi.mocked(taskRegistryMock).createTask;
   const updateTaskMock = vi.mocked(taskRegistryMock).updateTask;
   createTaskMock.mockImplementation((_name: string, _state: TaskState, labels?: { [id: string]: string }) => {
@@ -542,7 +654,13 @@ test('requestCreatePlayground should call createPlayground and createTask, then 
 
 test('requestCreatePlayground should call createPlayground and createTask, then updateTask when createPlayground fails', async () => {
   vi.useRealTimers();
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+  const manager = new PlaygroundV2Manager(
+    webviewMock,
+    inferenceManagerMock,
+    taskRegistryMock,
+    telemetryMock,
+    cancellationTokenRegistryMock,
+  );
   const createTaskMock = vi.mocked(taskRegistryMock).createTask;
   const updateTaskMock = vi.mocked(taskRegistryMock).updateTask;
   const getTasksByLabelsMock = vi.mocked(taskRegistryMock).getTasksByLabels;
@@ -590,7 +708,13 @@ describe('system prompt', () => {
         ],
       } as unknown as InferenceServer,
     ]);
-    const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+    const manager = new PlaygroundV2Manager(
+      webviewMock,
+      inferenceManagerMock,
+      taskRegistryMock,
+      telemetryMock,
+      cancellationTokenRegistryMock,
+    );
 
     expect(() => {
       manager.setSystemPrompt('invalid', 'content');
@@ -626,7 +750,13 @@ describe('system prompt', () => {
       },
     } as unknown as OpenAI);
 
-    const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock, telemetryMock);
+    const manager = new PlaygroundV2Manager(
+      webviewMock,
+      inferenceManagerMock,
+      taskRegistryMock,
+      telemetryMock,
+      cancellationTokenRegistryMock,
+    );
     await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, 'tracking-1');
 
     const date = new Date(2000, 1, 1, 13);

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -250,11 +250,13 @@ export class PlaygroundV2Manager implements Disposable {
       )
       .then(response => {
         // process stream async
-        this.processStream(conversation.id, response).catch((err: unknown) => {
-          console.error('Something went wrong while processing stream', err);
-        }).finally(() => {
-          this.cancellationTokenRegistry.delete(cancelTokenId);
-        });
+        this.processStream(conversation.id, response)
+          .catch((err: unknown) => {
+            console.error('Something went wrong while processing stream', err);
+          })
+          .finally(() => {
+            this.cancellationTokenRegistry.delete(cancelTokenId);
+          });
       })
       .catch((err: unknown) => {
         telemetry['errorMessage'] = `${String(err)}`;

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -252,6 +252,8 @@ export class PlaygroundV2Manager implements Disposable {
         // process stream async
         this.processStream(conversation.id, response).catch((err: unknown) => {
           console.error('Something went wrong while processing stream', err);
+        }).finally(() => {
+          this.cancellationTokenRegistry.delete(cancelTokenId);
         });
       })
       .catch((err: unknown) => {
@@ -262,7 +264,6 @@ export class PlaygroundV2Manager implements Disposable {
         });
       })
       .finally(() => {
-        this.cancellationTokenRegistry.delete(cancelTokenId);
         this.telemetry.logUsage('playground.submit', telemetry);
       });
     return cancelTokenId;

--- a/packages/backend/src/registries/CancellationTokenRegistry.ts
+++ b/packages/backend/src/registries/CancellationTokenRegistry.ts
@@ -60,6 +60,10 @@ export class CancellationTokenRegistry implements Disposable {
     if (!this.hasCancellationTokenSource(tokenId))
       throw new Error(`Cancellation token with id ${tokenId} does not exist.`);
     this.getCancellationTokenSource(tokenId)?.cancel();
+    this.delete(tokenId);
+  }
+
+  delete(tokenId: number): void {
     this.#callbacksCancellableToken.delete(tokenId);
   }
 

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -92,7 +92,7 @@ export class StudioApiImpl implements StudioAPI {
     }
   }
 
-  submitPlaygroundMessage(containerId: string, userInput: string, options?: ModelOptions): Promise<void> {
+  submitPlaygroundMessage(containerId: string, userInput: string, options?: ModelOptions): Promise<number> {
     return this.playgroundV2.submit(containerId, userInput, options);
   }
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -280,6 +280,7 @@ export class Studio {
       this.#inferenceManager,
       this.#taskRegistry,
       this.#telemetry,
+      this.#cancellationTokenRegistry,
     );
     this.#extensionContext.subscriptions.push(this.#playgroundManager);
 

--- a/packages/frontend/src/pages/Playground.spec.ts
+++ b/packages/frontend/src/pages/Playground.spec.ts
@@ -41,6 +41,7 @@ vi.mock('../utils/client', async () => {
     studioClient: {
       getCatalog: vi.fn(),
       submitPlaygroundMessage: vi.fn(),
+      requestCancelToken: vi.fn(),
     },
     rpcBrowser: {
       subscribe: () => {
@@ -274,7 +275,7 @@ test('sending prompt should disable the send button and the input element', asyn
     recipes: [],
     categories: [],
   });
-  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue();
+  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue(0);
   const customConversations = writable<Conversation[]>([
     {
       id: 'playground-1',
@@ -320,7 +321,7 @@ test('sending prompt not using button should disable the send button and the inp
     recipes: [],
     categories: [],
   });
-  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue();
+  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue(0);
   const customConversations = writable<Conversation[]>([
     {
       id: 'playground-1',
@@ -382,7 +383,7 @@ test('receiving complete message should enable the send button and the input ele
       status: 'running',
     } as unknown as InferenceServer,
   ]);
-  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue();
+  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue(0);
   render(Playground, {
     playgroundId: 'playground-1',
   });
@@ -456,7 +457,7 @@ test('sending prompt should display the prompt and the response', async () => {
       status: 'running',
     } as unknown as InferenceServer,
   ]);
-  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue();
+  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue(0);
   render(Playground, {
     playgroundId: 'playground-1',
   });
@@ -524,5 +525,59 @@ test('sending prompt should display the prompt and the response', async () => {
     const conversation = screen.getByLabelText('conversation');
     within(conversation).getByText('a question for the assistant');
     within(conversation).getByText('a response from the assistant');
+  });
+});
+
+test('user should be able to stop prompt', async () => {
+  vi.mocked(studioClient.getCatalog).mockResolvedValue({
+    models: [
+      {
+        id: 'model-1',
+        name: 'Model 1',
+      },
+    ] as ModelInfo[],
+    recipes: [],
+    categories: [],
+  });
+  vi.mocked(studioClient.submitPlaygroundMessage).mockResolvedValue(55);
+  const customConversations = writable<Conversation[]>([
+    {
+      id: 'playground-1',
+      name: 'Playground 1',
+      modelId: 'model-1',
+      messages: [],
+    },
+  ]);
+  vi.mocked(conversationsStore).conversations = customConversations;
+  vi.mocked(inferenceServersStore).inferenceServers = readable([
+    {
+      models: [{ id: 'model-1' }],
+      status: 'running',
+    } as unknown as InferenceServer,
+  ]);
+  render(Playground, {
+    playgroundId: 'playground-1',
+  });
+
+  let prompt: HTMLElement;
+  await waitFor(() => {
+    prompt = screen.getByLabelText('prompt');
+    expect(prompt).toBeInTheDocument();
+  });
+  fireEvent.change(prompt!, { target: { value: 'prompt' } });
+  fireEvent.keyDown(prompt!, { key: 'Enter' });
+
+  await waitFor(() => {
+    prompt = screen.getByRole('button', { name: 'Send prompt' });
+    expect(prompt).toBeDisabled();
+  });
+
+  const stopBtn = screen.getByTitle('Stop');
+  expect(stopBtn).toBeDefined();
+
+  fireEvent.click(stopBtn);
+
+  await vi.waitFor(() => {
+    expect(studioClient.requestCancelToken).toHaveBeenCalledWith(55);
   });
 });

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -277,14 +277,15 @@ export function goToUpPage(): void {
               <Button
                 title="Stop"
                 icon={faStop}
-                type="danger"
+                type="secondary"
                 on:click={() => cancellationTokenId && studioClient.requestCancelToken(cancellationTokenId)} />
             {:else}
               <Button
                 inProgress={!sendEnabled}
-                disabled={!isHealthy(server?.status, server?.health?.Status)}
+                disabled={!isHealthy(server?.status, server?.health?.Status) || !prompt?.length}
                 on:click={() => askPlayground()}
                 icon={faPaperPlane}
+                type="secondary"
                 title={getSendPromptTitle(sendEnabled, server?.status, server?.health?.Status)}
                 aria-label="Send prompt"></Button>
             {/if}

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -149,7 +149,7 @@ export abstract class StudioAPI {
    * @param userInput the user input, e.g. 'What is the capital of France ?'
    * @param options the options for the model, e.g. temperature
    */
-  abstract submitPlaygroundMessage(containerId: string, userInput: string, options?: ModelOptions): Promise<void>;
+  abstract submitPlaygroundMessage(containerId: string, userInput: string, options?: ModelOptions): Promise<number>;
 
   /**
    * Given a conversation, update the system prompt.


### PR DESCRIPTION
### What does this PR do?

Adding a Stop button to the playground when the LLM is responding. 

### Screenshot / video of UI

https://github.com/user-attachments/assets/f833fe0c-c175-4a7b-9df4-8b45a0022de6

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1089

### How to test this PR?

- [x] unit tests has been provided

**Manually**

- Create playground
- Submit message
- Stop message
- Again