### PR TITLE
feat: instructLab navigation bar and empty InstructLab sessions screen

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -32,6 +32,12 @@
           "minimum": 1024,
           "maximum": 65535,
           "description": "Port on which the API is listening (requires restart of extension)"
+        },
+        "ai-lab.experimentalTuning": {
+          "type": "boolean",
+          "default": false,
+          "description": "Display InstructLab Tuning screens (experimental)",
+          "hidden": true
         }
       }
     },

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -21,7 +21,12 @@ import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfig
 import { Messages } from '@shared/Messages';
 import path from 'node:path';
 
-const CONFIGURATION_SECTIONS: string[] = ['ai-lab.models.path', 'ai-lab.experimentalGPU', 'ai-lab.apiPort'];
+const CONFIGURATION_SECTIONS: string[] = [
+  'ai-lab.models.path',
+  'ai-lab.experimentalGPU',
+  'ai-lab.apiPort',
+  'ai-lab.experimentalTuning',
+];
 
 const API_PORT_DEFAULT = 10434;
 
@@ -43,6 +48,7 @@ export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> imp
       modelsPath: this.getModelsPath(),
       experimentalGPU: this.#configuration.get<boolean>('experimentalGPU') ?? false,
       apiPort: this.#configuration.get<number>('apiPort') ?? API_PORT_DEFAULT,
+      experimentalTuning: this.#configuration.get<boolean>('experimentalTuning') ?? false,
     };
   }
 

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -96,6 +96,7 @@ beforeEach(() => {
     experimentalGPU: false,
     modelsPath: 'model-path',
     apiPort: 10434,
+    experimentalTuning: false,
   });
   vi.mocked(podmanConnection.findRunningContainerProviderConnection).mockReturnValue(dummyConnection);
   vi.mocked(podmanConnection.getContainerProviderConnection).mockReturnValue(dummyConnection);
