### PR TITLE
feat: build extension as module instead of commonJS

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,12 +4,13 @@
   "description": "Podman AI Lab lets you work with LLMs locally, exploring AI fundamentals, experimenting with models and prompts, and serving models while maintaining data security and privacy.",
   "version": "1.3.0-next",
   "icon": "icon.png",
+  "type": "module",
   "publisher": "redhat",
   "license": "Apache-2.0",
   "engines": {
     "podman-desktop": ">=1.8.0"
   },
-  "main": "./dist/extension.js",
+  "main": "./dist/extension.cjs",
   "contributes": {
     "configuration": {
       "title": "AI Lab",

--- a/packages/backend/vite.config.js
+++ b/packages/backend/vite.config.js
@@ -53,7 +53,7 @@ const config = {
         ...builtinModules.flatMap(p => [p, `node:${p}`]),
       ],
       output: {
-        entryFileNames: '[name].js',
+        entryFileNames: '[name].cjs',
       },
     },
     emptyOutDir: true,


### PR DESCRIPTION
### What does this PR do?

Build extension as module instead of commonJS. As more and more dependencies are distributed in ESM-only format, let's build the extension in this format to prepare using such ESM-only dependency.
