### PR TITLE
feat: adding container provider connection select

### DIFF
--- a/packages/frontend/src/lib/select/ContainerProviderConnectionSelect.spec.ts
+++ b/packages/frontend/src/lib/select/ContainerProviderConnectionSelect.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { fireEvent, render, within } from '@testing-library/svelte';
+import ContainerProviderConnectionSelect from '/@/lib/select/ContainerProviderConnectionSelect.svelte';
+import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+import { VMType } from '@shared/src/models/IPodman';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // mock scrollIntoView
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+const wslConnection: ContainerProviderConnectionInfo = {
+  name: 'Machine 1',
+  type: 'podman',
+  status: 'started',
+  providerId: 'podman',
+  vmType: VMType.WSL,
+};
+
+const qemuConnection: ContainerProviderConnectionInfo = {
+  name: 'Machine 2',
+  type: 'podman',
+  status: 'started',
+  providerId: 'podman',
+  vmType: VMType.QEMU,
+};
+
+test('Should list all container provider connections', async () => {
+  const { container } = render(ContainerProviderConnectionSelect, {
+    value: undefined,
+    containerProviderConnections: [wslConnection, qemuConnection],
+  });
+
+  // first get the select input
+  const input = within(container).getByLabelText('Select Container Engine');
+  await fireEvent.pointerUp(input); // they are using the pointer up event instead of click.
+
+  // get all options available
+  const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
+  // ensure we have two options
+  expect(items.length).toBe(2);
+  expect(items[0]).toHaveTextContent(wslConnection.name);
+  expect(items[1]).toHaveTextContent(qemuConnection.name);
+});
+
+test('default value should be visible', async () => {
+  const { container } = render(ContainerProviderConnectionSelect, {
+    value: qemuConnection,
+    containerProviderConnections: [wslConnection, qemuConnection],
+  });
+
+  // first get the select input
+  const select = within(container).getByText(qemuConnection.name);
+  expect(select).toBeDefined();
+});

--- a/packages/frontend/src/lib/select/ContainerProviderConnectionSelect.svelte
+++ b/packages/frontend/src/lib/select/ContainerProviderConnectionSelect.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+import Select from '/@/lib/select/Select.svelte';
+
+export let disabled: boolean = false;
+import { VMType } from '@shared/src/models/IPodman';
+
+/**
+ * Current value selected
+ */
+export let value: ContainerProviderConnectionInfo | undefined = undefined;
+export let containerProviderConnections: ContainerProviderConnectionInfo[] = [];
+/**
+ * Handy mechanism to provide the mandatory property `label` and `value` to the Select component
+ */
+let selected: (ContainerProviderConnectionInfo & { label: string; value: string }) | undefined = undefined;
+$: {
+  // let's select a default model
+  if (value) {
+    selected = { ...value, label: value.name, value: value.name };
+  }
+}
+</script>
+
+<Select
+  label="Select Container Engine"
+  name="select-container-engine"
+  disabled={disabled}
+  bind:value={selected}
+  onchange={nValue => (value = nValue)}
+  placeholder="Select container provider to use"
+  items={containerProviderConnections.map(containerProviderConnection => ({
+    ...containerProviderConnection,
+    value: containerProviderConnection.name,
+    label: containerProviderConnection.name,
+  }))}>
+  <div slot="item" let:item>
+    <div class="flex items-center">
+      <div class="grow">
+        <span>{item.name}</span>
+      </div>
+
+      {#if item.vmType !== VMType.UNKNOWN}
+        <div>({item.vmType})</div>
+      {/if}
+    </div>
+  </div>
+</Select>

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -29,7 +29,10 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { writable } from 'svelte/store';
 import { router } from 'tinro';
 import * as connectionUtils from '../utils/connectionUtils';
-import type { ContainerConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+import type {
+  ContainerConnectionInfo,
+  ContainerProviderConnectionInfo,
+} from '@shared/src/models/IContainerConnectionInfo';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
@@ -53,6 +56,7 @@ const mocks = vi.hoisted(() => {
         return () => {};
       },
     },
+    getContainerConnectionInfoMock: vi.fn<() => ContainerProviderConnectionInfo[]>(),
   };
 });
 
