### PR TITLE
feat: make api port configurable

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,13 @@
           "type": "boolean",
           "default": false,
           "description": "Experimental GPU support for inference servers"
+        },
+        "ai-lab.apiPort": {
+          "type": "number",
+          "default": 10434,
+          "minimum": 1024,
+          "maximum": 65535,
+          "description": "Port on which the API is listening (requires restart of extension)"
         }
       }
     },

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -21,7 +21,9 @@ import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfig
 import { Messages } from '@shared/Messages';
 import path from 'node:path';
 
-const CONFIGURATION_SECTIONS: string[] = ['ai-lab.models.path', 'ai-lab.experimentalGPU'];
+const CONFIGURATION_SECTIONS: string[] = ['ai-lab.models.path', 'ai-lab.experimentalGPU', 'ai-lab.apiPort'];
+
+const API_PORT_DEFAULT = 10434;
 
 export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> implements Disposable {
   #configuration: Configuration;
@@ -40,6 +42,7 @@ export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> imp
     return {
       modelsPath: this.getModelsPath(),
       experimentalGPU: this.#configuration.get<boolean>('experimentalGPU') ?? false,
+      apiPort: this.#configuration.get<number>('apiPort') ?? API_PORT_DEFAULT,
     };
   }
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -328,7 +328,7 @@ export class Studio {
     // Register the instance
     this.#rpcExtension.registerInstance<StudioApiImpl>(StudioApiImpl, this.#studioApi);
 
-    const apiServer = new ApiServer(this.#extensionContext, this.#modelsManager);
+    const apiServer = new ApiServer(this.#extensionContext, this.#modelsManager, this.#configurationRegistry);
     await apiServer.init();
     this.#extensionContext.subscriptions.push(apiServer);
   }

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -95,6 +95,7 @@ beforeEach(() => {
   vi.mocked(configurationRegistry.getExtensionConfiguration).mockReturnValue({
     experimentalGPU: false,
     modelsPath: 'model-path',
+    apiPort: 10434,
   });
   vi.mocked(podmanConnection.findRunningContainerProviderConnection).mockReturnValue(dummyConnection);
   vi.mocked(podmanConnection.getContainerProviderConnection).mockReturnValue(dummyConnection);
@@ -271,6 +272,7 @@ describe('perform', () => {
     vi.mocked(configurationRegistry.getExtensionConfiguration).mockReturnValue({
       experimentalGPU: true,
       modelsPath: '',
+      apiPort: 10434,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
@@ -300,6 +302,7 @@ describe('perform', () => {
     vi.mocked(configurationRegistry.getExtensionConfiguration).mockReturnValue({
       experimentalGPU: true,
       modelsPath: '',
+      apiPort: 10434,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
@@ -331,6 +334,7 @@ describe('perform', () => {
     vi.mocked(configurationRegistry.getExtensionConfiguration).mockReturnValue({
       experimentalGPU: true,
       modelsPath: '',
+      apiPort: 10434,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -19,4 +19,5 @@
 export interface ExtensionConfiguration {
   experimentalGPU: boolean;
   modelsPath: string;
+  apiPort: number;
 }


### PR DESCRIPTION
### What does this PR do?

Make tha API port configurable 
 
### What issues does this PR fix or reference?

Fixes #1426 

### How to test this PR?

- Go to Preferences, change the API port, restart the extension and check the API is listening on this port
- Set a port in use, and check that an error is displayed in the status bar