### PR TITLE
fix(UI): spinner color in light theme

### DIFF
--- a/packages/frontend/src/lib/RecipeStatus.svelte
+++ b/packages/frontend/src/lib/RecipeStatus.svelte
@@ -39,7 +39,7 @@ function onClick(): void {
         disabled={loading}
         class="border-2 justify-center relative rounded border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-text)] w-10 p-2 text-center cursor-pointer flex flex-row">
         {#if loading}
-          <Spinner size="1em" />
+          <Spinner class="text-[var(--pd-table-body-text-highlight)]" size="1em" />
         {:else}
           <div aria-label="download icon">
             <Fa size="sm" icon={faDownload} />

--- a/packages/frontend/src/lib/table/application/ColumnStatus.svelte
+++ b/packages/frontend/src/lib/table/application/ColumnStatus.svelte
@@ -5,11 +5,12 @@ import PodIcon from '../../images/PodIcon.svelte';
 import { Spinner, StatusIcon } from '@podman-desktop/ui-svelte';
 export let object: ApplicationState;
 
+let status: string;
 $: status = getApplicationStatus(object);
 </script>
 
 {#if status === 'STARTING'}
-  <Spinner />
+  <Spinner class="text-[var(--pd-table-body-text-highlight)]" />
 {:else}
   <StatusIcon size={22} status={status} icon={PodIcon} />
 {/if}

--- a/packages/frontend/src/lib/table/service/ServiceStatus.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceStatus.svelte
@@ -47,7 +47,7 @@ function getStatus(): 'RUNNING' | 'STARTING' | 'DEGRADED' | '' {
 </script>
 
 {#if loading}
-  <Spinner />
+  <Spinner class="text-[var(--pd-table-body-text-highlight)]" />
 {:else}
   <button on:click={navigateToContainer}>
     <StatusIcon status={status} icon={ContainerIcon} />


### PR DESCRIPTION
### What does this PR do?

Provide the color of the table to the spinner props

### Screenshot / video of UI

| dark | light |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/086d4672-8830-4046-9370-3297717d1fda) | ![image](https://github.com/user-attachments/assets/1c866dc1-7d18-4ede-b1c6-b1dbe591b263) |
| ![image](https://github.com/user-attachments/assets/dc5f1123-edf3-482b-9c4b-0458452066bf) | ![image](https://github.com/user-attachments/assets/815e261a-ed2c-407c-97d7-ad4e03428483) | 

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1480

### How to test this PR?

<!-- Please explain steps to reproduce -->