### PR TITLE
fix: table header overflow

### DIFF
--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -13,7 +13,7 @@ const columns = [
   new TableColumn<{}>('', { width: '40px', renderer: PlaygroundColumnIcon }),
   new TableColumn<Conversation>('Name', { width: '1fr', renderer: PlaygroundColumnName }),
   new TableColumn<Conversation>('Model', { width: '1fr', renderer: PlaygroundColumnModel }),
-  new TableColumn<Conversation>('Actions', { width: '40px', renderer: ConversationColumnAction, align: 'center' }),
+  new TableColumn<Conversation>('Actions', { width: '80px', renderer: ConversationColumnAction, align: 'right' }),
 ];
 const row = new TableRow<Conversation>({});
 


### PR DESCRIPTION
### What does this PR do?

Increase slightly the action column of the playground to give enough space to have the full header displayed

### Screenshot / video of UI

**before**

![image](https://github.com/user-attachments/assets/65c789eb-a340-4b37-a65a-1d2428fd2f70)

**after**

![image](https://github.com/user-attachments/assets/9a130d02-80ba-4ee8-b1fd-9c06fd69a77f)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->