### PR TITLE
hotfix: remove MODEL prefix

### DIFF
--- a/packages/backend/src/utils/modelsUtils.ts
+++ b/packages/backend/src/utils/modelsUtils.ts
@@ -78,7 +78,7 @@ export function getModelPropertiesForEnvironment(modelInfo: ModelInfo): string[]
     envs.push(
       ...Object.entries(modelInfo.properties).map(([key, value]) => {
         const formattedKey = key.replace(/[A-Z]/g, m => `_${m}`).toUpperCase();
-        return `MODEL_${formattedKey}=${value}`;
+        return `${formattedKey}=${value}`;
       }),
     );
   }

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -228,10 +228,10 @@ describe('perform', () => {
 
     expect(containerEngine.createContainer).toHaveBeenCalledWith(DummyImageInfo.engineId, {
       Env: expect.arrayContaining([
-        'MODEL_BASIC_PROP=basicProp',
-        'MODEL_LOT_OF_CAMEL_CASES=lotOfCamelCases',
-        'MODEL_LOWERCASE=lowercase',
-        'MODEL_CHAT_FORMAT=dummyChatFormat',
+        'BASIC_PROP=basicProp',
+        'LOT_OF_CAMEL_CASES=lotOfCamelCases',
+        'LOWERCASE=lowercase',
+        'CHAT_FORMAT=dummyChatFormat',
       ]),
       Cmd: expect.anything(),
       HealthCheck: expect.anything(),


### PR DESCRIPTION
### What does this PR do?

The image we are using do not have the `MODEL_` prefix we place on every environment.

See https://github.com/containers/ai-lab-recipes/blob/f9ed8bbcbd518562518fae63fbd1234464f554f4/model_servers/llamacpp_python/src/run.sh#L18

Therefore we have are not able to provide the right `chatFormat`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->