### PR TITLE
feat(InferenceServer): adding whisper-cpp inference provider

### DIFF
--- a/packages/backend/src/managers/snippets/java-okhttp-snippet.spec.ts
+++ b/packages/backend/src/managers/snippets/java-okhttp-snippet.spec.ts
@@ -20,7 +20,7 @@ import { expect, test } from 'vitest';
 import { javaOkHttpGenerator } from './java-okhttp-snippet';
 
 test('expect return generated snippet', async () => {
-  const payload = await javaOkHttpGenerator({ url: 'http://localhost:32412' });
+  const payload = await javaOkHttpGenerator({ url: 'http://localhost:32412/v1/chat/completions' });
   expect(payload).toBeDefined();
-  expect(payload).toContain('.url("http://localhost:32412")');
+  expect(payload).toContain('.url("http://localhost:32412/v1/chat/completions")');
 });

--- a/packages/backend/src/managers/snippets/java-okhttp-snippet.ts
+++ b/packages/backend/src/managers/snippets/java-okhttp-snippet.ts
@@ -20,7 +20,7 @@ import mustache from 'mustache';
 import javaOkHttpTemplate from '../../templates/java-okhttp.mustache?raw';
 
 export async function javaOkHttpGenerator(requestOptions: RequestOptions): Promise<string> {
-  if(!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
+  if (!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
   return mustache.render(javaOkHttpTemplate, {
     endpoint: requestOptions.url,
   });

--- a/packages/backend/src/managers/snippets/java-okhttp-snippet.ts
+++ b/packages/backend/src/managers/snippets/java-okhttp-snippet.ts
@@ -20,7 +20,7 @@ import mustache from 'mustache';
 import javaOkHttpTemplate from '../../templates/java-okhttp.mustache?raw';
 
 export async function javaOkHttpGenerator(requestOptions: RequestOptions): Promise<string> {
-  if (!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
+  if (!requestOptions.url.endsWith('/v1/chat/completions')) throw new Error('Incompatible generator');
   return mustache.render(javaOkHttpTemplate, {
     endpoint: requestOptions.url,
   });

--- a/packages/backend/src/managers/snippets/java-okhttp-snippet.ts
+++ b/packages/backend/src/managers/snippets/java-okhttp-snippet.ts
@@ -20,6 +20,7 @@ import mustache from 'mustache';
 import javaOkHttpTemplate from '../../templates/java-okhttp.mustache?raw';
 
 export async function javaOkHttpGenerator(requestOptions: RequestOptions): Promise<string> {
+  if(!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
   return mustache.render(javaOkHttpTemplate, {
     endpoint: requestOptions.url,
   });

--- a/packages/backend/src/managers/snippets/python-langchain-snippet.ts
+++ b/packages/backend/src/managers/snippets/python-langchain-snippet.ts
@@ -20,7 +20,7 @@ import mustache from 'mustache';
 import pythonLangChainTemplate from '../../templates/python-langchain.mustache?raw';
 
 export async function pythonLangChainGenerator(requestOptions: RequestOptions): Promise<string> {
-  if(!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
+  if (!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
   return mustache.render(pythonLangChainTemplate, {
     endpoint: requestOptions.url.replace('chat/completions', ''),
   });

--- a/packages/backend/src/managers/snippets/python-langchain-snippet.ts
+++ b/packages/backend/src/managers/snippets/python-langchain-snippet.ts
@@ -20,6 +20,7 @@ import mustache from 'mustache';
 import pythonLangChainTemplate from '../../templates/python-langchain.mustache?raw';
 
 export async function pythonLangChainGenerator(requestOptions: RequestOptions): Promise<string> {
+  if(!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
   return mustache.render(pythonLangChainTemplate, {
     endpoint: requestOptions.url.replace('chat/completions', ''),
   });

--- a/packages/backend/src/managers/snippets/python-langchain-snippet.ts
+++ b/packages/backend/src/managers/snippets/python-langchain-snippet.ts
@@ -20,7 +20,7 @@ import mustache from 'mustache';
 import pythonLangChainTemplate from '../../templates/python-langchain.mustache?raw';
 
 export async function pythonLangChainGenerator(requestOptions: RequestOptions): Promise<string> {
-  if (!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
+  if (!requestOptions.url.endsWith('/v1/chat/completions')) throw new Error('Incompatible generator');
   return mustache.render(pythonLangChainTemplate, {
     endpoint: requestOptions.url.replace('chat/completions', ''),
   });

--- a/packages/backend/src/managers/snippets/quarkus-snippet.spec.ts
+++ b/packages/backend/src/managers/snippets/quarkus-snippet.spec.ts
@@ -34,7 +34,7 @@ test('expect fetched version in generated payload', async () => {
           ),
         ),
     });
-    const payload = await quarkusLangchain4Jgenerator({ url: 'http://localhost:32412' });
+    const payload = await quarkusLangchain4Jgenerator({ url: 'http://localhost:32412/v1/chat/completions' });
     expect(payload).toBeDefined();
     expect(payload).toContain('<version>release-version</version>');
   } finally {

--- a/packages/backend/src/managers/snippets/quarkus-snippet.ts
+++ b/packages/backend/src/managers/snippets/quarkus-snippet.ts
@@ -36,7 +36,7 @@ async function getQuarkusLangchain4jVersion(): Promise<string> {
   return (quarkusLangchain4jVersion = content.metadata.versioning.release._text);
 }
 export async function quarkusLangchain4Jgenerator(requestOptions: RequestOptions): Promise<string> {
-  if(!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
+  if (!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
   return mustache.render(template, {
     baseUrl: requestOptions.url.substring(0, requestOptions.url.length - SUFFIX_LENGTH),
     version: await getQuarkusLangchain4jVersion(),

--- a/packages/backend/src/managers/snippets/quarkus-snippet.ts
+++ b/packages/backend/src/managers/snippets/quarkus-snippet.ts
@@ -36,7 +36,7 @@ async function getQuarkusLangchain4jVersion(): Promise<string> {
   return (quarkusLangchain4jVersion = content.metadata.versioning.release._text);
 }
 export async function quarkusLangchain4Jgenerator(requestOptions: RequestOptions): Promise<string> {
-  if (!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
+  if (!requestOptions.url.endsWith('/v1/chat/completions')) throw new Error('Incompatible generator');
   return mustache.render(template, {
     baseUrl: requestOptions.url.substring(0, requestOptions.url.length - SUFFIX_LENGTH),
     version: await getQuarkusLangchain4jVersion(),

--- a/packages/backend/src/managers/snippets/quarkus-snippet.ts
+++ b/packages/backend/src/managers/snippets/quarkus-snippet.ts
@@ -36,6 +36,7 @@ async function getQuarkusLangchain4jVersion(): Promise<string> {
   return (quarkusLangchain4jVersion = content.metadata.versioning.release._text);
 }
 export async function quarkusLangchain4Jgenerator(requestOptions: RequestOptions): Promise<string> {
+  if(!requestOptions.url.endsWith('/v1/chat/completions')) return 'Incompatible generator';
   return mustache.render(template, {
     baseUrl: requestOptions.url.substring(0, requestOptions.url.length - SUFFIX_LENGTH),
     version: await getQuarkusLangchain4jVersion(),

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -47,6 +47,7 @@ import { InferenceProviderRegistry } from './registries/InferenceProviderRegistr
 import { ConfigurationRegistry } from './registries/ConfigurationRegistry';
 import { RecipeManager } from './managers/recipes/RecipeManager';
 import { GPUManager } from './managers/GPUManager';
+import { WhisperCpp } from './workers/provider/WhisperCpp';
 
 export class Studio {
   readonly #extensionContext: ExtensionContext;
@@ -264,6 +265,9 @@ export class Studio {
       this.#inferenceProviderRegistry.register(
         new LlamaCppPython(this.#taskRegistry, this.#podmanConnection, this.#gpuManager, this.#configurationRegistry),
       ),
+    );
+    this.#extensionContext.subscriptions.push(
+      this.#inferenceProviderRegistry.register(new WhisperCpp(this.#taskRegistry)),
     );
 
     /**

--- a/packages/backend/src/workers/provider/WhisperCpp.spec.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.spec.ts
@@ -19,16 +19,10 @@
 import { vi, test, expect, beforeEach } from 'vitest';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { WhisperCpp } from './WhisperCpp';
-import type { InferenceServer} from '@shared/src/models/IInference';
+import type { InferenceServer } from '@shared/src/models/IInference';
 import { InferenceType } from '@shared/src/models/IInference';
-import type {
-  ContainerProviderConnection,
-  ProviderContainerConnection,
-  ImageInfo,
-} from '@podman-desktop/api';
-import {
-  containerEngine,
-} from '@podman-desktop/api';
+import type { ContainerProviderConnection, ProviderContainerConnection, ImageInfo } from '@podman-desktop/api';
+import { containerEngine } from '@podman-desktop/api';
 import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
 
 vi.mock('@podman-desktop/api', () => ({
@@ -76,7 +70,7 @@ test('provider requires at least one model', async () => {
   const provider = new WhisperCpp(taskRegistry);
 
   await expect(() => {
-    return  provider.perform({
+    return provider.perform({
       port: 8888,
       labels: {},
       modelsInfo: [],
@@ -88,15 +82,17 @@ test('provider requires a downloaded model', async () => {
   const provider = new WhisperCpp(taskRegistry);
 
   await expect(() => {
-    return  provider.perform({
+    return provider.perform({
       port: 8888,
       labels: {},
-      modelsInfo: [{
-        id: 'whisper-cpp',
-        name: 'Whisper',
-        properties: {},
-        description: 'whisper desc',
-      }],
+      modelsInfo: [
+        {
+          id: 'whisper-cpp',
+          name: 'Whisper',
+          properties: {},
+          description: 'whisper desc',
+        },
+      ],
     });
   }).rejects.toThrowError('The model info file provided is undefined');
 });
@@ -105,22 +101,26 @@ test('provider requires a model with backend type Whisper', async () => {
   const provider = new WhisperCpp(taskRegistry);
 
   await expect(() => {
-    return  provider.perform({
+    return provider.perform({
       port: 8888,
       labels: {},
-      modelsInfo: [{
-        id: 'whisper-cpp',
-        name: 'Whisper',
-        properties: {},
-        description: 'whisper desc',
-        file: {
-          file: 'random-file',
-          path: 'path-to-file',
+      modelsInfo: [
+        {
+          id: 'whisper-cpp',
+          name: 'Whisper',
+          properties: {},
+          description: 'whisper desc',
+          file: {
+            file: 'random-file',
+            path: 'path-to-file',
+          },
+          backend: InferenceType.LLAMA_CPP,
         },
-        backend: InferenceType.LLAMA_CPP,
-      }],
+      ],
     });
-  }).rejects.toThrowError(`Whisper requires models with backend type ${InferenceType.WHISPER_CPP} got ${InferenceType.LLAMA_CPP}.`);
+  }).rejects.toThrowError(
+    `Whisper requires models with backend type ${InferenceType.WHISPER_CPP} got ${InferenceType.LLAMA_CPP}.`,
+  );
 });
 
 test('provider should propagate labels', async () => {
@@ -141,7 +141,7 @@ test('provider should propagate labels', async () => {
   const server: InferenceServer = await provider.perform({
     port: 8888,
     labels: {
-      'hello': 'world',
+      hello: 'world',
     },
     modelsInfo: [model],
   });
@@ -156,8 +156,8 @@ test('provider should propagate labels', async () => {
     },
     labels: {
       'ai-lab-inference-server': '["whisper-cpp"]',
-      'api': 'http://localhost:8888/inference',
-      'hello': 'world',
+      api: 'http://localhost:8888/inference',
+      hello: 'world',
     },
     models: [model],
     status: 'running',

--- a/packages/backend/src/workers/provider/WhisperCpp.spec.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.spec.ts
@@ -123,6 +123,37 @@ test('provider requires a model with backend type Whisper', async () => {
   );
 });
 
+test('custom image in inference server config should overwrite default', async () => {
+  const provider = new WhisperCpp(taskRegistry);
+
+  const model = {
+    id: 'whisper-cpp',
+    name: 'Whisper',
+    properties: {},
+    description: 'whisper desc',
+    file: {
+      file: 'random-file',
+      path: 'path-to-file',
+    },
+    backend: InferenceType.WHISPER_CPP,
+  };
+
+  await provider.perform({
+    port: 8888,
+    labels: {
+      hello: 'world',
+    },
+    image: 'localhost/whisper-cpp:custom',
+    modelsInfo: [model],
+  });
+
+  expect(getImageInfo).toHaveBeenCalledWith(
+    DummyProviderContainerConnection.connection,
+    'localhost/whisper-cpp:custom',
+    expect.any(Function),
+  );
+});
+
 test('provider should propagate labels', async () => {
   const provider = new WhisperCpp(taskRegistry);
 

--- a/packages/backend/src/workers/provider/WhisperCpp.spec.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.spec.ts
@@ -1,0 +1,166 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { vi, test, expect, beforeEach } from 'vitest';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import { WhisperCpp } from './WhisperCpp';
+import type { InferenceServer} from '@shared/src/models/IInference';
+import { InferenceType } from '@shared/src/models/IInference';
+import type {
+  ContainerProviderConnection,
+  ProviderContainerConnection,
+  ImageInfo,
+} from '@podman-desktop/api';
+import {
+  containerEngine,
+} from '@podman-desktop/api';
+import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
+
+vi.mock('@podman-desktop/api', () => ({
+  containerEngine: {
+    createContainer: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/inferenceUtils', () => ({
+  getProviderContainerConnection: vi.fn(),
+  getImageInfo: vi.fn(),
+  LABEL_INFERENCE_SERVER: 'ai-lab-inference-server',
+}));
+
+const DummyProviderContainerConnection: ProviderContainerConnection = {
+  providerId: 'dummy-provider-id',
+  connection: {
+    name: 'dummy-provider-connection',
+    type: 'podman',
+  } as unknown as ContainerProviderConnection,
+};
+
+const DummyImageInfo: ImageInfo = {
+  Id: 'dummy-image-id',
+  engineId: 'dummy-engine-id',
+} as unknown as ImageInfo;
+
+const taskRegistry: TaskRegistry = {
+  createTask: vi.fn(),
+  updateTask: vi.fn(),
+} as unknown as TaskRegistry;
+
+beforeEach(() => {
+  vi.mocked(getProviderContainerConnection).mockReturnValue(DummyProviderContainerConnection);
+  vi.mocked(taskRegistry.createTask).mockReturnValue({ id: 'dummy-task-id', name: '', labels: {}, state: 'loading' });
+
+  vi.mocked(getImageInfo).mockResolvedValue(DummyImageInfo);
+  vi.mocked(containerEngine.createContainer).mockResolvedValue({
+    id: 'dummy-container-id',
+    engineId: 'dummy-engine-id',
+  });
+});
+
+test('provider requires at least one model', async () => {
+  const provider = new WhisperCpp(taskRegistry);
+
+  await expect(() => {
+    return  provider.perform({
+      port: 8888,
+      labels: {},
+      modelsInfo: [],
+    });
+  }).rejects.toThrowError('Need at least one model info to start an inference server.');
+});
+
+test('provider requires a downloaded model', async () => {
+  const provider = new WhisperCpp(taskRegistry);
+
+  await expect(() => {
+    return  provider.perform({
+      port: 8888,
+      labels: {},
+      modelsInfo: [{
+        id: 'whisper-cpp',
+        name: 'Whisper',
+        properties: {},
+        description: 'whisper desc',
+      }],
+    });
+  }).rejects.toThrowError('The model info file provided is undefined');
+});
+
+test('provider requires a model with backend type Whisper', async () => {
+  const provider = new WhisperCpp(taskRegistry);
+
+  await expect(() => {
+    return  provider.perform({
+      port: 8888,
+      labels: {},
+      modelsInfo: [{
+        id: 'whisper-cpp',
+        name: 'Whisper',
+        properties: {},
+        description: 'whisper desc',
+        file: {
+          file: 'random-file',
+          path: 'path-to-file',
+        },
+        backend: InferenceType.LLAMA_CPP,
+      }],
+    });
+  }).rejects.toThrowError(`Whisper requires models with backend type ${InferenceType.WHISPER_CPP} got ${InferenceType.LLAMA_CPP}.`);
+});
+
+test('provider should propagate labels', async () => {
+  const provider = new WhisperCpp(taskRegistry);
+
+  const model = {
+    id: 'whisper-cpp',
+    name: 'Whisper',
+    properties: {},
+    description: 'whisper desc',
+    file: {
+      file: 'random-file',
+      path: 'path-to-file',
+    },
+    backend: InferenceType.WHISPER_CPP,
+  };
+
+  const server: InferenceServer = await provider.perform({
+    port: 8888,
+    labels: {
+      'hello': 'world',
+    },
+    modelsInfo: [model],
+  });
+
+  expect(server).toStrictEqual({
+    connection: {
+      port: 8888,
+    },
+    container: {
+      containerId: 'dummy-container-id',
+      engineId: 'dummy-engine-id',
+    },
+    labels: {
+      'ai-lab-inference-server': '["whisper-cpp"]',
+      'api': 'http://localhost:8888/inference',
+      'hello': 'world',
+    },
+    models: [model],
+    status: 'running',
+    type: InferenceType.WHISPER_CPP,
+  });
+});

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -45,7 +45,9 @@ export class WhisperCpp extends InferenceProvider {
     }
 
     if (modelInfo.backend !== InferenceType.WHISPER_CPP) {
-      throw new Error(`Whisper requires models with backend type ${InferenceType.WHISPER_CPP} got ${modelInfo.backend}.`);
+      throw new Error(
+        `Whisper requires models with backend type ${InferenceType.WHISPER_CPP} got ${modelInfo.backend}.`,
+      );
     }
 
     const labels: Record<string, string> = {

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -24,7 +24,8 @@ import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { MountConfig } from '@podman-desktop/api';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
 
-export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp@sha256:6c529656529da7aba851b6ab2d0653f23b77b9ca3c11cb46db47ff6dbd6d5e7c';
+export const WHISPER_CPP_CPU =
+  'ghcr.io/containers/whispercpp@sha256:6c529656529da7aba851b6ab2d0653f23b77b9ca3c11cb46db47ff6dbd6d5e7c';
 
 export class WhisperCpp extends InferenceProvider {
   constructor(taskRegistry: TaskRegistry) {

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -55,7 +55,7 @@ export class WhisperCpp extends InferenceProvider {
       [LABEL_INFERENCE_SERVER]: JSON.stringify(config.modelsInfo.map(model => model.id)),
     };
 
-    const imageInfo = await this.pullImage(config.providerId, WHISPER_CPP_CPU, labels);
+    const imageInfo = await this.pullImage(config.providerId, config.image ?? WHISPER_CPP_CPU, labels);
     const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
 
     const mounts: MountConfig = [

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -24,7 +24,7 @@ import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { MountConfig } from '@podman-desktop/api';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
 
-export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp:latest';
+export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp@sha256:6c529656529da7aba851b6ab2d0653f23b77b9ca3c11cb46db47ff6dbd6d5e7c';
 
 export class WhisperCpp extends InferenceProvider {
   constructor(taskRegistry: TaskRegistry) {

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -36,10 +36,16 @@ export class WhisperCpp extends InferenceProvider {
   }
 
   override async perform(config: InferenceServerConfig): Promise<InferenceServer> {
+    if (config.modelsInfo.length === 0) throw new Error('Need at least one model info to start an inference server.');
+
     const modelInfo = config.modelsInfo[0];
 
     if (modelInfo.file === undefined) {
       throw new Error('The model info file provided is undefined');
+    }
+
+    if (modelInfo.backend !== InferenceType.WHISPER_CPP) {
+      throw new Error(`Whisper requires models with backend type ${InferenceType.WHISPER_CPP} got ${modelInfo.backend}.`);
     }
 
     const labels: Record<string, string> = {
@@ -57,6 +63,8 @@ export class WhisperCpp extends InferenceProvider {
         Type: 'bind',
       },
     ];
+
+    labels['api'] = `http://localhost:${config.port}/inference`;
 
     const containerInfo = await this.createContainer(
       imageInfo.engineId,

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -28,7 +28,7 @@ export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp:latest';
 
 export class WhisperCpp extends InferenceProvider {
   constructor(taskRegistry: TaskRegistry) {
-    super(taskRegistry, InferenceType.WHISPER_CPP, 'LLama-cpp');
+    super(taskRegistry, InferenceType.WHISPER_CPP, 'Whisper-cpp');
   }
 
   override enabled(): boolean {

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -24,7 +24,7 @@ import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { MountConfig } from '@podman-desktop/api';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
 
-export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp:latest';
+export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp@sha256:d1d3fdbc9587ac5d28607742dec9296bec4022402b16d379accb331fb2e1302d';
 
 export class WhisperCpp extends InferenceProvider {
   constructor(taskRegistry: TaskRegistry) {

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -1,0 +1,99 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { InferenceProvider } from './InferenceProvider';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import type { InferenceServer } from '@shared/src/models/IInference';
+import { InferenceType } from '@shared/src/models/IInference';
+import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
+import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
+import type { MountConfig } from '@podman-desktop/api';
+import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
+
+export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp:latest';
+
+export class WhisperCpp extends InferenceProvider {
+  constructor(taskRegistry: TaskRegistry) {
+    super(taskRegistry, InferenceType.WHISPER_CPP, 'LLama-cpp');
+  }
+
+  override enabled(): boolean {
+    return true;
+  }
+
+  override async perform(config: InferenceServerConfig): Promise<InferenceServer> {
+    const modelInfo = config.modelsInfo[0];
+
+    if (modelInfo.file === undefined) {
+      throw new Error('The model info file provided is undefined');
+    }
+
+    const labels: Record<string, string> = {
+      ...config.labels,
+      [LABEL_INFERENCE_SERVER]: JSON.stringify(config.modelsInfo.map(model => model.id)),
+    };
+
+    const imageInfo = await this.pullImage(config.providerId, WHISPER_CPP_CPU, labels);
+    const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
+
+    const mounts: MountConfig = [
+      {
+        Target: '/models',
+        Source: modelInfo.file.path,
+        Type: 'bind',
+      },
+    ];
+
+    const containerInfo = await this.createContainer(
+      imageInfo.engineId,
+      {
+        Image: imageInfo.Id,
+        Detach: true,
+        Labels: labels,
+        HostConfig: {
+          AutoRemove: false,
+          Mounts: mounts,
+          PortBindings: {
+            '8000/tcp': [
+              {
+                HostPort: `${config.port}`,
+              },
+            ],
+          },
+          SecurityOpt: [DISABLE_SELINUX_LABEL_SECURITY_OPTION],
+        },
+        Env: envs,
+      },
+      labels,
+    );
+
+    return {
+      models: [modelInfo],
+      status: 'running',
+      connection: {
+        port: config.port,
+      },
+      container: {
+        containerId: containerInfo.id,
+        engineId: containerInfo.engineId,
+      },
+      type: InferenceType.WHISPER_CPP,
+      labels: labels,
+    };
+  }
+  override dispose(): void {}
+}

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -24,7 +24,7 @@ import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { MountConfig } from '@podman-desktop/api';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
 
-export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp@sha256:d1d3fdbc9587ac5d28607742dec9296bec4022402b16d379accb331fb2e1302d';
+export const WHISPER_CPP_CPU = 'ghcr.io/containers/whispercpp:latest';
 
 export class WhisperCpp extends InferenceProvider {
   constructor(taskRegistry: TaskRegistry) {

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -84,7 +84,7 @@ const generate = async (language: string, variant: string) => {
         method: 'POST',
         header: [
           {
-            key: 'Content-Type',
+            key: 'Accept',
             value: 'application/json',
           },
         ],

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -103,7 +103,12 @@ const generate = async (language: string, variant: string) => {
   }
 
   if (!options) return;
-  snippet = await studioClient.createSnippet(options, language, variant);
+
+  try {
+    snippet = await studioClient.createSnippet(options, language, variant);
+  } catch (err: unknown) {
+    snippet = `${String(err)}`;
+  }
 };
 
 $: {

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -19,10 +19,8 @@ import type { LanguageVariant } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
-import { Button, DetailsPage } from '@podman-desktop/ui-svelte';
-import { Tooltip } from '@podman-desktop/ui-svelte';
-import CopyButton from '/@/lib/button/CopyButton.svelte';
 import { Button, DetailsPage, Tooltip } from '@podman-desktop/ui-svelte';
+import CopyButton from '/@/lib/button/CopyButton.svelte';
 import type { RequestOptions } from '@shared/src/models/RequestOptions';
 
 export let containerId: string | undefined = undefined;

--- a/packages/shared/src/models/RequestOptions.ts
+++ b/packages/shared/src/models/RequestOptions.ts
@@ -1,3 +1,9 @@
+export interface FormParamDefinition {
+  key: string;
+  value: string;
+  type: string;
+}
+
 export interface RequestOptions {
   url: string;
   method?: string;
@@ -7,7 +13,8 @@ export interface RequestOptions {
     system?: boolean;
   }[];
   body?: {
-    mode: 'raw';
+    mode: 'raw' | 'formdata';
     raw?: string;
+    formdata?: FormParamDefinition[];
   };
 }


### PR DESCRIPTION
### What does this PR do?

This PR allow the inference server to serve the WhisperCpp model outside of a recipe.

### Notable changes

- Adding a new InferenceProvider
- Generating new snippets for WhisperCpp
- Preventing the hardcoded snippets to generate out of context content

### Screenshot / video of UI

**before**

![image](https://github.com/user-attachments/assets/9975896d-e5f4-43f0-a3e5-9add8e754375)

**after**

https://github.com/user-attachments/assets/994c90d1-eee5-474b-934d-7401e59da9b0

![image](https://github.com/user-attachments/assets/13002f7d-e481-439f-a5e5-3c71a580760b)

![image](https://github.com/user-attachments/assets/f6627b2d-c8f6-4b47-9af9-aeebe40d07ce)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1451

### How to test this PR?

- [x]: unit tests has been provided

:warning: you may need to pull manually `ghcr.io/containers/whispercpp:latest` if you already have the image locally.