### PR TITLE
chore(Inference): centralise inference images

### DIFF
--- a/packages/backend/src/assets/inference-images.json
+++ b/packages/backend/src/assets/inference-images.json
@@ -1,0 +1,10 @@
+{
+  "whispercpp": {
+    "default": "ghcr.io/containers/whispercpp@sha256:6c529656529da7aba851b6ab2d0653f23b77b9ca3c11cb46db47ff6dbd6d5e7c"
+  },
+  "llamacpp": {
+    "default": "ghcr.io/containers/llamacpp_python@sha256:b2402f52b757fb2a1cc2b3075f9fb1cb4082a81fbae37631499895619728fdd3",
+    "cuda": "ghcr.io/containers/llamacpp_python_cuda@sha256:eda2f13b0fa5b14e0b05414156f48fbf1f4a6a50517169bec25b83dc66f18f20",
+    "vulkan": "quay.io/ai-lab/llamacpp-python-vulkan@sha256:7e7d15086ec33d0547125a0afb479d91246a67b6d0681ae17260ea7665c333a0"
+  }
+}

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -28,11 +28,7 @@ import { GPUVendor, type IGPUInfo } from '@shared/src/models/IGPUInfo';
 import { VMType } from '@shared/src/models/IPodman';
 import type { PodmanConnection } from '../../managers/podmanConnection';
 import type { ConfigurationRegistry } from '../../registries/ConfigurationRegistry';
-
-export const LLAMA_CPP_CPU = 'ghcr.io/containers/llamacpp_python:latest';
-export const LLAMA_CPP_CUDA = 'ghcr.io/containers/llamacpp_python_cuda:latest';
-
-export const LLAMA_CPP_MAC_GPU = 'quay.io/ai-lab/llamacpp-python-vulkan:latest';
+import { llamacpp } from '../../assets/inference-images.json';
 
 export const SECOND: number = 1_000_000_000;
 
@@ -237,16 +233,15 @@ export class LlamaCppPython extends InferenceProvider {
   protected getLlamaCppInferenceImage(vmType: VMType, gpu?: IGPUInfo): string {
     switch (vmType) {
       case VMType.WSL:
-        return gpu?.vendor === GPUVendor.NVIDIA ? LLAMA_CPP_CUDA : LLAMA_CPP_CPU;
+        return gpu?.vendor === GPUVendor.NVIDIA ? llamacpp.cuda : llamacpp.default;
       case VMType.LIBKRUN:
-        return gpu ? LLAMA_CPP_MAC_GPU : LLAMA_CPP_CPU;
+        return gpu ? llamacpp.vulkan : llamacpp.default;
       // no GPU support
       case VMType.QEMU:
       case VMType.APPLEHV:
       case VMType.HYPERV:
-        return LLAMA_CPP_CPU;
       case VMType.UNKNOWN:
-        return LLAMA_CPP_CPU;
+        return llamacpp.default;
     }
   }
 }

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -23,9 +23,7 @@ import type { InferenceServerConfig } from '@shared/src/models/InferenceServerCo
 import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { MountConfig } from '@podman-desktop/api';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
-
-export const WHISPER_CPP_CPU =
-  'ghcr.io/containers/whispercpp@sha256:6c529656529da7aba851b6ab2d0653f23b77b9ca3c11cb46db47ff6dbd6d5e7c';
+import { whispercpp } from '../../assets/inference-images.json';
 
 export class WhisperCpp extends InferenceProvider {
   constructor(taskRegistry: TaskRegistry) {
@@ -56,7 +54,7 @@ export class WhisperCpp extends InferenceProvider {
       [LABEL_INFERENCE_SERVER]: JSON.stringify(config.modelsInfo.map(model => model.id)),
     };
 
-    const imageInfo = await this.pullImage(config.providerId, config.image ?? WHISPER_CPP_CPU, labels);
+    const imageInfo = await this.pullImage(config.providerId, config.image ?? whispercpp.default, labels);
     const envs: string[] = [`MODEL_PATH=/models/${modelInfo.file.file}`, 'HOST=0.0.0.0', 'PORT=8000'];
 
     const mounts: MountConfig = [


### PR DESCRIPTION
### What does this PR do?

Centralise the inference images to a single file `inference-images.json` to ease updating and maintenance.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1516

### How to test this PR?

- [x] unit tests has been provided


**Manually**

Create an inference server, check the architecture of the image match the architecture of the host.