### PR TITLE
fix: remove cgroup when adding device

### DIFF
--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -129,7 +129,7 @@ export class LlamaCppPython extends InferenceProvider {
           devices.push({
             PathOnHost: '/dev/dri',
             PathInContainer: '/dev/dri',
-            CgroupPermissions: 'r',
+            CgroupPermissions: '',
           });
           break;
       }


### PR DESCRIPTION
### What does this PR do?

It looks like that if we set the cgroup to read, the container is limited on how to discover the gpu and it only has visibility on the llvmpipe which is slower than a turtle. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it fixes #1479 

### How to test this PR?

1. run an inference server with gpu enabled on a mac MX