@@ -60,6 +64,15 @@ vi.mock('../stores/inferenceServers', () => ({
   inferenceServers: {
     subscribe: (f: (msg: any) => void) => {
       f(mocks.getInferenceServersMock());
+      return () => {};
+    },
+  },
+}));
+
+vi.mock('../stores/containerProviderConnections', () => ({
+  containerProviderConnections: {
+    subscribe: (f: (msg: any) => void) => {
+      f(mocks.getContainerConnectionInfoMock());
       return () => {};
     },
   },
@@ -88,6 +101,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   mocks.modelsInfoSubscribeMock.mockReturnValue([]);
   mocks.tasksSubscribeMock.mockReturnValue([]);
+  mocks.getContainerConnectionInfoMock.mockReturnValue([]);
 
   vi.mocked(studioClient.requestCreateInferenceServer).mockResolvedValue('dummyTrackingId');
   vi.mocked(studioClient.getHostFreePort).mockResolvedValue(8888);

--- a/packages/frontend/src/pages/StartRecipe.spec.ts
+++ b/packages/frontend/src/pages/StartRecipe.spec.ts
@@ -26,6 +26,7 @@ import { InferenceType } from '@shared/src/models/IInference';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import type { Task } from '@shared/src/models/ITask';
 import { router } from 'tinro';
+import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -37,6 +38,8 @@ const mocks = vi.hoisted(() => {
     getLocalRepositoriesMock: vi.fn(),
     // catalog store
     getCatalogMock: vi.fn(),
+    // containerProviderConnectionInfo store
+    getContainerConnectionInfoMock: vi.fn<() => ContainerProviderConnectionInfo[]>(),
   };
 });
 
@@ -45,6 +48,15 @@ vi.mock('../stores/localRepositories', () => ({
   localRepositories: {
     subscribe: (f: (msg: any) => void) => {
       f(mocks.getLocalRepositoriesMock());
+      return () => {};
+    },
+  },
+}));
+
+vi.mock('../stores/containerProviderConnections', () => ({
+  containerProviderConnections: {
+    subscribe: (f: (msg: any) => void) => {
+      f(mocks.getContainerConnectionInfoMock());
       return () => {};
     },
   },
@@ -134,6 +146,9 @@ beforeEach(() => {
   mocks.getCatalogMock.mockReturnValue({
     recipes: [fakeRecipe],
   });
+
+  // mock no ContainerConnectionInfo
+  mocks.getContainerConnectionInfoMock.mockReturnValue([]);
 
   mocks.getModelsInfoMock.mockReturnValue([fakeRecommendedModel, fakeRemoteModel]);
 

--- a/packages/frontend/src/stores/containerProviderConnections.ts
+++ b/packages/frontend/src/stores/containerProviderConnections.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { RPCReadable } from '/@/stores/rpcReadable';
+import { Messages } from '@shared/Messages';
+import { studioClient } from '/@/utils/client';
+import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+
+export const containerProviderConnections = RPCReadable<ContainerProviderConnectionInfo[]>(
+  [],
+  [Messages.MSG_PODMAN_CONNECTION_UPDATE],
+  studioClient.getContainerProviderConnection,
+);


### PR DESCRIPTION
### What does this PR do?

Allowing to select the connection the user want to use (if multiple exists) to deploy the Inference Server or Application.

Design is inspired from the `Pull Image` page of Podman Desktop

![image](https://github.com/user-attachments/assets/838967fe-00b9-43c7-ac0f-93d17ee130eb)

### Screenshot / video of UI

| Single connection | Multiple **started** connections |
| --- | ---- |
| ![image](https://github.com/user-attachments/assets/5ef73ef4-612b-417d-a86f-8b5286be07e5) | ![image](https://github.com/user-attachments/assets/cb8124c3-d542-4811-9db6-c25c036810a4) |
| ![image](https://github.com/user-attachments/assets/3735dc26-fae7-4431-ae6f-d149626c6346) | ![image](https://github.com/user-attachments/assets/d0ef26fc-c802-4bd6-98d3-39e09e2cec8e) |

**Demo**

https://github.com/user-attachments/assets/916d0533-7f33-4270-97f6-e6461c742006

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1462

> [!CAUTION]
> Requires https://github.com/containers/podman-desktop-extension-ai-lab/pull/1535 for windows

### How to test this PR?

- [x] unit tests has been added

**How to test**

- Start several podman machines
- Go to the  `Create Service` page
- assert all **started** machines are visible
- Select the target machine and create 
- assert `pdoman --connection=<machine-name> container ls` is listed