### PR TITLE
feat(recipe): adding ai-config versioning

### DIFF
--- a/packages/backend/src/managers/recipes/RecipeManager.spec.ts
+++ b/packages/backend/src/managers/recipes/RecipeManager.spec.ts
@@ -55,6 +55,9 @@ const recipeMock: Recipe = {
 };
 
 vi.mock('../../models/AIConfig', () => ({
+  AIConfigFormat: {
+    CURRENT: 'current',
+  },
   parseYamlFile: vi.fn(),
 }));
 

--- a/packages/backend/src/managers/recipes/RecipeManager.spec.ts
+++ b/packages/backend/src/managers/recipes/RecipeManager.spec.ts
@@ -25,7 +25,7 @@ import { containerEngine } from '@podman-desktop/api';
 import type { Recipe } from '@shared/src/models/IRecipe';
 import type { Stats } from 'node:fs';
 import { existsSync, statSync } from 'node:fs';
-import { parseYamlFile } from '../../models/AIConfig';
+import { AIConfigFormat, parseYamlFile } from '../../models/AIConfig';
 import { goarch } from '../../utils/arch';
 
 const taskRegistryMock = {
@@ -90,6 +90,7 @@ beforeEach(() => {
   } as unknown as Stats);
 
   vi.mocked(parseYamlFile).mockReturnValue({
+    version: AIConfigFormat.CURRENT,
     application: {
       containers: [
         {

--- a/packages/backend/src/models/AIConfig.spec.ts
+++ b/packages/backend/src/models/AIConfig.spec.ts
@@ -18,7 +18,7 @@
 
 import { expect, test, describe, vi } from 'vitest';
 import fs from 'fs';
-import { type AIConfig, parseYamlFile } from './AIConfig';
+import { type AIConfig, AIConfigFormat, parseYamlFile } from './AIConfig';
 
 // Define mock file paths and contents
 const mockYamlPath = '/path/to/mock.yml';
@@ -40,11 +40,22 @@ wrong:
 `);
     expect(() => {
       parseYamlFile(mockYamlPath, defaultArch);
-    }).toThrowError('AIConfig has bad formatting: missing application property');
+    }).toThrowError('malformed configuration file: missing version');
+  });
+
+  test('version mismatch', () => {
+    readFileSync.mockReturnValue(`
+version: unknown
+application: true
+`);
+    expect(() => {
+      parseYamlFile(mockYamlPath, defaultArch);
+    }).toThrowError('malformed configuration file: version not supported, got unknown expected v1.0.');
   });
 
   test('application primitive', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application: true
 `);
     expect(() => {
@@ -54,6 +65,7 @@ application: true
 
   test('containers not an array', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application:
   containers:
     name: container1
@@ -70,6 +82,7 @@ application:
 
   test('containers object', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application:
   containers: true
 `);
@@ -80,6 +93,7 @@ application:
 
   test('should use architecture as string', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application:
   containers:
     - name: container1
@@ -89,6 +103,7 @@ application:
 `);
 
     const expectedConfig: AIConfig = {
+      version: AIConfigFormat.CURRENT,
       application: {
         containers: [
           {
@@ -108,6 +123,7 @@ application:
 
   test('should use all architectures', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application:
   containers:
     - name: container1
@@ -117,6 +133,7 @@ application:
 `);
 
     const expectedConfig: AIConfig = {
+      version: AIConfigFormat.CURRENT,
       application: {
         containers: [
           {
@@ -136,6 +153,7 @@ application:
 
   test('should put the default architecture', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application:
   containers:
     - name: container1
@@ -144,6 +162,7 @@ application:
 `);
 
     const expectedConfig: AIConfig = {
+      version: AIConfigFormat.CURRENT,
       application: {
         containers: [
           {
@@ -163,6 +182,7 @@ application:
 
   test('should use the image provided in the config', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application:
   containers:
     - name: container1
@@ -172,6 +192,7 @@ application:
 `);
 
     const expectedConfig: AIConfig = {
+      version: AIConfigFormat.CURRENT,
       application: {
         containers: [
           {
@@ -192,6 +213,7 @@ application:
 
   test('ports should always be a final number', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application:
   containers:
     - name: container1
@@ -201,6 +223,7 @@ application:
 `);
 
     const expectedConfig: AIConfig = {
+      version: AIConfigFormat.CURRENT,
       application: {
         containers: [
           {
@@ -221,6 +244,7 @@ application:
 
   test('should use gpu env', () => {
     readFileSync.mockReturnValue(`
+version: ${AIConfigFormat.CURRENT}
 application:
   containers:
     - name: container1
@@ -235,6 +259,7 @@ application:
 `);
 
     const expectedConfig: AIConfig = {
+      version: AIConfigFormat.CURRENT,
       application: {
         containers: [
           {


### PR DESCRIPTION
### What does this PR do?

Similar to what has been done for the catalog (https://github.com/containers/podman-desktop-extension-ai-lab/pull/1381). This PR is adding a version check for the `ai-config.yaml`.

As mention in the linked issue, all recipes in the https://github.com/containers/ai-lab-recipes repository are already using the version field with the value `v1.0` so we will be using this too.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1431

### How to test this PR?

- [x] unit tests has been added

**manually**

Start any recipes