### PR TITLE
chore: ensure we can't use void prefix to ignore the await without a catch

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/no-explicit-any": "error",
     "prefer-promise-reject-errors": "error",
     "@typescript-eslint/await-thenable": "error",
-    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-floating-promises": ["error", {"ignoreVoid": false}],
     "@typescript-eslint/no-misused-promises": "error",
     "@typescript-eslint/prefer-optional-chain": "error",
     "no-null/no-null": "error",

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -811,7 +811,7 @@ describe('downloadModel', () => {
       };
     });
 
-    void manager.requestDownloadModel({
+    await manager.requestDownloadModel({
       id: 'id',
       url: 'url',
       name: 'name',

--- a/packages/backend/src/utils/downloader.spec.ts
+++ b/packages/backend/src/utils/downloader.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { vi, test, expect, beforeEach } from 'vitest';
+import { vi, test, expect, beforeEach, assert } from 'vitest';
 import { Downloader } from './downloader';
 import { EventEmitter } from '@podman-desktop/api';
 import { createWriteStream, promises, type WriteStream } from 'node:fs';
@@ -158,7 +158,7 @@ test('perform download successfully', async () => {
   downloader.onEvent(listenerMock);
 
   // perform download logic
-  void downloader.perform('followUpId');
+  downloader.perform('followUpId').catch((error: unknown) => assert.fail('unable to download' + error));
 
   // wait for listener to be registered
   await vi.waitFor(() => {


### PR DESCRIPTION
### What does this PR do?
add extra check lint

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->