### PR TITLE
chore: parse svelte files when doing the linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ __mocks__
 coverage
 packages/backend/media/**
 src-generated
+node_modules

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,10 +14,33 @@
     "plugin:etc/recommended",
     "plugin:sonarjs/recommended-legacy"
   ],
+  "overrides": [
+    {
+      "files": ["*.svelte"],
+      "parser": "svelte-eslint-parser",
+      "parserOptions": {
+        "parser": "@typescript-eslint/parser"
+      },
+      "rules": {
+        "eqeqeq": "off",
+        "etc/no-implicit-any-catch": "off",
+        "no-inner-declarations": "off",
+        "sonarjs/code-eval": "off",
+        "sonarjs/different-types-comparison": "off",
+        "sonarjs/prefer-nullish-coalescing": "off",
+        "sonarjs/no-unused-expressions": "off",
+        "sonarjs/no-nested-template-literals": "off",
+        "sonarjs/no-nested-conditional": "off",
+        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/ban-types": "off"
+      }
+    }
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 12,
     "sourceType": "module",
+    "extraFileExtensions": [".svelte"],
     "project": [
       "packages/*/tsconfig.json",
       "tests/*/tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "watch": "concurrently \"yarn --cwd packages/frontend watch\" \"yarn --cwd packages/backend watch\"",
     "format:check": "prettier --check \"**/src/**/*.{ts,svelte}\"",
     "format:fix": "prettier --write \"**/src/**/*.{ts,svelte}\"",
-    "lint:check": "eslint . --ext js,ts,tsx",
-    "lint:fix": "eslint . --fix --ext js,ts,tsx",
+    "lint:check": "eslint . --ext js,svelte,ts,tsx",
+    "lint:fix": "eslint . --fix --ext js,svelte,ts,tsx",
     "svelte:check": "svelte-check",
     "test:backend": "vitest run -r packages/backend --passWithNoTests --coverage",
     "test:frontend": "vitest -c packages/frontend/vite.config.js run packages/frontend --passWithNoTests --coverage",
@@ -49,6 +49,7 @@
     "prettier": "^3.3.3",
     "prettier-plugin-svelte": "^3.2.6",
     "svelte-check": "^3.8.6",
+    "svelte-eslint-parser": "^0.41.0",
     "typescript": "5.5.4",
     "vite": "^5.4.2",
     "vitest": "^2.0.5"

--- a/packages/frontend/src/lib/RecipeStatus.svelte
+++ b/packages/frontend/src/lib/RecipeStatus.svelte
@@ -3,9 +3,8 @@ import type { Recipe } from '@shared/src/models/IRecipe';
 import Fa from 'svelte-fa';
 import type { LocalRepository } from '@shared/src/models/ILocalRepository';
 import { faCircleCheck, faDownload } from '@fortawesome/free-solid-svg-icons';
-import { Spinner } from '@podman-desktop/ui-svelte';
+import { Spinner, Tooltip } from '@podman-desktop/ui-svelte';
 import { studioClient } from '/@/utils/client';
-import { Tooltip } from '@podman-desktop/ui-svelte';
 
 export let recipe: Recipe;
 export let localRepository: LocalRepository | undefined;

