### PR TITLE
refactor(UI): generify Select component

### DIFF
--- a/packages/frontend/src/lib/select/ModelSelect.spec.ts
+++ b/packages/frontend/src/lib/select/ModelSelect.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 import { beforeEach, vi, test, expect } from 'vitest';
 import { render, fireEvent, within } from '@testing-library/svelte';
-import ModelSelect from '/@/lib/ModelSelect.svelte';
+import ModelSelect from '/@/lib/select/ModelSelect.svelte';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { InferenceType } from '@shared/src/models/IInference';
 

--- a/packages/frontend/src/lib/select/ModelSelect.svelte
+++ b/packages/frontend/src/lib/select/ModelSelect.svelte
@@ -40,16 +40,15 @@ $: {
 </script>
 
 <Select
-  label='Select Model'
+  label="Select Model"
   name="select-model"
   disabled={disabled}
   value={selected}
-  onchange={(nValue) => (value = nValue)}
+  onchange={nValue => (value = nValue)}
   placeholder="Select model to use"
   items={models
     .toSorted((a, b) => getModelSortingScore(a) - getModelSortingScore(b))
-    .map(model => ({ ...model, value: model.id, label: model.name }))}
->
+    .map(model => ({ ...model, value: model.id, label: model.name }))}>
   <div slot="item" let:item>
     <div class="flex items-center">
       <div class="grow">

--- a/packages/frontend/src/lib/select/ModelSelect.svelte
+++ b/packages/frontend/src/lib/select/ModelSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faCheckCircle, faDownload } from '@fortawesome/free-solid-svg-icons';
-import Select from 'svelte-select';
+import Select from './Select.svelte';
 import Fa from 'svelte-fa';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
