### PR TITLE
fix: wrong VMtype returned by Podman Desktop causes inference servers…

### DIFF
--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -156,7 +156,7 @@ export class PodmanConnection extends Publisher<ContainerProviderConnectionInfo[
 
   protected parseVMType(vmtype: string | undefined): VMType {
     if (!vmtype) return VMType.UNKNOWN;
-    const type = VMType[vmtype.toUpperCase() as keyof typeof VMType];
+    const type = Object.values(VMType).find(s => s === vmtype);
     if (type === undefined) {
       return VMType.UNKNOWN;
     }

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -250,12 +250,10 @@ export class LlamaCppPython extends InferenceProvider {
       case VMType.WSL:
         return gpu?.vendor === GPUVendor.NVIDIA ? llamacpp.cuda : llamacpp.default;
       case VMType.LIBKRUN:
+      case VMType.LIBKRUN_LABEL:
         return gpu ? llamacpp.vulkan : llamacpp.default;
       // no GPU support
-      case VMType.QEMU:
-      case VMType.APPLEHV:
-      case VMType.HYPERV:
-      case VMType.UNKNOWN:
+      default:
         return llamacpp.default;
     }
   }

--- a/packages/shared/src/models/IPodman.ts
+++ b/packages/shared/src/models/IPodman.ts
@@ -19,8 +19,10 @@
 export enum VMType {
   WSL = 'wsl',
   LIBKRUN = 'libkrun',
+  LIBKRUN_LABEL = 'GPU enabled (LibKrun)',
   QEMU = 'qemu',
   APPLEHV = 'applehv',
+  APPLEHV_LABEL = 'default (Apple HyperVisor)',
   HYPERV = 'hyperv',
   UNKNOWN = 'unknown',
 }


### PR DESCRIPTION
…… (#1549)

* fix: wrong VMtype returned by Podman Desktop causes inference servers start failure



* fix: fix failing unit tests



---------

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->