### PR TITLE
chore(eslint): prevent forbidden imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,7 +41,7 @@
     "node_modules/**",
     "**/dist/**"
   ],
-  "plugins": ["@typescript-eslint", "sonarjs", "etc", "redundant-undefined", "no-null"],
+  "plugins": ["@typescript-eslint", "sonarjs", "etc", "redundant-undefined", "no-null", "import"],
   "rules": {
     "eqeqeq": "error",
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
@@ -90,6 +90,16 @@
     "etc/no-commented-out-code": "error",
     "etc/no-deprecated": "off",
     "redundant-undefined/redundant-undefined": "error",
-    "import/no-extraneous-dependencies": "error"
+    "import/no-extraneous-dependencies": "error",
+    "import/no-restricted-paths": ["error", {
+      "zones": [{
+        "target": "./packages/backend/**/*",
+        "from": ["./packages/frontend/**/*"]
+      },
+        {
+          "target": "./packages/frontend/**/*",
+          "from": ["./packages/backend/**/*"]
+        }]
+    }]
   }
 }

--- a/packages/frontend/src/pages/Model.spec.ts
+++ b/packages/frontend/src/pages/Model.spec.ts
@@ -42,7 +42,7 @@ const model: ModelInfo = {
  name: 'Model 1',
  properties: {},
  description: '',
-}
+};
 
 test('should display model information', async () => {
   vi.mocked(studioClient.getCatalog).mockResolvedValue({
@@ -57,7 +57,7 @@ test('should display model information', async () => {
   });
 
   await vi.waitFor(() => {
-    const elements = screen.getAllByText(model.name)
+    const elements = screen.getAllByText(model.name);
     expect(elements.length).toBeGreaterThan(0);
   });
 });

--- a/packages/frontend/src/pages/Model.spec.ts
+++ b/packages/frontend/src/pages/Model.spec.ts
@@ -38,10 +38,10 @@ vi.mock('../utils/client', async () => {
 });
 
 const model: ModelInfo = {
- id: 'model1',
- name: 'Model 1',
- properties: {},
- description: '',
+  id: 'model1',
+  name: 'Model 1',
+  properties: {},
+  description: '',
 };
 
 test('should display model information', async () => {

--- a/packages/frontend/src/pages/Model.spec.ts
+++ b/packages/frontend/src/pages/Model.spec.ts
@@ -19,18 +19,13 @@
 import { vi, test, expect } from 'vitest';
 import { screen, render } from '@testing-library/svelte';
 import Model from './Model.svelte';
-import catalog from '../../../backend/src/tests/ai-user-test.json';
-
-const mocks = vi.hoisted(() => {
-  return {
-    getCatalogMock: vi.fn(),
-  };
-});
+import { studioClient } from '../utils/client';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 vi.mock('../utils/client', async () => {
   return {
     studioClient: {
-      getCatalog: mocks.getCatalogMock,
+      getCatalog: vi.fn(),
     },
     rpcBrowser: {
       subscribe: () => {
@@ -42,16 +37,27 @@ vi.mock('../utils/client', async () => {
   };
 });
 
-test('should display model information', async () => {
-  const model = catalog.models.find(m => m.id === 'model1');
-  expect(model).not.toBeUndefined();
+const model: ModelInfo = {
+ id: 'model1',
+ name: 'Model 1',
+ properties: {},
+ description: '',
+}
 
-  mocks.getCatalogMock.mockResolvedValue(catalog);
+test('should display model information', async () => {
+  vi.mocked(studioClient.getCatalog).mockResolvedValue({
+    models: [model],
+    categories: [],
+    recipes: [],
+    version: 'v1',
+  });
+
   render(Model, {
     modelId: 'model1',
   });
-  await new Promise(resolve => setTimeout(resolve, 200));
 
-  expect(screen.getAllByText(model!.name).length).toBeGreaterThan(0);
-  screen.getByText(model!.description);
+  await vi.waitFor(() => {
+    const elements = screen.getAllByText(model.name)
+    expect(elements.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Configuring [import/no-restricted-paths](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md).

The change are the following

- Inside `packages/backend` you cannot import anything from `packages/frontend`
- Inside `packages/frontend` you cannot import anything from `packages/backend`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->