### PR TITLE
feat(PodmanConnection): makes class extend Publisher

### DIFF
--- a/packages/backend/src/managers/application/applicationManager.spec.ts
+++ b/packages/backend/src/managers/application/applicationManager.spec.ts
@@ -41,8 +41,7 @@ const webviewMock = {
 } as unknown as Webview;
 
 const podmanConnectionMock = {
-  startupSubscribe: vi.fn(),
-  onMachineStop: vi.fn(),
+  onPodmanConnectionEvent: vi.fn(),
   getVMType: vi.fn(),
 } as unknown as PodmanConnection;
 

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -63,8 +63,7 @@ const containerRegistryMock = {
 } as unknown as ContainerRegistry;
 
 const podmanConnectionMock = {
-  onMachineStart: vi.fn(),
-  onMachineStop: vi.fn(),
+  onPodmanConnectionEvent: vi.fn(),
 } as unknown as PodmanConnection;
 
 const modelsManager = {

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { InferenceServer, InferenceServerStatus, InferenceType } from '@shared/src/models/IInference';
-import type { PodmanConnection } from '../podmanConnection';
+import type { PodmanConnection, PodmanConnectionEvent } from '../podmanConnection';
 import { containerEngine, Disposable } from '@podman-desktop/api';
 import { type ContainerInfo, type TelemetryLogger, type Webview } from '@podman-desktop/api';
 import type { ContainerRegistry, ContainerStart } from '../../registries/ContainerRegistry';
@@ -58,8 +58,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
   }
 
   init(): void {
-    this.podmanConnection.onMachineStart(this.watchMachineEvent.bind(this, 'start'));
-    this.podmanConnection.onMachineStop(this.watchMachineEvent.bind(this, 'stop'));
+    this.podmanConnection.onPodmanConnectionEvent(this.watchMachineEvent.bind(this));
     this.containerRegistry.onStartContainerEvent(this.watchContainerStart.bind(this));
     this.catalogManager.onUpdate(() => {
       this.retryableRefresh(1);
@@ -285,7 +284,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     this.#disposables.push(disposable);
   }
 
-  private watchMachineEvent(_event: 'start' | 'stop'): void {
+  private watchMachineEvent(_event: PodmanConnectionEvent): void {
     this.retryableRefresh(2);
   }
 

--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -418,6 +418,20 @@ describe('getVMType', () => {
     expect(await manager.getVMType()).toBe(VMType.WSL);
   });
 
+  test('unknown string should return UNKNOWN', async () => {
+    vi.mocked(process.exec).mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          Name: 'machine-1',
+          VMType: 'fake-content',
+        },
+      ]),
+    } as unknown as RunResult);
+
+    const manager = new PodmanConnection(webviewMock);
+    expect(await manager.getVMType()).toBe(VMType.UNKNOWN);
+  });
+
   test.each(Object.values(VMType) as string[])('%s type should be the expected result', async vmtype => {
     vi.mocked(process.exec).mockResolvedValue({
       stdout: JSON.stringify([

--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -16,23 +16,33 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { PodmanConnection } from './podmanConnection';
-import type { RegisterContainerConnectionEvent, RunResult, UpdateContainerConnectionEvent } from '@podman-desktop/api';
-import { process } from '@podman-desktop/api';
+import type {
+  ProviderEvent,
+  RegisterContainerConnectionEvent,
+  RunResult,
+  UnregisterContainerConnectionEvent,
+  UpdateContainerConnectionEvent,
+  Webview,
+} from '@podman-desktop/api';
+import { process, provider, EventEmitter } from '@podman-desktop/api';
 import { VMType } from '@shared/src/models/IPodman';
+import { Messages } from '@shared/Messages';
 
-const mocks = vi.hoisted(() => ({
-  getFirstRunningPodmanConnectionMock: vi.fn(),
-  onDidRegisterContainerConnection: vi.fn(),
-  onDidUpdateContainerConnection: vi.fn(),
-}));
+const webviewMock = {
+  postMessage: vi.fn(),
+} as unknown as Webview;
 
 vi.mock('@podman-desktop/api', async () => {
   return {
+    EventEmitter: vi.fn(),
     provider: {
-      onDidRegisterContainerConnection: mocks.onDidRegisterContainerConnection,
-      onDidUpdateContainerConnection: mocks.onDidUpdateContainerConnection,
+      onDidUnregisterContainerConnection: vi.fn(),
+      onDidRegisterContainerConnection: vi.fn(),
+      onDidUpdateContainerConnection: vi.fn(),
+      onDidUpdateProvider: vi.fn(),
+      getContainerConnections: vi.fn(),
     },
     process: {
       exec: vi.fn(),
@@ -43,100 +53,278 @@ vi.mock('@podman-desktop/api', async () => {
 vi.mock('../utils/podman', () => {
   return {
     getPodmanCli: vi.fn(),
-    getFirstRunningPodmanConnection: mocks.getFirstRunningPodmanConnectionMock,
   };
 });
 
-test('startupSubscribe should execute immediately if provider already registered', async () => {
-  const manager = new PodmanConnection();
-  // one provider is already registered
-  mocks.getFirstRunningPodmanConnectionMock.mockReturnValue({
-    connection: {
-      type: 'podman',
-      status: () => 'started',
-    },
-  });
-  mocks.onDidRegisterContainerConnection.mockReturnValue({
-    dispose: vi.fn,
-  });
-  manager.listenRegistration();
-  const handler = vi.fn();
-  manager.startupSubscribe(handler);
-  // the handler is called immediately
-  expect(handler).toHaveBeenCalledOnce();
+beforeEach(() => {
+  vi.mocked(webviewMock.postMessage).mockResolvedValue(true);
+  vi.mocked(provider.getContainerConnections).mockReturnValue([]);
+
+  const listeners: ((value: unknown) => void)[] = [];
+
+  vi.mocked(EventEmitter).mockReturnValue({
+    event: vi.fn().mockImplementation(callback => {
+      listeners.push(callback);
+    }),
+    fire: vi.fn().mockImplementation((content: unknown) => {
+      listeners.forEach(listener => listener(content));
+    }),
+  } as unknown as EventEmitter<unknown>);
 });
 
-test('startupSubscribe should execute  when provider is registered', async () => {
-  const manager = new PodmanConnection();
+describe('podman connection initialization', () => {
+  test('init should notify publisher', () => {
+    const manager = new PodmanConnection(webviewMock);
+    manager.init();
 
-  // no provider is already registered
-  mocks.getFirstRunningPodmanConnectionMock.mockReturnValue(undefined);
-  mocks.onDidRegisterContainerConnection.mockImplementation((f: (e: RegisterContainerConnectionEvent) => void) => {
-    setTimeout(() => {
-      f({
-        connection: {
-          type: 'podman',
-          status: () => 'started',
-        },
-      } as unknown as RegisterContainerConnectionEvent);
-    }, 1);
-    return {
-      dispose: vi.fn(),
-    };
+    expect(webviewMock.postMessage).toHaveBeenCalledWith({
+      id: Messages.MSG_PODMAN_CONNECTION_UPDATE,
+      body: [],
+    });
   });
-  manager.listenRegistration();
-  const handler = vi.fn();
-  manager.startupSubscribe(handler);
-  // the handler is not called immediately
-  expect(handler).not.toHaveBeenCalledOnce();
-  await new Promise(resolve => setTimeout(resolve, 10));
-  expect(handler).toHaveBeenCalledOnce();
-});
 
-test('onMachineStart should call the handler when machine starts', async () => {
-  const manager = new PodmanConnection();
-  mocks.onDidUpdateContainerConnection.mockImplementation((f: (e: UpdateContainerConnectionEvent) => void) => {
-    setTimeout(() => {
-      f({
+  test('init should register all provider events', () => {
+    const manager = new PodmanConnection(webviewMock);
+    manager.init();
+
+    expect(provider.onDidUnregisterContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+    expect(provider.onDidRegisterContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+    expect(provider.onDidUpdateContainerConnection).toHaveBeenCalledWith(expect.any(Function));
+    expect(provider.onDidUpdateProvider).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  test('init should fetch all container connections', () => {
+    const statusMock = vi.fn().mockReturnValue('started');
+
+    vi.mocked(provider.getContainerConnections).mockReturnValue([
+      {
         connection: {
           type: 'podman',
+          status: statusMock,
+          name: 'Podman Machine',
+          endpoint: {
+            socketPath: './socket-path',
+          },
         },
+        providerId: 'podman',
+      },
+    ]);
+
+    const manager = new PodmanConnection(webviewMock);
+    manager.init();
+
+    expect(manager.getContainerProviderConnectionInfo()).toStrictEqual([
+      {
+        name: 'Podman Machine',
+        providerId: 'podman',
         status: 'started',
-      } as UpdateContainerConnectionEvent);
-    }, 1);
-    return {
-      dispose: vi.fn(),
-    };
+        type: 'podman',
+        vmType: VMType.UNKNOWN,
+      },
+    ]);
+
+    expect(statusMock).toHaveBeenCalled();
   });
-  manager.listenMachine();
-  const handler = vi.fn();
-  manager.onMachineStart(handler);
-  expect(handler).not.toHaveBeenCalledOnce();
-  await new Promise(resolve => setTimeout(resolve, 10));
-  expect(handler).toHaveBeenCalledOnce();
 });
 
-test('onMachineStop should call the handler when machine stops', async () => {
-  const manager = new PodmanConnection();
-  mocks.onDidUpdateContainerConnection.mockImplementation((f: (e: UpdateContainerConnectionEvent) => void) => {
-    setTimeout(() => {
-      f({
-        connection: {
-          type: 'podman',
+async function getListeners(): Promise<{
+  onDidUnregisterContainerConnection: (e: UnregisterContainerConnectionEvent) => void;
+  onDidRegisterContainerConnection: (e: RegisterContainerConnectionEvent) => void;
+  onDidUpdateContainerConnection: (e: UpdateContainerConnectionEvent) => void;
+  onDidUpdateProvider: (e: ProviderEvent) => void;
+  podmanConnection: PodmanConnection;
+}> {
+  const onDidUnregisterContainerConnectionPromise: Promise<(e: UnregisterContainerConnectionEvent) => void> =
+    new Promise(resolve => {
+      vi.mocked(provider.onDidUnregisterContainerConnection).mockImplementation(
+        (fn: (e: UnregisterContainerConnectionEvent) => void) => {
+          resolve(fn);
+          return {
+            dispose: vi.fn(),
+          };
         },
-        status: 'stopped',
-      } as UpdateContainerConnectionEvent);
-    }, 1);
-    return {
-      dispose: vi.fn(),
-    };
+      );
+    });
+
+  const onDidRegisterContainerConnectionPromise: Promise<(e: RegisterContainerConnectionEvent) => void> = new Promise(
+    resolve => {
+      vi.mocked(provider.onDidRegisterContainerConnection).mockImplementation(
+        (fn: (e: RegisterContainerConnectionEvent) => void) => {
+          resolve(fn);
+          return {
+            dispose: vi.fn(),
+          };
+        },
+      );
+    },
+  );
+
+  const onDidUpdateContainerConnectionPromise: Promise<(e: UpdateContainerConnectionEvent) => void> = new Promise(
+    resolve => {
+      vi.mocked(provider.onDidUpdateContainerConnection).mockImplementation(
+        (fn: (e: UpdateContainerConnectionEvent) => void) => {
+          resolve(fn);
+          return {
+            dispose: vi.fn(),
+          };
+        },
+      );
+    },
+  );
+
+  const onDidUpdateProviderPromise: Promise<(e: ProviderEvent) => void> = new Promise(resolve => {
+    vi.mocked(provider.onDidUpdateProvider).mockImplementation((fn: (e: ProviderEvent) => void) => {
+      resolve(fn);
+      return {
+        dispose: vi.fn(),
+      };
+    });
   });
-  manager.listenMachine();
-  const handler = vi.fn();
-  manager.onMachineStop(handler);
-  expect(handler).not.toHaveBeenCalledOnce();
-  await new Promise(resolve => setTimeout(resolve, 10));
-  expect(handler).toHaveBeenCalledOnce();
+
+  const manager = new PodmanConnection(webviewMock);
+  manager.init();
+
+  return {
+    onDidUnregisterContainerConnection: await onDidUnregisterContainerConnectionPromise,
+    onDidRegisterContainerConnection: await onDidRegisterContainerConnectionPromise,
+    onDidUpdateContainerConnection: await onDidUpdateContainerConnectionPromise,
+    onDidUpdateProvider: await onDidUpdateProviderPromise,
+    podmanConnection: manager,
+  };
+}
+
+describe('container connection event', () => {
+  test('onDidUnregisterContainerConnection should refresh and notify webview', async () => {
+    const { onDidUnregisterContainerConnection } = await getListeners();
+
+    // simulate onDidUnregisterContainerConnection event
+    onDidUnregisterContainerConnection({ providerId: 'podman' });
+
+    // ensure the webview has been notified
+    await vi.waitFor(() => {
+      expect(webviewMock.postMessage).toHaveBeenCalledWith({
+        id: Messages.MSG_PODMAN_CONNECTION_UPDATE,
+        body: [],
+      });
+    });
+  });
+
+  test('onDidUnregisterContainerConnection should fire PodmanConnectionEvent', async () => {
+    const { onDidUnregisterContainerConnection, podmanConnection } = await getListeners();
+
+    // register event listener
+    const onPodmanConnectionEventListenerMock = vi.fn();
+    podmanConnection.onPodmanConnectionEvent(onPodmanConnectionEventListenerMock);
+
+    // simulate onDidUnregisterContainerConnection event
+    onDidUnregisterContainerConnection({ providerId: 'podman' });
+
+    expect(onPodmanConnectionEventListenerMock).toHaveBeenCalledWith({
+      status: 'unregister',
+    });
+  });
+
+  test('onDidRegisterContainerConnection should notify webview', async () => {
+    const { onDidRegisterContainerConnection, podmanConnection } = await getListeners();
+
+    // simulate a onDidRegisterContainerConnection event
+    onDidRegisterContainerConnection({
+      providerId: 'podman',
+      connection: {
+        type: 'podman',
+        name: 'Podman Machine',
+        status: () => 'started',
+        endpoint: {
+          socketPath: './socket-path',
+        },
+      },
+    });
+
+    // ensure the webview has been notified
+    await vi.waitFor(() => {
+      expect(webviewMock.postMessage).toHaveBeenCalledWith({
+        id: Messages.MSG_PODMAN_CONNECTION_UPDATE,
+        body: [
+          {
+            providerId: 'podman',
+            name: 'Podman Machine',
+            status: 'started',
+            type: 'podman',
+            vmType: VMType.UNKNOWN,
+          },
+        ],
+      });
+    });
+
+    // ensure it has properly been added
+    expect(podmanConnection.getContainerProviderConnectionInfo().length).toBe(1);
+  });
+
+  test('onDidRegisterContainerConnection should fire PodmanConnectionEvent', async () => {
+    const { onDidRegisterContainerConnection, podmanConnection } = await getListeners();
+
+    // register event listener
+    const onPodmanConnectionEventListenerMock = vi.fn();
+    podmanConnection.onPodmanConnectionEvent(onPodmanConnectionEventListenerMock);
+
+    // simulate a onDidRegisterContainerConnection event
+    onDidRegisterContainerConnection({
+      providerId: 'podman',
+      connection: {
+        type: 'podman',
+        name: 'Podman Machine',
+        status: () => 'started',
+        endpoint: {
+          socketPath: './socket-path',
+        },
+      },
+    });
+
+    expect(onPodmanConnectionEventListenerMock).toHaveBeenCalledWith({
+      status: 'register',
+    });
+  });
+
+  test('onDidUpdateProvider should refresh and notify webview', async () => {
+    const { onDidUpdateProvider } = await getListeners();
+
+    // simulate onDidUnregisterContainerConnection event
+    onDidUpdateProvider({ name: 'podman', status: 'unknown', id: 'podman' });
+
+    // ensure the webview has been notified
+    await vi.waitFor(() => {
+      expect(webviewMock.postMessage).toHaveBeenCalledWith({
+        id: Messages.MSG_PODMAN_CONNECTION_UPDATE,
+        body: [],
+      });
+    });
+  });
+
+  test('onDidUpdateContainerConnection should refresh and notify webview', async () => {
+    const { onDidUpdateContainerConnection } = await getListeners();
+
+    // simulate onDidUnregisterContainerConnection event
+    onDidUpdateContainerConnection({
+      status: 'started',
+      providerId: 'podman',
+      connection: {
+        type: 'podman',
+        name: 'Podman Machine',
+        status: () => 'started',
+        endpoint: {
+          socketPath: './socket-path',
+        },
+      },
+    });
+
+    // ensure the webview has been notified
+    await vi.waitFor(() => {
+      expect(webviewMock.postMessage).toHaveBeenCalledWith({
+        id: Messages.MSG_PODMAN_CONNECTION_UPDATE,
+        body: [],
+      });
+    });
+  });
 });
 
 describe('getVMType', () => {
@@ -145,7 +333,7 @@ describe('getVMType', () => {
       stdout: '[]',
     } as unknown as RunResult);
 
-    const manager = new PodmanConnection();
+    const manager = new PodmanConnection(webviewMock);
     await expect(() => manager.getVMType('machine')).rejects.toThrowError(
       'podman machine list provided an empty array',
     );
@@ -156,7 +344,7 @@ describe('getVMType', () => {
       stdout: '[]',
     } as unknown as RunResult);
 
-    const manager = new PodmanConnection();
+    const manager = new PodmanConnection(webviewMock);
     expect(await manager.getVMType()).toBe(VMType.UNKNOWN);
   });
 
@@ -165,7 +353,7 @@ describe('getVMType', () => {
       stdout: '{}',
     } as unknown as RunResult);
 
-    const manager = new PodmanConnection();
+    const manager = new PodmanConnection(webviewMock);
     await expect(() => manager.getVMType()).rejects.toThrowError('podman machine list provided a malformed response');
   });
 
@@ -174,7 +362,7 @@ describe('getVMType', () => {
       stdout: '[{}, {}]',
     } as unknown as RunResult);
 
-    const manager = new PodmanConnection();
+    const manager = new PodmanConnection(webviewMock);
     await expect(() => manager.getVMType()).rejects.toThrowError(
       'name need to be provided when more than one podman machine is configured.',
     );
@@ -194,7 +382,7 @@ describe('getVMType', () => {
       ]),
     } as unknown as RunResult);
 
-    const manager = new PodmanConnection();
+    const manager = new PodmanConnection(webviewMock);
     expect(await manager.getVMType('machine-2')).toBe(VMType.APPLEHV);
   });
 
@@ -210,7 +398,7 @@ describe('getVMType', () => {
       ]),
     } as unknown as RunResult);
 
-    const manager = new PodmanConnection();
+    const manager = new PodmanConnection(webviewMock);
     await expect(() => manager.getVMType('potatoes')).rejects.toThrowError(
       'cannot find matching podman machine with name potatoes',
     );
@@ -226,7 +414,7 @@ describe('getVMType', () => {
       ]),
     } as unknown as RunResult);
 
-    const manager = new PodmanConnection();
+    const manager = new PodmanConnection(webviewMock);
     expect(await manager.getVMType()).toBe(VMType.WSL);
   });
 
@@ -239,7 +427,7 @@ describe('getVMType', () => {
       ]),
     } as unknown as RunResult);
 
-    const manager = new PodmanConnection();
+    const manager = new PodmanConnection(webviewMock);
     expect(await manager.getVMType()).toBe(vmtype);
   });
 });

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -16,15 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { process, EventEmitter, provider } from '@podman-desktop/api';
 import type {
+  ContainerProviderConnection,
   Disposable,
   Event,
   RegisterContainerConnectionEvent,
   UpdateContainerConnectionEvent,
   Webview,
-  ContainerProviderConnection,
 } from '@podman-desktop/api';
+import { EventEmitter, process, provider } from '@podman-desktop/api';
 import type { MachineJSON } from '../utils/podman';
 import { getPodmanCli } from '../utils/podman';
 import { VMType } from '@shared/src/models/IPodman';
@@ -151,22 +151,12 @@ export class PodmanConnection extends Publisher<ContainerProviderConnectionInfo[
   }
 
   protected parseVMType(vmtype: string | undefined): VMType {
-    switch (vmtype) {
-      // mac
-      case VMType.APPLEHV:
-        return VMType.APPLEHV;
-      case VMType.QEMU:
-        return VMType.QEMU;
-      case VMType.LIBKRUN:
-        return VMType.LIBKRUN;
-      // windows
-      case VMType.HYPERV:
-        return VMType.HYPERV;
-      case VMType.WSL:
-        return VMType.WSL;
-      default:
-        return VMType.UNKNOWN;
+    if (!vmtype) return VMType.UNKNOWN;
+    const type = VMType[vmtype.toUpperCase() as keyof typeof VMType];
+    if (type === undefined) {
+      return VMType.UNKNOWN;
     }
+    return type;
   }
 
   /**

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -16,94 +16,163 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import {
-  type Disposable,
-  process,
-  provider,
-  type RegisterContainerConnectionEvent,
-  type UpdateContainerConnectionEvent,
+import { process, EventEmitter, provider } from '@podman-desktop/api';
+import type {
+  Disposable,
+  Event,
+  RegisterContainerConnectionEvent,
+  UpdateContainerConnectionEvent,
+  Webview,
+  ContainerProviderConnection,
 } from '@podman-desktop/api';
 import type { MachineJSON } from '../utils/podman';
-import { getFirstRunningPodmanConnection, getPodmanCli } from '../utils/podman';
+import { getPodmanCli } from '../utils/podman';
 import { VMType } from '@shared/src/models/IPodman';
+import { Publisher } from '../utils/Publisher';
+import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+import { Messages } from '@shared/Messages';
 
-export type startupHandle = () => void;
-export type machineStartHandle = () => void;
-export type machineStopHandle = () => void;
+export interface PodmanConnectionEvent {
+  status: 'stopped' | 'started' | 'unregister' | 'register';
+}
 
-export class PodmanConnection implements Disposable {
-  #firstFound = false;
-  #toExecuteAtStartup: startupHandle[] = [];
-  #toExecuteAtMachineStop: machineStopHandle[] = [];
-  #toExecuteAtMachineStart: machineStartHandle[] = [];
+export class PodmanConnection extends Publisher<ContainerProviderConnectionInfo[]> implements Disposable {
+  // Map of providerId with corresponding connections
+  #providers: Map<string, ContainerProviderConnection[]>;
+  #disposables: Disposable[];
 
-  #onEventDisposable: Disposable | undefined;
+  private readonly _onPodmanConnectionEvent = new EventEmitter<PodmanConnectionEvent>();
+  readonly onPodmanConnectionEvent: Event<PodmanConnectionEvent> = this._onPodmanConnectionEvent.event;
+
+  constructor(webview: Webview) {
+    super(webview, Messages.MSG_PODMAN_CONNECTION_UPDATE, () => this.getContainerProviderConnectionInfo());
+    this.#providers = new Map();
+    this.#disposables = [];
+  }
+
+  /**
+   * This method flatten the
+   */
+  getContainerProviderConnectionInfo(): ContainerProviderConnectionInfo[] {
+    const output: ContainerProviderConnectionInfo[] = [];
+
+    for (const [providerId, connections] of Array.from(this.#providers.entries())) {
+      output.push(
+        ...connections.map(
+          (connection): ContainerProviderConnectionInfo => ({
+            providerId: providerId,
+            name: connection.name,
+            vmType: this.parseVMType(connection.vmType),
+            type: 'podman',
+            status: connection.status(),
+          }),
+        ),
+      );
+    }
+
+    return output;
+  }
 
   init(): void {
-    this.listenRegistration();
-    this.listenMachine();
+    // setup listeners
+    this.listen();
+
+    this.refreshProviders();
   }
 
   dispose(): void {
-    this.#onEventDisposable?.dispose();
+    this.#disposables.forEach(disposable => disposable.dispose());
   }
 
-  listenRegistration() {
-    // In case the extension has not yet registered, we listen for new registrations
-    // and retain the first started podman provider
-    const disposable = provider.onDidRegisterContainerConnection((e: RegisterContainerConnectionEvent) => {
-      if (e.connection.type !== 'podman' || e.connection.status() !== 'started') {
-        return;
-      }
-      if (this.#firstFound) {
-        return;
-      }
-      this.#firstFound = true;
-      for (const f of this.#toExecuteAtStartup) {
-        f();
-      }
-      this.#toExecuteAtStartup = [];
-      disposable.dispose();
-    });
+  protected refreshProviders(): void {
+    // clear all providers
+    this.#providers.clear();
 
-    // In case at least one extension has already registered, we get one started podman provider
-    const engine = getFirstRunningPodmanConnection();
-    if (engine) {
-      disposable.dispose();
-      this.#firstFound = true;
-    }
+    const providers = provider.getContainerConnections();
+
+    // register the podman container connection
+    providers
+      .filter(({ connection }) => connection.type === 'podman')
+      .forEach(({ providerId, connection }) => {
+        this.#providers.set(providerId, [connection, ...(this.#providers.get(providerId) ?? [])]);
+      });
+
+    // notify
+    this.notify();
   }
 
-  // startupSubscribe registers f to be executed when a podman container provider
-  // registers, or immediately if already registered
-  startupSubscribe(f: startupHandle): void {
-    if (this.#firstFound) {
-      f();
-    } else {
-      this.#toExecuteAtStartup.push(f);
-    }
-  }
+  private listen() {
+    // capture unregister event
+    this.#disposables.push(
+      provider.onDidUnregisterContainerConnection(() => {
+        this.refreshProviders();
+        this._onPodmanConnectionEvent.fire({
+          status: 'unregister',
+        });
+      }),
+    );
 
-  listenMachine() {
-    provider.onDidUpdateContainerConnection((e: UpdateContainerConnectionEvent) => {
-      if (e.connection.type !== 'podman') {
-        return;
-      }
-      if (e.status === 'stopped') {
-        for (const f of this.#toExecuteAtMachineStop) {
-          f();
+    this.#disposables.push(
+      provider.onDidRegisterContainerConnection(({ providerId, connection }: RegisterContainerConnectionEvent) => {
+        if (connection.type !== 'podman') {
+          return;
         }
-      } else if (e.status === 'started') {
-        for (const f of this.#toExecuteAtMachineStart) {
-          f();
+
+        // update connection
+        this.#providers.set(providerId, [connection, ...(this.#providers.get(providerId) ?? [])]);
+        this.notify();
+        this._onPodmanConnectionEvent.fire({
+          status: 'register',
+        });
+      }),
+    );
+
+    this.#disposables.push(
+      provider.onDidUpdateContainerConnection(({ status }: UpdateContainerConnectionEvent) => {
+        switch (status) {
+          case 'started':
+          case 'stopped':
+            this._onPodmanConnectionEvent.fire({
+              status: status,
+            });
+            this.notify();
+            break;
+          default:
+            break;
         }
-      }
-    });
+      }),
+    );
+
+    this.#disposables.push(
+      provider.onDidUpdateProvider(() => {
+        this.refreshProviders();
+      }),
+    );
+  }
+
+  protected parseVMType(vmtype: string | undefined): VMType {
+    switch (vmtype) {
+      // mac
+      case VMType.APPLEHV:
+        return VMType.APPLEHV;
+      case VMType.QEMU:
+        return VMType.QEMU;
+      case VMType.LIBKRUN:
+        return VMType.LIBKRUN;
+      // windows
+      case VMType.HYPERV:
+        return VMType.HYPERV;
+      case VMType.WSL:
+        return VMType.WSL;
+      default:
+        return VMType.UNKNOWN;
+    }
   }
 
   /**
    * Get the VMType of the podman machine
    * @param name the machine name, from {@link ContainerProviderConnection}
+   * @deprecated should uses the `getContainerProviderConnectionInfo()`
    */
   async getVMType(name?: string): Promise<VMType> {
     const { stdout } = await process.exec(getPodmanCli(), ['machine', 'list', '--format', 'json']);
@@ -124,29 +193,6 @@ export class PodmanConnection implements Disposable {
       output = parsed[0];
     }
 
-    switch (output.VMType) {
-      // mac
-      case VMType.APPLEHV:
-        return VMType.APPLEHV;
-      case VMType.QEMU:
-        return VMType.QEMU;
-      case VMType.LIBKRUN:
-        return VMType.LIBKRUN;
-      // windows
-      case VMType.HYPERV:
-        return VMType.HYPERV;
-      case VMType.WSL:
-        return VMType.WSL;
-      default:
-        return VMType.UNKNOWN;
-    }
-  }
-
-  onMachineStart(f: machineStartHandle) {
-    this.#toExecuteAtMachineStart.push(f);
-  }
-
-  onMachineStop(f: machineStopHandle) {
-    this.#toExecuteAtMachineStop.push(f);
+    return this.parseVMType(output.VMType);
   }
 }

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -91,6 +91,8 @@ vi.mock('@podman-desktop/api', async () => {
     provider: {
       onDidRegisterContainerConnection: vi.fn(),
       onDidUpdateContainerConnection: vi.fn(),
+      onDidUnregisterContainerConnection: vi.fn(),
+      onDidUpdateProvider: vi.fn(),
       getContainerConnections: mocks.getContainerConnections,
     },
     commands: {

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -166,7 +166,7 @@ export class Studio {
     /**
      * The podman connection class is responsible for podman machine events (start/stop)
      */
-    this.#podmanConnection = new PodmanConnection();
+    this.#podmanConnection = new PodmanConnection(this.#panel.webview);
     this.#podmanConnection.init();
     this.#extensionContext.subscriptions.push(this.#podmanConnection);
 

--- a/packages/shared/Messages.ts
+++ b/packages/shared/Messages.ts
@@ -29,4 +29,5 @@ export enum Messages {
   MSG_GPUS_UPDATE = 'gpus-update',
   MSG_INFERENCE_PROVIDER_UPDATE = 'inference-provider-update',
   MSG_CONFIGURATION_UPDATE = 'configuration-update',
+  MSG_PODMAN_CONNECTION_UPDATE = 'podman-connecting-update',
 }

--- a/packages/shared/src/models/IContainerConnectionInfo.ts
+++ b/packages/shared/src/models/IContainerConnectionInfo.ts
@@ -15,6 +15,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { VMType } from './IPodman';
+
+export interface ContainerProviderConnectionInfo {
+  providerId: string;
+  name: string;
+  type: 'podman'; // we only support podman
+  status: 'started' | 'stopped' | 'starting' | 'stopping' | 'unknown';
+  vmType: VMType;
+}
 
 export type ContainerConnectionInfo =
   | RunningContainerConnection


### PR DESCRIPTION
### What does this PR do?

Makes the `PodmanConnection` extend the Publisher class to exposes the ContainerProviderConnections.

### Notable change

- Refactoring the `PodmanConnection` to keep track of the Connections available
- Adding onDidUnregisterContainerConnection listener 
- Adding onDidUpdateProvider listener
- Replacing manual type listener by `Event` and `EventEmitter`

### Screenshot / video of UI


https://github.com/user-attachments/assets/c151c8c7-2ac5-4281-9a4b-cbc988088f31

We are still not getting the events when the user is stopping the machine from the terminal.

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1520

### How to test this PR?

- [x] unit tests has been added (a lot)