### PR TITLE
feat: add visual indication for gpu accelerated inference servers

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -34,7 +34,7 @@ import { Messages } from '@shared/Messages';
 import type { InferenceProviderRegistry } from '../../registries/InferenceProviderRegistry';
 import type { InferenceProvider } from '../../workers/provider/InferenceProvider';
 import type { CatalogManager } from '../catalogManager';
-import type { InferenceServer} from '@shared/src/models/IInference';
+import type { InferenceServer } from '@shared/src/models/IInference';
 import { InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('@podman-desktop/api', async () => {

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -17,14 +17,14 @@
  ***********************************************************************/
 import {
   containerEngine,
-  type Webview,
-  type TelemetryLogger,
   type ContainerInfo,
   type ContainerInspectInfo,
+  type TelemetryLogger,
+  type Webview,
 } from '@podman-desktop/api';
 import type { ContainerRegistry } from '../../registries/ContainerRegistry';
 import type { PodmanConnection } from '../podmanConnection';
-import { beforeEach, expect, describe, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { InferenceManager } from './inferenceManager';
 import type { ModelsManager } from '../modelsManager';
 import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
@@ -34,6 +34,8 @@ import { Messages } from '@shared/Messages';
 import type { InferenceProviderRegistry } from '../../registries/InferenceProviderRegistry';
 import type { InferenceProvider } from '../../workers/provider/InferenceProvider';
 import type { CatalogManager } from '../catalogManager';
+import type { InferenceServer} from '@shared/src/models/IInference';
+import { InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
@@ -195,6 +197,9 @@ describe('init Inference Manager', () => {
         models: [],
         status: 'running',
         type: expect.anything(),
+        labels: {
+          [LABEL_INFERENCE_SERVER]: '[]',
+        },
       },
     ]);
   });
@@ -269,7 +274,17 @@ describe('Create Inference Server', () => {
       enabled: () => true,
       name: 'dummy-inference-provider',
       dispose: () => {},
-      perform: vi.fn().mockResolvedValue({ id: 'dummy-container-id', engineId: 'dummy-engine-id' }),
+      perform: vi.fn<() => InferenceServer>().mockResolvedValue({
+        container: {
+          containerId: 'dummy-container-id',
+          engineId: 'dummy-engine-id',
+        },
+        models: [],
+        status: 'running',
+        type: InferenceType.LLAMA_CPP,
+        connection: { port: 0 },
+        labels: {},
+      }),
     } as unknown as InferenceProvider;
     vi.mocked(inferenceProviderRegistryMock.get).mockReturnValue(provider);
 
@@ -570,6 +585,7 @@ describe('transition statuses', () => {
           health: undefined,
           status: 'stopping',
           type: expect.anything(),
+          labels: expect.anything(),
         },
       ],
     });
@@ -585,6 +601,7 @@ describe('transition statuses', () => {
           health: undefined,
           status: 'stopped',
           type: expect.anything(),
+          labels: expect.anything(),
         },
       ],
     });
@@ -620,6 +637,7 @@ describe('transition statuses', () => {
           health: undefined,
           status: 'deleting',
           type: expect.anything(),
+          labels: expect.anything(),
         },
       ],
     });
@@ -656,6 +674,7 @@ describe('transition statuses', () => {
           health: undefined,
           status: 'starting',
           type: expect.anything(),
+          labels: expect.anything(),
         },
       ],
     });
@@ -671,6 +690,7 @@ describe('transition statuses', () => {
           health: undefined,
           status: 'running',
           type: expect.anything(),
+          labels: expect.anything(),
         },
       ],
     });