@@ -40,29 +40,16 @@ $: {
 </script>
 
 <Select
-  inputAttributes={{ 'aria-label': 'Select Model' }}
+  label='Select Model'
   name="select-model"
   disabled={disabled}
   value={selected}
-  on:change={e => (value = e.detail)}
-  --item-color={'var(--pd-dropdown-item-text)'}
-  --item-is-active-color={'var(--pd-dropdown-item-text)'}
-  --item-hover-color="var(--pd-dropdown-item-hover-text)"
-  --item-active-background="var(--pd-input-field-hover-stroke)"
-  --item-is-active-bg="var(--pd-input-field-hover-stroke)"
-  --background={'var(--pd-dropdown-bg)'}
-  --list-background={'var(--pd-dropdown-bg)'}
-  --item-hover-bg="var(--pd-dropdown-item-hover-bg)"
-  --border="1px solid var(--pd-input-field-focused-bg)"
-  --border-hover="1px solid var(--pd-input-field-hover-stroke)"
-  --list-border="1px solid var(--pd-input-field-focused-bg)"
-  --border-focused="var(--pd-input-field-focused-bg)"
+  onchange={(nValue) => (value = nValue)}
   placeholder="Select model to use"
-  class="!bg-[var(--pd-content-bg)] !text-[var(--pd-content-card-text)]"
   items={models
     .toSorted((a, b) => getModelSortingScore(a) - getModelSortingScore(b))
     .map(model => ({ ...model, value: model.id, label: model.name }))}
-  showChevron>
+>
   <div slot="item" let:item>
     <div class="flex items-center">
       <div class="grow">

--- a/packages/frontend/src/lib/select/Select.spec.ts
+++ b/packages/frontend/src/lib/select/Select.spec.ts
@@ -1,0 +1,117 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, vi, test, expect } from 'vitest';
+import { render, fireEvent, within } from '@testing-library/svelte';
+import Select from '/@/lib/select/Select.svelte';
+
+beforeEach(() => {
+  // mock scrollIntoView
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+test('empty slot should use basic list', async () => {
+  const { container} = render(Select, {
+    label: 'Select Item',
+    items: [{
+      label: 'Dummy Item 1',
+      value: 'item-1',
+    },
+      {
+        label: 'Dummy Item 2',
+        value: 'item-2',
+      }],
+  });
+
+  // first get the select input
+  const input = within(container).getByLabelText('Select Item');
+  await fireEvent.pointerUp(input); // they are using the pointer up event instead of click.
+
+  // get all options available
+  const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
+  // ensure we have two options
+  expect(items.length).toBe(2);
+  expect(items[0]).toHaveTextContent('Dummy Item 1');
+  expect(items[1]).toHaveTextContent('Dummy Item 2');
+});
+
+test('defined value should have corresponding active class to item', async () => {
+  const { container} = render(Select, {
+    label: 'Select Item',
+    items: [{
+      label: 'Dummy Item 1',
+      value: 'item-1',
+    },
+      {
+        label: 'Dummy Item 2',
+        value: 'item-2',
+      }],
+    value: {
+      label: 'Dummy Item 2',
+      value: 'item-2',
+    },
+  });
+
+  // first get the select input
+  const input = within(container).getByLabelText('Select Item');
+  await fireEvent.pointerUp(input); // they are using the pointer up event instead of click.
+
+  // get all options available
+  const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
+  // ensure we have two options
+  expect(items.length).toBe(2);
+  expect(items[0].children.length).toBe(1);
+  expect(items[0].children[0].classList.value).not.toContain('active');
+  expect(items[1].children.length).toBe(1);
+  expect(items[1].children[0].classList.value).toContain('active');
+});
+
+test('selecting value should call onchange callback', async () => {
+  const onChangeMock = vi.fn();
+  const { container} = render(Select, {
+    label: 'Select Item',
+    items: [{
+      label: 'Dummy Item 1',
+      value: 'item-1',
+    },
+      {
+        label: 'Dummy Item 2',
+        value: 'item-2',
+      }],
+    onchange: onChangeMock,
+  });
+
+  // first get the select input
+  const input = within(container).getByLabelText('Select Item');
+  await fireEvent.pointerUp(input); // they are using the pointer up event instead of click.
+
+  // get all options available
+  const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
+  // ensure we have two options
+  expect(items.length).toBe(2);
+
+  await fireEvent.click(items[1]);
+
+  await vi.waitFor(() => {
+    expect(onChangeMock).toHaveBeenCalledWith({
+      label: 'Dummy Item 2',
+      value: 'item-2',
+    });
+  });
+});

--- a/packages/frontend/src/lib/select/Select.spec.ts
+++ b/packages/frontend/src/lib/select/Select.spec.ts
@@ -27,16 +27,18 @@ beforeEach(() => {
 });
 
 test('empty slot should use basic list', async () => {
-  const { container} = render(Select, {
+  const { container } = render(Select, {
     label: 'Select Item',
-    items: [{
-      label: 'Dummy Item 1',
-      value: 'item-1',
-    },
+    items: [
+      {
+        label: 'Dummy Item 1',
+        value: 'item-1',
+      },
       {
         label: 'Dummy Item 2',
         value: 'item-2',
-      }],
+      },
+    ],
   });
 
   // first get the select input
@@ -52,16 +54,18 @@ test('empty slot should use basic list', async () => {
 });
 
 test('defined value should have corresponding active class to item', async () => {
-  const { container} = render(Select, {
+  const { container } = render(Select, {
     label: 'Select Item',
-    items: [{
-      label: 'Dummy Item 1',
-      value: 'item-1',
-    },
+    items: [
+      {
+        label: 'Dummy Item 1',
+        value: 'item-1',
+      },
       {
         label: 'Dummy Item 2',
         value: 'item-2',
-      }],
+      },
+    ],
     value: {
       label: 'Dummy Item 2',
       value: 'item-2',
@@ -84,16 +88,18 @@ test('defined value should have corresponding active class to item', async () =>
 
 test('selecting value should call onchange callback', async () => {
   const onChangeMock = vi.fn();
-  const { container} = render(Select, {
+  const { container } = render(Select, {
     label: 'Select Item',
-    items: [{
-      label: 'Dummy Item 1',
-      value: 'item-1',
-    },
+    items: [
+      {
+        label: 'Dummy Item 1',
+        value: 'item-1',
+      },
       {
         label: 'Dummy Item 2',
         value: 'item-2',
-      }],
+      },
+    ],
     onchange: onChangeMock,
   });
 

--- a/packages/frontend/src/lib/select/Select.svelte
+++ b/packages/frontend/src/lib/select/Select.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Select from 'svelte-select';
 
-type T = $$Generic<{ label: string, value: string }>;
+type T = $$Generic<{ label: string; value: string }>;
 export let disabled: boolean = false;
 
 export let value: T | undefined = undefined;
@@ -38,7 +38,7 @@ export let onchange: ((value: T | undefined) => void) | undefined = undefined;
   items={items}
   showChevron>
   <div slot="item" let:item>
-    <slot name="item" item="{item}" >
+    <slot name="item" item={item}>
       <div>{item.label}</div>
     </slot>
   </div>

--- a/packages/frontend/src/lib/select/Select.svelte
+++ b/packages/frontend/src/lib/select/Select.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+import Select from 'svelte-select';
+
+type T = $$Generic<{ label: string, value: string }>;
+export let disabled: boolean = false;
+
+export let value: T | undefined = undefined;
+export let items: T[] = [];
+export let placeholder: string | undefined = undefined;
+export let label: string | undefined = undefined;
+export let name: string | undefined = undefined;
+export let onchange: ((value: T | undefined) => void) | undefined = undefined;
+</script>
+
+<Select
+  inputAttributes={{ 'aria-label': label }}
+  name={name}
+  disabled={disabled}
+  value={value}
+  on:change={e => {
+    value = e.detail;
+    onchange?.(value);
+  }}
+  --item-color={'var(--pd-dropdown-item-text)'}
+  --item-is-active-color={'var(--pd-dropdown-item-text)'}
+  --item-hover-color="var(--pd-dropdown-item-hover-text)"
+  --item-active-background="var(--pd-input-field-hover-stroke)"
+  --item-is-active-bg="var(--pd-input-field-hover-stroke)"
+  --background={'var(--pd-dropdown-bg)'}
+  --list-background={'var(--pd-dropdown-bg)'}
+  --item-hover-bg="var(--pd-dropdown-item-hover-bg)"
+  --border="1px solid var(--pd-input-field-focused-bg)"
+  --border-hover="1px solid var(--pd-input-field-hover-stroke)"
+  --list-border="1px solid var(--pd-input-field-focused-bg)"
+  --border-focused="var(--pd-input-field-focused-bg)"
+  placeholder={placeholder}
+  class="!bg-[var(--pd-content-bg)] !text-[var(--pd-content-card-text)]"
+  items={items}
+  showChevron>
+  <div slot="item" let:item>
+    <slot name="item" item="{item}" >
+      <div>{item.label}</div>
+    </slot>
+  </div>
+</Select>

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -15,7 +15,7 @@ import ContainerConnectionStatusInfo from '../lib/notification/ContainerConnecti
 import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 import { checkContainerConnectionStatus } from '../utils/connectionUtils';
 import { Button, ErrorMessage, FormPage, Input } from '@podman-desktop/ui-svelte';
-import ModelSelect from '/@/lib/ModelSelect.svelte';
+import ModelSelect from '/@/lib/select/ModelSelect.svelte';
 
 // List of the models available locally
 let localModels: ModelInfo[];

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -12,7 +12,7 @@ import { tasks } from '../stores/tasks';
 import { filterByLabel } from '../utils/taskUtils';
 import type { Unsubscriber } from 'svelte/store';
 import { Button, ErrorMessage, FormPage, Input } from '@podman-desktop/ui-svelte';
-import ModelSelect from '/@/lib/ModelSelect.svelte';
+import ModelSelect from '/@/lib/select/ModelSelect.svelte';
 import { InferenceType } from '@shared/src/models/IInference';
 
 let localModels: ModelInfo[];

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -20,7 +20,7 @@ import { router } from 'tinro';
 import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 import { checkContainerConnectionStatus } from '/@/utils/connectionUtils';
 import ContainerConnectionStatusInfo from '/@/lib/notification/ContainerConnectionStatusInfo.svelte';
-import ModelSelect from '/@/lib/ModelSelect.svelte';
+import ModelSelect from '/@/lib/select/ModelSelect.svelte';
 
 export let recipeId: string;
 


### PR DESCRIPTION
### What does this PR do?

The `SelectModel` component used in the `CreateService`, `PlaygroundCreate`, `StartRecipe` was adding all the css/classes required to style the `svelte-select` component. 

For https://github.com/containers/podman-desktop-extension-ai-lab/issues/1462 we need to expose a new select, allowing the user to select the connection when multiple are available.

Therefore we need to make the Select more generic so the styling can be reused.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1518

### How to test this PR?

- [x] unit tests has been provided

**Testing manually**

- Go to AI Lab
- Go to the `CreateService` page
- Select any model from the list 
- Start it
- assert => the selected model has been properly selected