### PR TITLE
feat: models table should sort on status by default

### DIFF
--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -155,6 +155,45 @@ test('should display one model', async () => {
   expect(name).not.toBeNull();
 });
 
+test('should display downloaded model first', async () => {
+  mocks.modelsInfoSubscribeMock.mockReturnValue([
+    {
+      id: 'dummy-local-id',
+      name: 'dummy-local-name',
+      memory: 1024,
+      file: {
+        path: 'random',
+      },
+    },
+    {
+      id: 'dummy-id',
+      name: 'dummy-name',
+      memory: 1024,
+    },
+  ]);
+  mocks.tasksSubscribeMock.mockReturnValue([]);
+
+  const { container } = render(Models);
+
+  const table = within(container).getByRole('table');
+  expect(table).toBeDefined();
+
+  const rows = within(table).queryAllByRole('row');
+  expect(rows.length).toBe(3);
+
+  // First row should be the headers
+  const headers = within(rows[0]).queryAllByRole('columnheader');
+  expect(headers.length > 0).toBeTruthy();
+
+  // second raw should be the model downloaded
+  const deleteBtn = within(rows[1]).getByTitle('Delete Model');
+  expect(deleteBtn).toBeDefined();
+
+  // last raw should be the remote model
+  const downloadBtn = within(rows[2]).getByTitle('Download Model');
+  expect(downloadBtn).toBeDefined();
+});
+
 describe('downloaded models', () => {
   test('should display no model in downloaded tab', async () => {
     mocks.modelsInfoSubscribeMock.mockReturnValue([

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -20,7 +20,11 @@ import { faBookOpen, faFileImport } from '@fortawesome/free-solid-svg-icons';
 import { Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
 
 const columns: TableColumn<ModelInfo>[] = [
-  new TableColumn<ModelInfo>('', { width: '40px', renderer: ModelColumnIcon }),
+  new TableColumn<ModelInfo>('Status', {
+    width: '60px',
+    renderer: ModelColumnIcon,
+    comparator: (a, b) => (a.file ? 0 : 1) - (b.file ? 0 : 1),
+  }),
   new TableColumn<ModelInfo>('Name', {
     width: '3fr',
     renderer: ModelColumnName,
@@ -131,7 +135,7 @@ async function importModel() {
           <!-- All models -->
           <Route path="/">
             {#if filteredModels.length > 0}
-              <Table kind="model" data={filteredModels} columns={columns} row={row}></Table>
+              <Table defaultSortColumn="Status" kind="model" data={filteredModels} columns={columns} row={row}></Table>
             {:else}
               <EmptyScreen aria-label="status" icon={faBookOpen} title="No models" message="No models available" />
             {/if}


### PR DESCRIPTION
### What does this PR do?

We display the models randomly on the `Models` page, however when using a lot AI Lab I usually have to scroll down to find the models which are available locally.

This PR adds the default sort on models status column to always display the locally available on top by default.

### Screenshot / video of UI

**before**

![image](https://github.com/user-attachments/assets/5670ae1a-7044-454f-9dfd-5723b1ce9339)

**after**

![image](https://github.com/user-attachments/assets/4f3a44e5-8240-45a4-8d4b-401fc245107e)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] unit test has been added