@@ -273,6 +274,7 @@ describe('perform', () => {
       experimentalGPU: true,
       modelsPath: '',
       apiPort: 10434,
+      experimentalTuning: false,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
@@ -303,6 +305,7 @@ describe('perform', () => {
       experimentalGPU: true,
       modelsPath: '',
       apiPort: 10434,
+      experimentalTuning: false,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
@@ -335,6 +338,7 @@ describe('perform', () => {
       experimentalGPU: true,
       modelsPath: '',
       apiPort: 10434,
+      experimentalTuning: false,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([

--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -22,16 +22,24 @@ import PlaygroundCreate from './pages/PlaygroundCreate.svelte';
 import ImportModels from './pages/ImportModel.svelte';
 import StartRecipe from '/@/pages/StartRecipe.svelte';
 import TuneSessions from './pages/TuneSessions.svelte';
+import { configuration } from './stores/extensionConfiguration';
+import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
 
 router.mode.hash();
 
 let isMounted = false;
+
+let experimentalTuning: boolean = false;
 
 onMount(() => {
   // Load router state on application startup
   const state = getRouterState();
   router.goto(state.url);
   isMounted = true;
+
+  configuration.subscribe((val: ExtensionConfiguration | undefined) => {
+    experimentalTuning = val?.experimentalTuning ?? false;
+  });
 });
 </script>
 
@@ -66,12 +74,12 @@ onMount(() => {
           <Playground playgroundId={meta.params.id} />
         {/if}
       </Route>
-
-      <!-- Tune with InstructLab -->
-      <Route path="/tune">
-        <TuneSessions />
-      </Route>
-
+      {#if experimentalTuning}
+        <!-- Tune with InstructLab -->
+        <Route path="/tune">
+          <TuneSessions />
+        </Route>
+      {/if}
       <!-- Preferences -->
       <Route path="/preferences">
         <Preferences />

--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -21,6 +21,7 @@ import Playground from './pages/Playground.svelte';
 import PlaygroundCreate from './pages/PlaygroundCreate.svelte';
 import ImportModels from './pages/ImportModel.svelte';
 import StartRecipe from '/@/pages/StartRecipe.svelte';
+import TuneSessions from './pages/TuneSessions.svelte';
 
 router.mode.hash();
 
@@ -64,6 +65,11 @@ onMount(() => {
         {:else}
           <Playground playgroundId={meta.params.id} />
         {/if}
+      </Route>
+
+      <!-- Tune with InstructLab -->
+      <Route path="/tune">
+        <TuneSessions />
       </Route>
 
       <!-- Preferences -->

--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -11,7 +11,7 @@ import Preferences from '/@/pages/Preferences.svelte';
 import Models from '/@/pages/Models.svelte';
 import Recipe from '/@/pages/Recipe.svelte';
 import Model from './pages/Model.svelte';
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 import { getRouterState } from '/@/utils/client';
 import CreateService from '/@/pages/CreateService.svelte';
 import Services from '/@/pages/InferenceServers.svelte';
@@ -24,12 +24,14 @@ import StartRecipe from '/@/pages/StartRecipe.svelte';
 import TuneSessions from './pages/TuneSessions.svelte';
 import { configuration } from './stores/extensionConfiguration';
 import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
+import type { Unsubscriber } from 'svelte/store';
 
 router.mode.hash();
 
 let isMounted = false;
 
 let experimentalTuning: boolean = false;
+let cfgUnsubscribe: Unsubscriber;
 
 onMount(() => {
   // Load router state on application startup
@@ -37,9 +39,13 @@ onMount(() => {
   router.goto(state.url);
   isMounted = true;
 
-  configuration.subscribe((val: ExtensionConfiguration | undefined) => {
+  cfgUnsubscribe = configuration.subscribe((val: ExtensionConfiguration | undefined) => {
     experimentalTuning = val?.experimentalTuning ?? false;
   });
+});
+
+onDestroy(() => {
+  cfgUnsubscribe?.();
 });
 </script>
 

--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { TinroRouteMeta } from 'tinro';
 import Fa from 'svelte-fa';
-import { faBookOpen, faBrain, faMessage, faRocket, faServer } from '@fortawesome/free-solid-svg-icons';
+import { faBookOpen, faBrain, faGaugeHigh, faMessage, faRocket, faServer } from '@fortawesome/free-solid-svg-icons';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
 
 export let meta: TinroRouteMeta;
@@ -29,5 +29,11 @@ export let meta: TinroRouteMeta;
     <SettingsNavItem icon={faBookOpen} title="Catalog" selected={meta.url === '/models'} href="/models" />
     <SettingsNavItem icon={faRocket} title="Services" selected={meta.url === '/services'} href="/services" />
     <SettingsNavItem icon={faMessage} title="Playgrounds" selected={meta.url === '/playgrounds'} href="/playgrounds" />
+
+    <!-- Tuning -->
+    <div class="pl-3 mt-2 ml-[4px]">
+      <span class="text-[color:var(--pd-secondary-nav-header-text)]">TUNING</span>
+    </div>
+    <SettingsNavItem icon={faGaugeHigh} title="Tune with InstructLab" selected={meta.url === '/tune'} href="/tune" />
   </div>
 </nav>

--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -3,17 +3,23 @@ import type { TinroRouteMeta } from 'tinro';
 import Fa from 'svelte-fa';
 import { faBookOpen, faBrain, faGaugeHigh, faMessage, faRocket, faServer } from '@fortawesome/free-solid-svg-icons';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 import { configuration } from '../stores/extensionConfiguration';
 import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
+import type { Unsubscriber } from 'svelte/store';
 
 export let meta: TinroRouteMeta;
 let experimentalTuning: boolean = false;
+let cfgUnsubscribe: Unsubscriber;
 
 onMount(() => {
-  configuration.subscribe((val: ExtensionConfiguration | undefined) => {
+  cfgUnsubscribe = configuration.subscribe((val: ExtensionConfiguration | undefined) => {
     experimentalTuning = val?.experimentalTuning ?? false;
   });
+});
+
+onDestroy(() => {
+  cfgUnsubscribe?.();
 });
 </script>
 

--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -3,8 +3,18 @@ import type { TinroRouteMeta } from 'tinro';
 import Fa from 'svelte-fa';
 import { faBookOpen, faBrain, faGaugeHigh, faMessage, faRocket, faServer } from '@fortawesome/free-solid-svg-icons';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { configuration } from '../stores/extensionConfiguration';
+import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
 
 export let meta: TinroRouteMeta;
+let experimentalTuning: boolean = false;
+
+onMount(() => {
+  configuration.subscribe((val: ExtensionConfiguration | undefined) => {
+    experimentalTuning = val?.experimentalTuning ?? false;
+  });
+});
 </script>
 
 <nav
@@ -30,10 +40,12 @@ export let meta: TinroRouteMeta;
     <SettingsNavItem icon={faRocket} title="Services" selected={meta.url === '/services'} href="/services" />
     <SettingsNavItem icon={faMessage} title="Playgrounds" selected={meta.url === '/playgrounds'} href="/playgrounds" />
 
-    <!-- Tuning -->
-    <div class="pl-3 mt-2 ml-[4px]">
-      <span class="text-[color:var(--pd-secondary-nav-header-text)]">TUNING</span>
-    </div>
-    <SettingsNavItem icon={faGaugeHigh} title="Tune with InstructLab" selected={meta.url === '/tune'} href="/tune" />
+    {#if experimentalTuning}
+      <!-- Tuning -->
+      <div class="pl-3 mt-2 ml-[4px]">
+        <span class="text-[color:var(--pd-secondary-nav-header-text)]">TUNING</span>
+      </div>
+      <SettingsNavItem icon={faGaugeHigh} title="Tune with InstructLab" selected={meta.url === '/tune'} href="/tune" />
+    {/if}
   </div>
 </nav>

--- a/packages/frontend/src/pages/TuneSessions.svelte
+++ b/packages/frontend/src/pages/TuneSessions.svelte
@@ -1,0 +1,24 @@
+<script>
+import { faGaugeHigh, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { Button, EmptyScreen, NavPage } from '@podman-desktop/ui-svelte';
+
+function start() {}
+</script>
+
+<NavPage title="InstructLab Sessions" searchEnabled={false}>
+  <svelte:fragment slot="additional-actions">
+    <Button icon={faPlusCircle} on:click={() => start()}>Start Fine Tuning</Button>
+  </svelte:fragment>
+  <svelte:fragment slot="content">
+    <div class="flex min-w-full">
+      <EmptyScreen
+        icon={faGaugeHigh}
+        title="No InstructLab Session"
+        message="Create InstructLab session to improve trained models with specialized knowledges and skills tuning">
+        <div class="flex gap-2 justify-center">
+          <Button type="link" on:click={() => start()}>Create InstructLab Session</Button>
+        </div>
+      </EmptyScreen>
+    </div>
+  </svelte:fragment>
+</NavPage>

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -20,4 +20,5 @@ export interface ExtensionConfiguration {
   experimentalGPU: boolean;
   modelsPath: string;
   apiPort: number;
+  experimentalTuning: boolean;
 }

--- a/tests/playwright/src/model/ai-lab-navigation-bar.ts
+++ b/tests/playwright/src/model/ai-lab-navigation-bar.ts
@@ -28,6 +28,7 @@ export class AILabNavigationBar extends AILabBasePage {
   readonly catalogButton: Locator;
   readonly servicesButton: Locator;
   readonly playgroundsButton: Locator;
+  readonly tuneButton: Locator;
 
   constructor(page: Page, webview: Page) {
     super(page, webview, undefined);
@@ -37,6 +38,7 @@ export class AILabNavigationBar extends AILabBasePage {
     this.catalogButton = this.navigationBar.getByRole('link', { name: 'Catalog', exact: true });
     this.servicesButton = this.navigationBar.getByRole('link', { name: 'Services' });
     this.playgroundsButton = this.navigationBar.getByRole('link', { name: 'Playgrounds' });
+    this.tuneButton = this.navigationBar.getByRole('link', { name: 'Tune with InstructLab' });
   }
 
   async waitForLoad(): Promise<void> {


### PR DESCRIPTION
### What does this PR do?

implement InstructLab navigation bar and empty InstructLab sessions screen

### Screenshot / video of UI

![ai-lab-tuning](https://github.com/user-attachments/assets/b03a858e-378d-4478-9f9c-cfd29bffa5f9)

### What issues does this PR fix or reference?

Fixes #1567 

### How to test this PR?

You need to set an hidden setting, in `~/.local/share/containers/podman-desktop/configuration/settings.json`

(you must completely stop Podman Desktop - not only close the window -, edit the config file, then restart Podman Desktop for the change to be taken into consideration) 

```
  "ai-lab.experimentalTuning": true,
```