### PR TITLE
feat(InferenceManager): handle podman connections

### DIFF
--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -267,7 +267,7 @@ export class Studio {
       ),
     );
     this.#extensionContext.subscriptions.push(
-      this.#inferenceProviderRegistry.register(new WhisperCpp(this.#taskRegistry)),
+      this.#inferenceProviderRegistry.register(new WhisperCpp(this.#taskRegistry, this.#podmanConnection)),
     );
 
     /**

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -21,6 +21,7 @@ import { getFreeRandomPort } from './ports';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import type { InferenceServer, InferenceServerStatus } from '@shared/src/models/IInference';
 import { InferenceType } from '@shared/src/models/IInference';
+import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 
 vi.mock('./ports', () => ({
   getFreeRandomPort: vi.fn(),
@@ -46,14 +47,17 @@ describe('withDefaultConfiguration', () => {
     expect(result.port).toBe(8888);
     expect(result.image).toBe(undefined);
     expect(result.labels).toStrictEqual({});
-    expect(result.providerId).toBe(undefined);
+    expect(result.connection).toBe(undefined);
   });
 
   test('expect no default values', async () => {
+    const connectionMock = {
+      name: 'Dummy Connection',
+    } as unknown as ContainerProviderConnectionInfo;
     const result = await withDefaultConfiguration({
       modelsInfo: [{ id: 'dummyId' } as unknown as ModelInfo],
       port: 9999,
-      providerId: 'dummyProviderId',
+      connection: connectionMock,
       image: 'random-image',
       labels: { hello: 'world' },
     });
@@ -63,7 +67,7 @@ describe('withDefaultConfiguration', () => {
     expect(result.port).toBe(9999);
     expect(result.image).toBe('random-image');
     expect(result.labels).toStrictEqual({ hello: 'world' });
-    expect(result.providerId).toBe('dummyProviderId');
+    expect(result.connection).toBe(connectionMock);
   });
 });
 

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -20,8 +20,6 @@ import {
   type ContainerProviderConnection,
   type ImageInfo,
   type ListImagesOptions,
-  provider,
-  type ProviderContainerConnection,
   type PullEvent,
 } from '@podman-desktop/api';
 import type { CreationInferenceServerOptions, InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
@@ -30,33 +28,6 @@ import { type InferenceServer, InferenceType } from '@shared/src/models/IInferen
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export const LABEL_INFERENCE_SERVER: string = 'ai-lab-inference-server';
-
-/**
- * Return container connection provider
- */
-export function getProviderContainerConnection(providerId?: string): ProviderContainerConnection {
-  // Get started providers
-  const providers = provider
-    .getContainerConnections()
-    .filter(connection => connection.connection.status() === 'started');
-
-  if (providers.length === 0) throw new Error('no engine started could be find.');
-
-  let output: ProviderContainerConnection | undefined = undefined;
-
-  // If we expect a specific engine
-  if (providerId !== undefined) {
-    output = providers.find(engine => engine.providerId === providerId);
-  } else {
-    // Have a preference for a podman engine
-    output = providers.find(engine => engine.connection.type === 'podman');
-    if (output === undefined) {
-      output = providers[0];
-    }
-  }
-  if (output === undefined) throw new Error('cannot find any started container provider.');
-  return output;
-}
 
 /**
  * Given an image name, it will return the ImageInspectInfo corresponding. Will raise an error if not found.
@@ -107,7 +78,7 @@ export async function withDefaultConfiguration(
     image: options.image,
     labels: options.labels || {},
     modelsInfo: options.modelsInfo,
-    providerId: options.providerId,
+    connection: options.connection,
     inferenceProvider: options.inferenceProvider,
     gpuLayers: options.gpuLayers !== undefined ? options.gpuLayers : -1,
   };

--- a/packages/backend/src/workers/provider/WhisperCpp.spec.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.spec.ts
@@ -21,9 +21,10 @@ import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { WhisperCpp } from './WhisperCpp';
 import type { InferenceServer } from '@shared/src/models/IInference';
 import { InferenceType } from '@shared/src/models/IInference';
-import type { ContainerProviderConnection, ProviderContainerConnection, ImageInfo } from '@podman-desktop/api';
+import type { ContainerProviderConnection, ImageInfo } from '@podman-desktop/api';
 import { containerEngine } from '@podman-desktop/api';
-import { getImageInfo, getProviderContainerConnection } from '../../utils/inferenceUtils';
+import { getImageInfo } from '../../utils/inferenceUtils';
+import type { PodmanConnection } from '../../managers/podmanConnection';
 
 vi.mock('@podman-desktop/api', () => ({
   containerEngine: {
@@ -37,13 +38,10 @@ vi.mock('../../utils/inferenceUtils', () => ({
   LABEL_INFERENCE_SERVER: 'ai-lab-inference-server',
 }));
 
-const DummyProviderContainerConnection: ProviderContainerConnection = {
-  providerId: 'dummy-provider-id',
-  connection: {
-    name: 'dummy-provider-connection',
-    type: 'podman',
-  } as unknown as ContainerProviderConnection,
-};
+const connectionMock: ContainerProviderConnection = {
+  name: 'dummy-provider-connection',
+  type: 'podman',
+} as unknown as ContainerProviderConnection;
 
 const DummyImageInfo: ImageInfo = {
   Id: 'dummy-image-id',
@@ -55,8 +53,12 @@ const taskRegistry: TaskRegistry = {
   updateTask: vi.fn(),
 } as unknown as TaskRegistry;
 
+const podmanConnection: PodmanConnection = {
+  findRunningContainerProviderConnection: vi.fn(),
+} as unknown as PodmanConnection;
+
 beforeEach(() => {
-  vi.mocked(getProviderContainerConnection).mockReturnValue(DummyProviderContainerConnection);
+  vi.mocked(podmanConnection.findRunningContainerProviderConnection).mockReturnValue(connectionMock);
   vi.mocked(taskRegistry.createTask).mockReturnValue({ id: 'dummy-task-id', name: '', labels: {}, state: 'loading' });
 
   vi.mocked(getImageInfo).mockResolvedValue(DummyImageInfo);
@@ -67,7 +69,7 @@ beforeEach(() => {
 });
 
 test('provider requires at least one model', async () => {
-  const provider = new WhisperCpp(taskRegistry);
+  const provider = new WhisperCpp(taskRegistry, podmanConnection);
 
   await expect(() => {
     return provider.perform({
@@ -79,7 +81,7 @@ test('provider requires at least one model', async () => {
 });
 
 test('provider requires a downloaded model', async () => {
-  const provider = new WhisperCpp(taskRegistry);
+  const provider = new WhisperCpp(taskRegistry, podmanConnection);
 
   await expect(() => {
     return provider.perform({
@@ -98,7 +100,7 @@ test('provider requires a downloaded model', async () => {
 });
 
 test('provider requires a model with backend type Whisper', async () => {
-  const provider = new WhisperCpp(taskRegistry);
+  const provider = new WhisperCpp(taskRegistry, podmanConnection);
 
   await expect(() => {
     return provider.perform({
@@ -124,7 +126,7 @@ test('provider requires a model with backend type Whisper', async () => {
 });
 
 test('custom image in inference server config should overwrite default', async () => {
-  const provider = new WhisperCpp(taskRegistry);
+  const provider = new WhisperCpp(taskRegistry, podmanConnection);
 
   const model = {
     id: 'whisper-cpp',
@@ -147,15 +149,11 @@ test('custom image in inference server config should overwrite default', async (
     modelsInfo: [model],
   });
 
-  expect(getImageInfo).toHaveBeenCalledWith(
-    DummyProviderContainerConnection.connection,
-    'localhost/whisper-cpp:custom',
-    expect.any(Function),
-  );
+  expect(getImageInfo).toHaveBeenCalledWith(connectionMock, 'localhost/whisper-cpp:custom', expect.any(Function));
 });
 
 test('provider should propagate labels', async () => {
-  const provider = new WhisperCpp(taskRegistry);
+  const provider = new WhisperCpp(taskRegistry, podmanConnection);
 
   const model = {
     id: 'whisper-cpp',

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { ModelInfo } from './IModelInfo';
+import type { ContainerProviderConnectionInfo } from './IContainerConnectionInfo';
 
 export type CreationInferenceServerOptions = Partial<InferenceServerConfig> & { modelsInfo: ModelInfo[] };
 
@@ -25,9 +26,9 @@ export interface InferenceServerConfig {
    */
   port: number;
   /**
-   * The identifier of the container provider to use
+   * The connection info to use
    */
-  providerId?: string;
+  connection?: ContainerProviderConnectionInfo;
   /**
    * The name of the inference provider to use
    */


### PR DESCRIPTION
### What does this PR do?

Same as https://github.com/containers/podman-desktop-extension-ai-lab/pull/1528 but for Inference Servers 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1529
Required for https://github.com/containers/podman-desktop-extension-ai-lab/issues/1462

### How to test this PR?

- [x] unit tests has been provided