--- a/packages/frontend/src/lib/conversation/ChatMessage.svelte
+++ b/packages/frontend/src/lib/conversation/ChatMessage.svelte
@@ -35,7 +35,7 @@ function getMessageParagraphs(message: ChatMessage): string[] {
 function elapsedTime(msg: AssistantChat): string {
   if (isPendingChat(msg)) {
     return ((Date.now() - msg.timestamp) / 1000).toFixed(1);
-  } else if (!!msg.completed) {
+  } else if (msg.completed) {
     return ((msg.completed - msg.timestamp) / 1000).toFixed(1);
   } else {
     // should not happen

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
-import { faDownload, faRocket, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { faDownload, faRocket, faTrash, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '../../button/ListItemButtonIcon.svelte';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
@@ -19,7 +18,7 @@ function deleteModel() {
 }
 
 function openModelFolder() {
-  if (object && object.file) {
+  if (object?.file) {
     studioClient.openFile(object.file.path);
   }
 }

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -9,8 +9,7 @@ import { faRocket, faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-ico
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
 import { onMount } from 'svelte';
-import { Button } from '@podman-desktop/ui-svelte';
-import { Table, TableColumn, TableRow, NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
+import { Button, Table, TableColumn, TableRow, NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
 
 const columns: TableColumn<InferenceServer>[] = [
   new TableColumn<InferenceServer>('Status', { width: '70px', renderer: ServiceStatus, align: 'center' }),

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -10,14 +10,12 @@ import { onMount } from 'svelte';
 import ModelColumnSize from '../lib/table/model/ModelColumnSize.svelte';
 import ModelColumnAge from '../lib/table/model/ModelColumnAge.svelte';
 import ModelColumnActions from '../lib/table/model/ModelColumnActions.svelte';
-import { EmptyScreen, Tab } from '@podman-desktop/ui-svelte';
+import { EmptyScreen, Tab, Button, Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
 import Route from '/@/Route.svelte';
 import { tasks } from '/@/stores/tasks';
 import ModelColumnIcon from '../lib/table/model/ModelColumnIcon.svelte';
 import { router } from 'tinro';
-import { Button } from '@podman-desktop/ui-svelte';
 import { faBookOpen, faFileImport } from '@fortawesome/free-solid-svg-icons';
-import { Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
 
 const columns: TableColumn<ModelInfo>[] = [
   new TableColumn<ModelInfo>('Status', {

--- a/packages/frontend/src/pages/Playgrounds.svelte
+++ b/packages/frontend/src/pages/Playgrounds.svelte
@@ -5,8 +5,7 @@ import PlaygroundColumnName from '../lib/table/playground/PlaygroundColumnName.s
 import ConversationColumnAction from '/@/lib/table/playground/ConversationColumnAction.svelte';
 import { conversations } from '/@/stores/conversations';
 import PlaygroundColumnIcon from '/@/lib/table/playground/PlaygroundColumnIcon.svelte';
-import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
-import { Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
+import { Button, EmptyScreen, Table, TableColumn, TableRow, NavPage } from '@podman-desktop/ui-svelte';
 import type { Conversation } from '@shared/src/models/IPlaygroundMessage';
 import { faMessage, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { studioClient } from '/@/utils/client';
-import { DetailsPage, Tab } from '@podman-desktop/ui-svelte';
+import { DetailsPage, Tab, Button, EmptyScreen } from '@podman-desktop/ui-svelte';
 import Card from '/@/lib/Card.svelte';
 import MarkdownRenderer from '/@/lib/markdown/MarkdownRenderer.svelte';
 import { getIcon } from '/@/utils/categoriesUtils';
@@ -9,7 +9,6 @@ import RecipeDetails from '/@/lib/RecipeDetails.svelte';
 import ContentDetailsLayout from '../lib/ContentDetailsLayout.svelte';
 import { router } from 'tinro';
 import { faRocket } from '@fortawesome/free-solid-svg-icons';
-import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 import Route from '/@/Route.svelte';
 import ApplicationTable from '/@/lib/table/application/ApplicationTable.svelte';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5745,6 +5745,11 @@ postcss-nested@^6.0.1:
   dependencies:
     postcss-selector-parser "^6.1.1"
 
+postcss-scss@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.9.tgz#a03c773cd4c9623cb04ce142a52afcec74806685"
+  integrity sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==
+
 postcss-selector-parser@6.0.10:
   version "6.0.10"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
@@ -5766,7 +5771,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.23, postcss@^8.4.41:
+postcss@^8.4.23, postcss@^8.4.39, postcss@^8.4.41:
   version "8.4.41"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.41.tgz#d6104d3ba272d882fe18fc07d15dc2da62fa2681"
   integrity sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==
@@ -6709,6 +6714,17 @@ svelte-check@^3.8.6:
     sade "^1.7.4"
     svelte-preprocess "^5.1.3"
     typescript "^5.0.3"
+
+svelte-eslint-parser@^0.41.0:
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/svelte-eslint-parser/-/svelte-eslint-parser-0.41.0.tgz#7d02c2314abe7dc4fe0e935bf4fcc28078c590f2"
+  integrity sha512-L6f4hOL+AbgfBIB52Z310pg1d2QjRqm7wy3kI1W6hhdhX5bvu7+f0R6w4ykp5HoDdzq+vGhIJmsisaiJDGmVfA==
+  dependencies:
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
+    postcss "^8.4.39"
+    postcss-scss "^4.0.9"
 
 svelte-fa@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
### What does this PR do?
While wanting to update eslint dependency, I noticed that svelte files are not analyzed

so before doing the library update, include svelte files during the linting process

files are not compliant so fix the automatic fixes and exclude files from some rules to be able to continue

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop-extension-ai-lab/issues/1607

### How to test this PR?

<!-- Please explain steps to reproduce -->