--- a/packages/backend/src/workers/provider/InferenceProvider.spec.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.spec.ts
@@ -29,6 +29,7 @@ import type {
 import { containerEngine } from '@podman-desktop/api';
 import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
 import type { TaskState } from '@shared/src/models/ITask';
+import type { InferenceServer } from '@shared/src/models/IInference';
 import { InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('../../utils/inferenceUtils', () => ({
@@ -86,7 +87,7 @@ class TestInferenceProvider extends InferenceProvider {
     };
   }
 
-  async perform(_config: InferenceServerConfig): Promise<BetterContainerCreateResult> {
+  async perform(_config: InferenceServerConfig): Promise<InferenceServer> {
     throw new Error('not implemented');
   }
   dispose(): void {}

--- a/packages/backend/src/workers/provider/InferenceProvider.ts
+++ b/packages/backend/src/workers/provider/InferenceProvider.ts
@@ -27,13 +27,11 @@ import type { InferenceServerConfig } from '@shared/src/models/InferenceServerCo
 import type { IWorker } from '../IWorker';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
-import type { InferenceType } from '@shared/src/models/IInference';
+import type { InferenceServer, InferenceType } from '@shared/src/models/IInference';
 
 export type BetterContainerCreateResult = ContainerCreateResult & { engineId: string };
 
-export abstract class InferenceProvider
-  implements IWorker<InferenceServerConfig, BetterContainerCreateResult>, Disposable
-{
+export abstract class InferenceProvider implements IWorker<InferenceServerConfig, InferenceServer>, Disposable {
   readonly type: InferenceType;
   readonly name: string;
 
@@ -47,7 +45,7 @@ export abstract class InferenceProvider
   }
 
   abstract enabled(): boolean;
-  abstract perform(config: InferenceServerConfig): Promise<BetterContainerCreateResult>;
+  abstract perform(config: InferenceServerConfig): Promise<InferenceServer>;
   abstract dispose(): void;
 
   protected async createContainer(

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -28,7 +28,7 @@ import type { PodmanConnection } from '../../managers/podmanConnection';
 import { VMType } from '@shared/src/models/IPodman';
 import type { ConfigurationRegistry } from '../../registries/ConfigurationRegistry';
 import { GPUVendor } from '@shared/src/models/IGPUInfo';
-import type { InferenceServer} from '@shared/src/models/IInference';
+import type { InferenceServer } from '@shared/src/models/IInference';
 import { InferenceType } from '@shared/src/models/IInference';
 
 vi.mock('@podman-desktop/api', () => ({

--- a/packages/frontend/src/lib/table/model/ModelColumnAction.spec.ts
+++ b/packages/frontend/src/lib/table/model/ModelColumnAction.spec.ts
@@ -200,6 +200,7 @@ test('Expect delete button to be disabled when model in use', async () => {
         port: 0,
       },
       health: undefined,
+      labels: {},
     },
   ]);
   render(ModelColumnActions, { object });

--- a/packages/frontend/src/lib/table/model/ModelColumnIcon.spec.ts
+++ b/packages/frontend/src/lib/table/model/ModelColumnIcon.spec.ts
@@ -118,6 +118,7 @@ test('Expect in used model to have USED title', async () => {
         port: 0,
       },
       health: undefined,
+      labels: {},
     },
   ]);
   render(ModelColumnIcon, { object });

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -3,7 +3,14 @@ import { inferenceServers } from '/@/stores/inferenceServers';
 import ServiceStatus from '/@/lib/table/service/ServiceStatus.svelte';
 import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 import Fa from 'svelte-fa';
-import { faBuildingColumns, faCheck, faCopy, faScaleBalanced } from '@fortawesome/free-solid-svg-icons';
+import {
+  faBuildingColumns,
+  faCheck,
+  faCopy,
+  faFan,
+  faMicrochip,
+  faScaleBalanced,
+} from '@fortawesome/free-solid-svg-icons';
 import type { InferenceServer } from '@shared/src/models/IInference';
 import { snippetLanguages } from '/@/stores/snippetLanguages';
 import type { LanguageVariant } from 'postman-code-generators';
@@ -11,6 +18,7 @@ import { studioClient } from '/@/utils/client';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 import { Button, DetailsPage } from '@podman-desktop/ui-svelte';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 
 export let containerId: string | undefined = undefined;
 
@@ -192,6 +200,21 @@ export function goToUpPage(): void {
                     class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center">
                     http://localhost:{service.connection.port}/v1
                   </div>
+                  {#if 'gpu' in service.labels}
+                    <Tooltip tip={service.labels['gpu']}>
+                      <div
+                        class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center">
+                        GPU Inference
+                        <Fa spin={service.status === 'running'} class="ml-2" icon={faFan} />
+                      </div>
+                    </Tooltip>
+                  {:else}
+                    <div
+                      class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center">
+                      CPU Inference
+                      <Fa class="ml-2" icon={faMicrochip} />
+                    </div>
+                  {/if}
                 </div>
               </div>
 

--- a/packages/frontend/src/pages/InferenceServers.spec.ts
+++ b/packages/frontend/src/pages/InferenceServers.spec.ts
@@ -69,6 +69,7 @@ test('store with inference server should display the table', async () => {
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
       type: InferenceType.NONE,
+      labels: {},
     },
   ] as InferenceServer[]);
   render(InferenceServers);
@@ -98,6 +99,7 @@ test('table should have checkbox', async () => {
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
       type: InferenceType.NONE,
+      labels: {},
     },
   ] as InferenceServer[]);
   render(InferenceServers);
@@ -118,6 +120,7 @@ test('delete button should delete selected item', async () => {
       status: 'running',
       container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
       type: InferenceType.NONE,
+      labels: {},
     },
   ] as InferenceServer[]);
   render(InferenceServers);

--- a/packages/shared/src/models/IInference.ts
+++ b/packages/shared/src/models/IInference.ts
@@ -65,4 +65,8 @@ export interface InferenceServer {
    * The type of inference server (aka backend)
    */
   type: InferenceType;
+  /**
+   * Inference labels
+   */
+  labels: Record<string, string>;
 }


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/containers/podman-desktop-extension-ai-lab/pull/1433, this PR replace the removed `hardware` indication on the `Inference Server Details` page.

### Notable change

- Adding a `labels: Record<string, string>` property to InferenceServer
- Using the gpu label to change the hardware display

### Screenshot / video of UI

**gpu inference server**

https://github.com/user-attachments/assets/685ae3c6-cd08-4214-ad7a-4ce71d248e8b

**cpu inference server**
![image](https://github.com/user-attachments/assets/3baca1a3-8518-4c14-9f5b-a143e1d60ad1)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1434

### How to test this PR?

- [x] unit tests has been added

**manually**

- Using libkrun or WSL Nvidia
- Turn on experimental GPU support in Podman-Desktop preference
- Create an inference server
- See the `GPU Inference` on the Inference Server Details page

> I do not have a libkrun machine, please @jeffmaury could you try it out ?