### PR TITLE
use inference server when model service image is equivalent to inference server image

### DIFF
--- a/packages/backend/src/managers/application/applicationManager.spec.ts
+++ b/packages/backend/src/managers/application/applicationManager.spec.ts
@@ -126,7 +126,7 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(webviewMock.postMessage).mockResolvedValue(true);
-  vi.mocked(recipeManager.buildRecipe).mockResolvedValue([recipeImageInfoMock]);
+  vi.mocked(recipeManager.buildRecipe).mockResolvedValue({ images: [recipeImageInfoMock] });
   vi.mocked(podManager.createPod).mockResolvedValue({ engineId: 'test-engine-id', Id: 'test-pod-id' });
   vi.mocked(podManager.getPod).mockResolvedValue({ engineId: 'test-engine-id', Id: 'test-pod-id' } as PodInfo);
   vi.mocked(podManager.getPodsWithLabels).mockResolvedValue([]);
@@ -312,7 +312,7 @@ describe('pullApplication', () => {
       'model-id': remoteModelMock.id,
     });
     // build the recipe
-    expect(recipeManager.buildRecipe).toHaveBeenCalledWith(connectionMock, recipeMock, {
+    expect(recipeManager.buildRecipe).toHaveBeenCalledWith(connectionMock, recipeMock, remoteModelMock, {
       'test-label': 'test-value',
       'recipe-id': recipeMock.id,
       'model-id': remoteModelMock.id,
@@ -374,18 +374,20 @@ describe('pullApplication', () => {
   test('qemu connection should have specific flag', async () => {
     vi.mocked(podManager.findPodByLabelsValues).mockResolvedValue(undefined);
 
-    vi.mocked(recipeManager.buildRecipe).mockResolvedValue([
-      recipeImageInfoMock,
-      {
-        modelService: true,
-        ports: ['8888'],
-        name: 'llamacpp',
-        id: 'llamacpp',
-        appName: 'llamacpp',
-        engineId: recipeImageInfoMock.engineId,
-        recipeId: recipeMock.id,
-      },
-    ]);
+    vi.mocked(recipeManager.buildRecipe).mockResolvedValue({
+      images: [
+        recipeImageInfoMock,
+        {
+          modelService: true,
+          ports: ['8888'],
+          name: 'llamacpp',
+          id: 'llamacpp',
+          appName: 'llamacpp',
+          engineId: recipeImageInfoMock.engineId,
+          recipeId: recipeMock.id,
+        },
+      ],
+    });
 
     await getInitializedApplicationManager().pullApplication(connectionMock, recipeMock, remoteModelMock);
 

--- a/packages/backend/src/managers/application/applicationManager.ts
+++ b/packages/backend/src/managers/application/applicationManager.ts
@@ -331,7 +331,6 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
               envs = [`MODEL_ENDPOINT=${endPoint}`];
             }
           }
-          
         }
         if (image.ports.length > 0) {
           healthcheck = {

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -109,8 +109,8 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     // check if model backend is supported
     const backend: InferenceType = getInferenceType([model]);
     const providers: InferenceProvider[] = this.inferenceProviderRegistry
-        .getByType(backend)
-        .filter(provider => provider.enabled());
+      .getByType(backend)
+      .filter(provider => provider.enabled());
     if (providers.length === 0) {
       throw new Error('no enabled provider could be found.');
     }

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -105,7 +105,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
    * return the first inference server which is using the specific model
    * it throws if the model backend is not currently supported
    */
-  public getServerByModel(model: ModelInfo): InferenceServer | undefined {
+  public findServerByModel(model: ModelInfo): InferenceServer | undefined {
     // check if model backend is supported
     const backend: InferenceType = getInferenceType([model]);
     const providers: InferenceProvider[] = this.inferenceProviderRegistry

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -102,6 +102,22 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
   }
 
   /**
+   * return the first inference server which is using the specific model
+   * it throws if the model backend is not currently supported
+   */
+  public getServerByModel(model: ModelInfo): InferenceServer | undefined {
+    // check if model backend is supported
+    const backend: InferenceType = getInferenceType([model]);
+    const providers: InferenceProvider[] = this.inferenceProviderRegistry
+        .getByType(backend)
+        .filter(provider => provider.enabled());
+    if (providers.length === 0) {
+      throw new Error('no enabled provider could be found.');
+    }
+    return this.getServers().find(s => s.models.some(m => m.id === model.id));
+  }
+
+  /**
    * Creating an inference server can be heavy task (pulling image, uploading model to WSL etc.)
    * The frontend cannot wait endlessly, therefore we provide a method returning a tracking identifier
    * that can be used to fetch the tasks

--- a/packages/backend/src/managers/recipes/RecipeManager.spec.ts
+++ b/packages/backend/src/managers/recipes/RecipeManager.spec.ts
@@ -28,6 +28,8 @@ import { existsSync, statSync } from 'node:fs';
 import { AIConfigFormat, parseYamlFile } from '../../models/AIConfig';
 import { goarch } from '../../utils/arch';
 import { VMType } from '@shared/src/models/IPodman';
+import type { InferenceManager } from '../inference/inferenceManager';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 const taskRegistryMock = {
   createTask: vi.fn(),
@@ -46,6 +48,8 @@ const localRepositoriesMock = {
   register: vi.fn(),
 } as unknown as LocalRepositoryRegistry;
 
+const inferenceManagerMock = {} as unknown as InferenceManager;
+
 const recipeMock: Recipe = {
   id: 'recipe-test',
   name: 'Test Recipe',
@@ -59,6 +63,12 @@ const connectionMock: ContainerProviderConnection = {
   name: 'Podman Machine',
   vmType: VMType.UNKNOWN,
 } as unknown as ContainerProviderConnection;
+
+const modelInfoMock: ModelInfo = {
+  id: 'modelId',
+  name: 'Model',
+  description: 'model to test',
+} as unknown as ModelInfo;
 
 vi.mock('../../models/AIConfig', () => ({
   AIConfigFormat: {
@@ -123,6 +133,7 @@ async function getInitializedRecipeManager(): Promise<RecipeManager> {
     taskRegistryMock,
     builderManagerMock,
     localRepositoriesMock,
+    inferenceManagerMock,
   );
   manager.init();
   return manager;
@@ -180,14 +191,14 @@ describe('buildRecipe', () => {
     const manager = await getInitializedRecipeManager();
 
     await expect(() => {
-      return manager.buildRecipe(connectionMock, recipeMock);
+      return manager.buildRecipe(connectionMock, recipeMock, modelInfoMock);
     }).rejects.toThrowError('build error');
   });
 
   test('labels should be propagated', async () => {
     const manager = await getInitializedRecipeManager();
 
-    await manager.buildRecipe(connectionMock, recipeMock, {
+    await manager.buildRecipe(connectionMock, recipeMock, modelInfoMock, {
       'test-label': 'test-value',
     });
 

--- a/packages/backend/src/managers/recipes/RecipeManager.ts
+++ b/packages/backend/src/managers/recipes/RecipeManager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import type { GitCloneInfo, GitManager } from '../gitManager';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
-import type { Recipe, RecipeComponents, RecipeImage } from '@shared/src/models/IRecipe';
+import type { Recipe, RecipeComponents } from '@shared/src/models/IRecipe';
 import path from 'node:path';
 import type { Task } from '@shared/src/models/ITask';
 import type { LocalRepositoryRegistry } from '../../registries/LocalRepositoryRegistry';
@@ -28,10 +28,10 @@ import { goarch } from '../../utils/arch';
 import type { BuilderManager } from './BuilderManager';
 import type { ContainerProviderConnection, Disposable } from '@podman-desktop/api';
 import { CONFIG_FILENAME } from '../../utils/RecipeConstants';
-import { InferenceManager } from '../inference/inferenceManager';
-import { ModelInfo } from '@shared/src/models/IModelInfo';
+import type { InferenceManager } from '../inference/inferenceManager';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { withDefaultConfiguration } from '../../utils/inferenceUtils';
-import { InferenceServer } from '@shared/src/models/IInference';
+import type { InferenceServer } from '@shared/src/models/IInference';
 
 export interface AIContainers {
   aiConfigFile: AIConfigFile;
@@ -96,33 +96,64 @@ export class RecipeManager implements Disposable {
     });
   }
 
-  public async buildRecipe(connection: ContainerProviderConnection, recipe: Recipe, model: ModelInfo, labels?: { [key: string]: string }): Promise<RecipeComponents> {
+  public async buildRecipe(
+    connection: ContainerProviderConnection,
+    recipe: Recipe,
+    model: ModelInfo,
+    labels?: { [key: string]: string },
+  ): Promise<RecipeComponents> {
     const localFolder = path.join(this.appUserDirectory, recipe.id);
 
     let inferenceServer: InferenceServer | undefined;
-    if (this.canUseInferenceServer(recipe.basedir, localFolder)) {
+    // if the recipe has a defined backend, we gives priority to using an inference server
+    if (recipe.backend && recipe.backend === model.backend) {
+      let task: Task | undefined;
       try {
         inferenceServer = this.inferenceManager.getServerByModel(model);
+        task = this.taskRegistry.createTask('Starting Inference server', 'loading', labels);
         if (!inferenceServer) {
           const inferenceContainerId = await this.inferenceManager.createInferenceServer(
             await withDefaultConfiguration({
               modelsInfo: [model],
             }),
           );
-          inferenceServer = this.inferenceManager.get(inferenceContainerId)
+          inferenceServer = this.inferenceManager.get(inferenceContainerId);
+          this.taskRegistry.updateTask({
+            ...task,
+            labels: {
+              ...task.labels,
+              containerId: inferenceContainerId,
+            },
+          });
         } else if (inferenceServer.status === 'stopped') {
           await this.inferenceManager.startInferenceServer(inferenceServer.container.containerId);
         }
+        task.state = 'success';
       } catch (e) {
-        // we do not support this backend for inference servers
+        // we only skip the task update if the error is that we do not support this backend.
+        // If so, we build the image for the model service
+        if (task && String(e) !== 'no enabled provider could be found.') {
+          task.state = 'error';
+          task.error = `Something went wrong while starting the inference server: ${String(e)}`;
+          throw e;
+        }
+      } finally {
+        if (task) {
+          this.taskRegistry.updateTask(task);
+        }
       }
     }
-        
+
     // load and parse the recipe configuration file and filter containers based on architecture
-    const configAndFilteredContainers = this.getConfigAndFilterContainers(recipe.basedir, localFolder, {
-      ...labels,
-      'recipe-id': recipe.id,
-    });
+    const configAndFilteredContainers = this.getConfigAndFilterContainers(
+      recipe.basedir,
+      localFolder,
+      !!inferenceServer,
+      {
+        ...labels,
+        'recipe-id': recipe.id,
+      },
+    );
 
     const images = await this.builderManager.build(
       connection,
@@ -144,6 +175,7 @@ export class RecipeManager implements Disposable {
   private getConfigAndFilterContainers(
     recipeBaseDir: string | undefined,
     localFolder: string,
+    useInferenceServer: boolean,
     labels?: { [key: string]: string },
   ): AIContainers {
     // Adding loading configuration task
@@ -160,7 +192,11 @@ export class RecipeManager implements Disposable {
     }
 
     // filter the containers based on architecture, gpu accelerator and backend (that define which model supports)
-    const filteredContainers: ContainerConfig[] = this.filterContainers(aiConfigFile.aiConfig);
+    let filteredContainers: ContainerConfig[] = this.filterContainers(aiConfigFile.aiConfig);
+    // if we are using the inference server we can remove the model service
+    if (useInferenceServer) {
+      filteredContainers = filteredContainers.filter(c => !c.modelService);
+    }
     if (filteredContainers.length > 0) {
       // Mark as success.
       task.state = 'success';
@@ -180,25 +216,8 @@ export class RecipeManager implements Disposable {
 
   private filterContainers(aiConfig: AIConfig): ContainerConfig[] {
     return aiConfig.application.containers.filter(
-      container => container.gpu_env.length === 0 && container.arch.some(arc => arc === goarch() && !this.isInferenceServer(container)),
+      container => container.gpu_env.length === 0 && container.arch.some(arc => arc === goarch()),
     );
-  }
-
-  private canUseInferenceServer(
-    recipeBaseDir: string | undefined,
-    localFolder: string): boolean {
-    let aiConfigFile: AIConfigFile;
-    try {
-      // load and parse the recipe configuration file
-      aiConfigFile = this.getConfiguration(recipeBaseDir, localFolder);
-    } catch (e) {
-      throw e;
-    }
-    return !!aiConfigFile.aiConfig.application.containers.find(container => this.isInferenceServer(container));
-  }
-
-  private isInferenceServer(config: ContainerConfig): boolean {
-    return config.image === 'quay.io/ai-lab/llamacpp_python:latest';
   }
 
   private getConfiguration(recipeBaseDir: string | undefined, localFolder: string): AIConfigFile {

--- a/packages/backend/src/managers/recipes/RecipeManager.ts
+++ b/packages/backend/src/managers/recipes/RecipeManager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import type { GitCloneInfo, GitManager } from '../gitManager';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
-import type { Recipe, RecipeImage } from '@shared/src/models/IRecipe';
+import type { Recipe, RecipeComponents, RecipeImage } from '@shared/src/models/IRecipe';
 import path from 'node:path';
 import type { Task } from '@shared/src/models/ITask';
 import type { LocalRepositoryRegistry } from '../../registries/LocalRepositoryRegistry';
@@ -28,6 +28,10 @@ import { goarch } from '../../utils/arch';
 import type { BuilderManager } from './BuilderManager';
 import type { ContainerProviderConnection, Disposable } from '@podman-desktop/api';
 import { CONFIG_FILENAME } from '../../utils/RecipeConstants';
+import { InferenceManager } from '../inference/inferenceManager';
+import { ModelInfo } from '@shared/src/models/IModelInfo';
+import { withDefaultConfiguration } from '../../utils/inferenceUtils';
+import { InferenceServer } from '@shared/src/models/IInference';
 
 export interface AIContainers {
   aiConfigFile: AIConfigFile;
@@ -41,6 +45,7 @@ export class RecipeManager implements Disposable {
     private taskRegistry: TaskRegistry,
     private builderManager: BuilderManager,
     private localRepositories: LocalRepositoryRegistry,
+    private inferenceManager: InferenceManager,
   ) {}
 
   dispose(): void {}
@@ -91,20 +96,35 @@ export class RecipeManager implements Disposable {
     });
   }
 
-  public async buildRecipe(
-    connection: ContainerProviderConnection,
-    recipe: Recipe,
-    labels?: { [key: string]: string },
-  ): Promise<RecipeImage[]> {
+  public async buildRecipe(connection: ContainerProviderConnection, recipe: Recipe, model: ModelInfo, labels?: { [key: string]: string }): Promise<RecipeComponents> {
     const localFolder = path.join(this.appUserDirectory, recipe.id);
 
+    let inferenceServer: InferenceServer | undefined;
+    if (this.canUseInferenceServer(recipe.basedir, localFolder)) {
+      try {
+        inferenceServer = this.inferenceManager.getServerByModel(model);
+        if (!inferenceServer) {
+          const inferenceContainerId = await this.inferenceManager.createInferenceServer(
+            await withDefaultConfiguration({
+              modelsInfo: [model],
+            }),
+          );
+          inferenceServer = this.inferenceManager.get(inferenceContainerId)
+        } else if (inferenceServer.status === 'stopped') {
+          await this.inferenceManager.startInferenceServer(inferenceServer.container.containerId);
+        }
+      } catch (e) {
+        // we do not support this backend for inference servers
+      }
+    }
+        
     // load and parse the recipe configuration file and filter containers based on architecture
     const configAndFilteredContainers = this.getConfigAndFilterContainers(recipe.basedir, localFolder, {
       ...labels,
       'recipe-id': recipe.id,
     });
 
-    return await this.builderManager.build(
+    const images = await this.builderManager.build(
       connection,
       recipe,
       configAndFilteredContainers.containers,
@@ -114,6 +134,11 @@ export class RecipeManager implements Disposable {
         'recipe-id': recipe.id,
       },
     );
+
+    return {
+      images,
+      inferenceServer,
+    };
   }
 
   private getConfigAndFilterContainers(
@@ -155,8 +180,25 @@ export class RecipeManager implements Disposable {
 
   private filterContainers(aiConfig: AIConfig): ContainerConfig[] {
     return aiConfig.application.containers.filter(
-      container => container.gpu_env.length === 0 && container.arch.some(arc => arc === goarch()),
+      container => container.gpu_env.length === 0 && container.arch.some(arc => arc === goarch() && !this.isInferenceServer(container)),
     );
+  }
+
+  private canUseInferenceServer(
+    recipeBaseDir: string | undefined,
+    localFolder: string): boolean {
+    let aiConfigFile: AIConfigFile;
+    try {
+      // load and parse the recipe configuration file
+      aiConfigFile = this.getConfiguration(recipeBaseDir, localFolder);
+    } catch (e) {
+      throw e;
+    }
+    return !!aiConfigFile.aiConfig.application.containers.find(container => this.isInferenceServer(container));
+  }
+
+  private isInferenceServer(config: ContainerConfig): boolean {
+    return config.image === 'quay.io/ai-lab/llamacpp_python:latest';
   }
 
   private getConfiguration(recipeBaseDir: string | undefined, localFolder: string): AIConfigFile {

--- a/packages/backend/src/managers/recipes/RecipeManager.ts
+++ b/packages/backend/src/managers/recipes/RecipeManager.ts
@@ -109,7 +109,7 @@ export class RecipeManager implements Disposable {
     if (recipe.backend && recipe.backend === model.backend) {
       let task: Task | undefined;
       try {
-        inferenceServer = this.inferenceManager.getServerByModel(model);
+        inferenceServer = this.inferenceManager.findServerByModel(model);
         task = this.taskRegistry.createTask('Starting Inference server', 'loading', labels);
         if (!inferenceServer) {
           const inferenceContainerId = await this.inferenceManager.createInferenceServer(

--- a/packages/backend/src/models/AIConfig.ts
+++ b/packages/backend/src/models/AIConfig.ts
@@ -28,6 +28,7 @@ export interface ContainerConfig {
   gpu_env: string[];
   ports?: number[];
   image?: string;
+  backend?: string[];
 }
 
 export enum AIConfigFormat {
@@ -130,6 +131,7 @@ export function parseYamlFile(filepath: string, defaultArch: string): AIConfig {
               ? container['ports'].map(port => parseInt(port))
               : [],
           image: 'image' in container && isString(container['image']) ? container['image'] : undefined,
+          backend: 'backend' in container && Array.isArray(container['backend']) ? container['backend'] : undefined,
         };
       }),
     },

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -221,7 +221,6 @@ export class Studio {
     this.#localRepositoryRegistry.init();
     this.#extensionContext.subscriptions.push(this.#localRepositoryRegistry);
 
-    
     /**
      * GPUManager is a class responsible for detecting and storing the GPU specs
      */

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -221,35 +221,7 @@ export class Studio {
     this.#localRepositoryRegistry.init();
     this.#extensionContext.subscriptions.push(this.#localRepositoryRegistry);
 
-    /**
-     * The recipe manage offer some andy methods to manage recipes, build get images etc.
-     */
-    this.#recipeManager = new RecipeManager(
-      appUserDirectory,
-      gitManager,
-      this.#taskRegistry,
-      this.#builderManager,
-      this.#localRepositoryRegistry,
-    );
-    this.#recipeManager.init();
-    this.#extensionContext.subscriptions.push(this.#recipeManager);
-
-    /**
-     * The application manager is managing the Recipes
-     */
-    this.#applicationManager = new ApplicationManager(
-      this.#taskRegistry,
-      this.#panel.webview,
-      this.#podmanConnection,
-      this.#catalogManager,
-      this.#modelsManager,
-      this.#telemetry,
-      this.#podManager,
-      this.#recipeManager,
-    );
-    this.#applicationManager.init();
-    this.#extensionContext.subscriptions.push(this.#applicationManager);
-
+    
     /**
      * GPUManager is a class responsible for detecting and storing the GPU specs
      */
@@ -285,6 +257,36 @@ export class Studio {
     );
     this.#inferenceManager.init();
     this.#extensionContext.subscriptions.push(this.#inferenceManager);
+
+    /**
+     * The recipe manage offer some andy methods to manage recipes, build get images etc.
+     */
+    this.#recipeManager = new RecipeManager(
+      appUserDirectory,
+      gitManager,
+      this.#taskRegistry,
+      this.#builderManager,
+      this.#localRepositoryRegistry,
+      this.#inferenceManager,
+    );
+    this.#recipeManager.init();
+    this.#extensionContext.subscriptions.push(this.#recipeManager);
+
+    /**
+     * The application manager is managing the Recipes
+     */
+    this.#applicationManager = new ApplicationManager(
+      this.#taskRegistry,
+      this.#panel.webview,
+      this.#podmanConnection,
+      this.#catalogManager,
+      this.#modelsManager,
+      this.#telemetry,
+      this.#podManager,
+      this.#recipeManager,
+    );
+    this.#applicationManager.init();
+    this.#extensionContext.subscriptions.push(this.#applicationManager);
 
     /**
      * PlaygroundV2Manager handle the conversations of the Playground by using the InferenceServer available

--- a/packages/shared/src/models/IRecipe.ts
+++ b/packages/shared/src/models/IRecipe.ts
@@ -23,7 +23,7 @@ export interface RecipePullOptions {
   modelId: string;
 }
 
-import type { InferenceServer } from "./IInference";
+import type { InferenceServer } from './IInference';
 
 export interface RecipeComponents {
   images: RecipeImage[];

--- a/packages/shared/src/models/IRecipe.ts
+++ b/packages/shared/src/models/IRecipe.ts
@@ -23,6 +23,13 @@ export interface RecipePullOptions {
   modelId: string;
 }
 
+import type { InferenceServer } from "./IInference";
+
+export interface RecipeComponents {
+  images: RecipeImage[];
+  inferenceServer?: InferenceServer;
+}
+
 export interface RecipeImage {
   id: string;
   engineId: string;


### PR DESCRIPTION
### What does this PR do?

This PR is just a POC about using an inference server instead of creating the model service container inside the pod with the recipe app container.

The problem that we may face is that there is no link between the recipe and the inference server in the UI so the user does not know that by stopping the inference server the recipe will not work.

It also misses a new task for the creation/reuse of an inference server
The image id is hardcoded 
The image in the chatbot recipe in ai-lab-recipes is wrong

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->