### PR TITLE
feat: implement pull model for API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -51,6 +51,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListResponse'
+  /api/pull:
+    post:
+      operationId: pullModel
+      tags:
+        - models
+      description: | 
+        Download a model from the Podman AI Lab catalog.
+      summary: |
+        Download a model from the Podman AI Lab Catalog.
+      requestBody:
+        required: true
+        description: Request to pull a model
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PullRequest'
+      responses:
+        '200':
+          description: Model was successfully pulled
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: '#/components/schemas/ProgressResponse'
+
 
 components:
   schemas:
@@ -99,3 +123,40 @@ components:
           type: string
         quantization_level:
           type: string
+
+    PullRequest:
+      type: object
+      description: Request to pull a model
+      properties:
+        model:
+          type: string
+          description: The name of the model to pull
+          example: instructlab/granite-7b-lab-GGUF
+        insecure:
+          type: boolean
+          description: |
+            allow insecure connections to the catalog.
+        stream:
+          type: boolean
+          description: |
+            If false the response will be returned as a single response object, 
+            rather than a stream of objects
+      required: 
+        - model
+
+    ProgressResponse:
+      type: object
+      description: The response returned from various streaming endpoints
+      properties:
+        status:
+          type: string
+          description: The status of the request
+        digest:
+          type: string
+          description: The SHA256 digest of the blob
+        total:
+          type: integer
+          description: The total size of the task
+        completed:
+          type: integer
+          description: The completed size of the task

--- a/packages/backend/src/managers/apiServer.spec.ts
+++ b/packages/backend/src/managers/apiServer.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ApiServer, PREFERENCE_RANDOM_PORT } from './apiServer';
 import request from 'supertest';
 import type * as podmanDesktopApi from '@podman-desktop/api';
@@ -163,92 +163,122 @@ test('/api/pull returns an error if no body is passed', async () => {
   await request(server.getListener()!).post('/api/pull').expect(415);
 });
 
-test('/api/pull returns an error if the model is not known', async () => {
-  expect(server.getListener()).toBeDefined();
-  vi.mocked(catalogManager.getModelByName).mockImplementation(() => {
-    throw new Error('model unknown');
+describe.each([undefined, true, false])('/api/pull endpoint, stream is %o', stream => {
+  test('/api/pull returns an error if the model is not known', async () => {
+    expect(server.getListener()).toBeDefined();
+    vi.mocked(catalogManager.getModelByName).mockImplementation(() => {
+      throw new Error('model unknown');
+    });
+    const req = request(server.getListener()!).post('/api/pull').send({ model: 'unknown-model-name', stream });
+    if (stream === false) {
+      const res = await req.expect(500).expect('Content-Type', 'application/json; charset=utf-8');
+      expect(res.body.error).toEqual('pull model manifest: file does not exist');
+    } else {
+      const res = await req.expect(200);
+      const lines = res.text.split('\n');
+      expect(lines.length).toEqual(3);
+      expect(lines[0]).toEqual('{"status":"pulling manifest"}');
+      expect(lines[1]).toEqual('{"error":"pull model manifest: file does not exist"}');
+      expect(lines[2]).toEqual('');
+    }
   });
-  const res = await request(server.getListener()!).post('/api/pull').send({ model: 'unknown-model-name' }).expect(200);
-  const lines = res.text.split('\n');
-  expect(lines.length).toEqual(3);
-  expect(lines[0]).toEqual('{"status":"pulling manifest"}');
-  expect(lines[1]).toEqual('{"error":"pull model manifest: file does not exist"}');
-  expect(lines[2]).toEqual('');
-});
 
-test('/api/pull returns success if model already downloaded', async () => {
-  expect(server.getListener()).toBeDefined();
-  vi.mocked(catalogManager.getModelByName).mockReturnValue({
-    id: 'modelId',
-    name: 'model-name',
-    description: 'a description',
+  test('/api/pull returns success if model already downloaded', async () => {
+    expect(server.getListener()).toBeDefined();
+    vi.mocked(catalogManager.getModelByName).mockReturnValue({
+      id: 'modelId',
+      name: 'model-name',
+      description: 'a description',
+    });
+    vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(true);
+    const req = request(server.getListener()!).post('/api/pull').send({ model: 'model-name', stream });
+    if (stream === false) {
+      const res = await req.expect(200).expect('Content-Type', 'application/json; charset=utf-8');
+      expect(res.body.status).toEqual('success');
+    } else {
+      const res = await req.expect(200).expect('transfer-encoding', 'chunked');
+      const lines = res.text.split('\n');
+      expect(lines.length).toEqual(3);
+      expect(lines[0]).toEqual('{"status":"pulling manifest"}');
+      expect(lines[1]).toEqual('{"status":"success"}');
+      expect(lines[2]).toEqual('');
+    }
   });
-  vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(true);
-  const res = await request(server.getListener()!).post('/api/pull').send({ model: 'model-name' }).expect(200);
-  const lines = res.text.split('\n');
-  expect(lines.length).toEqual(3);
-  expect(lines[0]).toEqual('{"status":"pulling manifest"}');
-  expect(lines[1]).toEqual('{"status":"success"}');
-  expect(lines[2]).toEqual('');
-});
 
-test('/api/pull downloads model and returns success', async () => {
-  expect(server.getListener()).toBeDefined();
-  vi.mocked(catalogManager.getModelByName).mockReturnValue({
-    id: 'modelId',
-    name: 'model-name',
-    description: 'a description',
-    sha256: '123456',
+  test('/api/pull downloads model and returns success', async () => {
+    expect(server.getListener()).toBeDefined();
+    vi.mocked(catalogManager.getModelByName).mockReturnValue({
+      id: 'modelId',
+      name: 'model-name',
+      description: 'a description',
+      sha256: '123456',
+    });
+    vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(false);
+    vi.mocked(modelsManager.createDownloader).mockReturnValue({
+      perform: async (_name: string) => {},
+      onEvent: (listener: (e: ProgressEvent) => void) => {
+        listener({
+          status: 'progress',
+          id: 'model-name',
+          total: 100000,
+          value: 100000,
+        });
+      },
+    } as unknown as Downloader);
+    const req = request(server.getListener()!).post('/api/pull').send({ model: 'model-name', stream });
+    if (stream === false) {
+      const res = await req.expect(200).expect('Content-Type', 'application/json; charset=utf-8');
+      expect(res.body.status).toEqual('success');
+    } else {
+      const res = await req.expect(200).expect('transfer-encoding', 'chunked');
+      const lines = res.text.split('\n');
+      expect(lines.length).toEqual(4);
+      expect(lines[0]).toEqual('{"status":"pulling manifest"}');
+      expect(lines[1]).toEqual(
+        '{"status":"pulling 123456","digest":"sha256:123456","total":100000,"completed":100000000}',
+      );
+      expect(lines[2]).toEqual('{"status":"success"}');
+      expect(lines[3]).toEqual('');
+    }
   });
-  vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(false);
-  vi.mocked(modelsManager.createDownloader).mockReturnValue({
-    perform: async (_name: string) => {},
-    onEvent: (listener: (e: ProgressEvent) => void) => {
-      listener({
-        status: 'progress',
-        id: 'model-name',
-        total: 100000,
-        value: 100000,
-      });
-    },
-  } as unknown as Downloader);
-  const res = await request(server.getListener()!).post('/api/pull').send({ model: 'model-name' }).expect(200);
-  const lines = res.text.split('\n');
-  expect(lines.length).toEqual(4);
-  expect(lines[0]).toEqual('{"status":"pulling manifest"}');
-  expect(lines[1]).toEqual('{"status":"pulling 123456","digest":"sha256:123456","total":100000,"completed":100000000}');
-  expect(lines[2]).toEqual('{"status":"success"}');
-  expect(lines[3]).toEqual('');
-});
 
-test('/api/pull should return an error if an error occurs during download', async () => {
-  expect(server.getListener()).toBeDefined();
-  vi.mocked(catalogManager.getModelByName).mockReturnValue({
-    id: 'modelId',
-    name: 'model-name',
-    description: 'a description',
-    sha256: '123456',
+  test('/api/pull should return an error if an error occurs during download', async () => {
+    expect(server.getListener()).toBeDefined();
+    vi.mocked(catalogManager.getModelByName).mockReturnValue({
+      id: 'modelId',
+      name: 'model-name',
+      description: 'a description',
+      sha256: '123456',
+    });
+    vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(false);
+    vi.mocked(modelsManager.createDownloader).mockReturnValue({
+      perform: async (_name: string) => {
+        await new Promise(resolve => setTimeout(resolve, 0)); // wait for random port to be set
+        throw new Error('an error');
+      },
+      onEvent: (listener: (e: ProgressEvent) => void) => {
+        listener({
+          status: 'progress',
+          id: 'model-name',
+          total: 100000,
+          value: 100000,
+        });
+      },
+    } as unknown as Downloader);
+    const req = request(server.getListener()!).post('/api/pull').send({ model: 'model-name', stream });
+    if (stream === false) {
+      const res = await req.expect(500).expect('Content-Type', 'application/json; charset=utf-8');
+      expect(res.body.error).toEqual('Error: an error');
+    } else {
+      const res = await req.expect(200).expect('transfer-encoding', 'chunked');
+      const lines = res.text.split('\n');
+      expect(lines.length).toEqual(4);
+      expect(lines[0]).toEqual('{"status":"pulling manifest"}');
+      expect(lines[1]).toEqual(
+        '{"status":"pulling 123456","digest":"sha256:123456","total":100000,"completed":100000000}',
+      );
+      expect(lines[2]).toEqual('{"error":"Error: an error"}');
+      expect(lines[3]).toEqual('');
+    }
   });
-  vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(false);
-  vi.mocked(modelsManager.createDownloader).mockReturnValue({
-    perform: async (_name: string) => {
-      await new Promise(resolve => setTimeout(resolve, 0)); // wait for random port to be set
-      throw new Error('an error');
-    },
-    onEvent: (listener: (e: ProgressEvent) => void) => {
-      listener({
-        status: 'progress',
-        id: 'model-name',
-        total: 100000,
-        value: 100000,
-      });
-    },
-  } as unknown as Downloader);
-  const res = await request(server.getListener()!).post('/api/pull').send({ model: 'model-name' }).expect(200);
-  const lines = res.text.split('\n');
-  expect(lines.length).toEqual(4);
-  expect(lines[0]).toEqual('{"status":"pulling manifest"}');
-  expect(lines[1]).toEqual('{"status":"pulling 123456","digest":"sha256:123456","total":100000,"completed":100000000}');
-  expect(lines[2]).toEqual('{"error":"Error: an error"}');
-  expect(lines[3]).toEqual('');
 });

--- a/packages/backend/src/managers/apiServer.spec.ts
+++ b/packages/backend/src/managers/apiServer.spec.ts
@@ -27,6 +27,9 @@ import type { EventEmitter } from 'node:events';
 import { once } from 'node:events';
 import type { ConfigurationRegistry } from '../registries/ConfigurationRegistry';
 import type { AddressInfo } from 'node:net';
+import type { CatalogManager } from './catalogManager';
+import type { Downloader } from '../utils/downloader';
+import type { ProgressEvent } from '../models/baseEvent';
 
 class TestApiServer extends ApiServer {
   public override getListener(): Server | undefined {
@@ -40,8 +43,12 @@ let server: TestApiServer;
 
 const modelsManager = {
   getModelsInfo: vi.fn(),
+  isModelOnDisk: vi.fn(),
+  createDownloader: vi.fn(),
 } as unknown as ModelsManager;
-
+const catalogManager = {
+  getModelByName: vi.fn(),
+} as unknown as CatalogManager;
 const configurationRegistry = {
   getExtensionConfiguration: () => {
     return {
@@ -50,7 +57,8 @@ const configurationRegistry = {
   },
 } as unknown as ConfigurationRegistry;
 beforeEach(async () => {
-  server = new TestApiServer(extensionContext, modelsManager, configurationRegistry);
+  vi.clearAllMocks();
+  server = new TestApiServer(extensionContext, modelsManager, catalogManager, configurationRegistry);
   vi.spyOn(server, 'displayApiInfo').mockReturnValue();
   vi.spyOn(server, 'getSpecFile').mockReturnValue(path.join(__dirname, '../../../../api/openapi.yaml'));
   vi.spyOn(server, 'getPackageFile').mockReturnValue(path.join(__dirname, '../../../../package.json'));
@@ -148,4 +156,99 @@ test('/api/tags returns error', async () => {
 test('verify listening on localhost', async () => {
   expect(server.getListener()).toBeDefined();
   expect((server.getListener()?.address() as AddressInfo).address).toEqual('127.0.0.1');
+});
+
+test('/api/pull returns an error if no body is passed', async () => {
+  expect(server.getListener()).toBeDefined();
+  await request(server.getListener()!).post('/api/pull').expect(415);
+});
+
+test('/api/pull returns an error if the model is not known', async () => {
+  expect(server.getListener()).toBeDefined();
+  vi.mocked(catalogManager.getModelByName).mockImplementation(() => {
+    throw new Error('model unknown');
+  });
+  const res = await request(server.getListener()!).post('/api/pull').send({ model: 'unknown-model-name' }).expect(200);
+  const lines = res.text.split('\n');
+  expect(lines.length).toEqual(3);
+  expect(lines[0]).toEqual('{"status":"pulling manifest"}');
+  expect(lines[1]).toEqual('{"error":"pull model manifest: file does not exist"}');
+  expect(lines[2]).toEqual('');
+});
+
+test('/api/pull returns success if model already downloaded', async () => {
+  expect(server.getListener()).toBeDefined();
+  vi.mocked(catalogManager.getModelByName).mockReturnValue({
+    id: 'modelId',
+    name: 'model-name',
+    description: 'a description',
+  });
+  vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(true);
+  const res = await request(server.getListener()!).post('/api/pull').send({ model: 'model-name' }).expect(200);
+  const lines = res.text.split('\n');
+  expect(lines.length).toEqual(3);
+  expect(lines[0]).toEqual('{"status":"pulling manifest"}');
+  expect(lines[1]).toEqual('{"status":"success"}');
+  expect(lines[2]).toEqual('');
+});
+
+test('/api/pull downloads model and returns success', async () => {
+  expect(server.getListener()).toBeDefined();
+  vi.mocked(catalogManager.getModelByName).mockReturnValue({
+    id: 'modelId',
+    name: 'model-name',
+    description: 'a description',
+    sha256: '123456',
+  });
+  vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(false);
+  vi.mocked(modelsManager.createDownloader).mockReturnValue({
+    perform: async (_name: string) => {},
+    onEvent: (listener: (e: ProgressEvent) => void) => {
+      listener({
+        status: 'progress',
+        id: 'model-name',
+        total: 100000,
+        value: 100000,
+      });
+    },
+  } as unknown as Downloader);
+  const res = await request(server.getListener()!).post('/api/pull').send({ model: 'model-name' }).expect(200);
+  const lines = res.text.split('\n');
+  expect(lines.length).toEqual(4);
+  expect(lines[0]).toEqual('{"status":"pulling manifest"}');
+  expect(lines[1]).toEqual('{"status":"pulling 123456","digest":"sha256:123456","total":100000,"completed":100000000}');
+  expect(lines[2]).toEqual('{"status":"success"}');
+  expect(lines[3]).toEqual('');
+});
+
+test('/api/pull should return an error if an error occurs during download', async () => {
+  expect(server.getListener()).toBeDefined();
+  vi.mocked(catalogManager.getModelByName).mockReturnValue({
+    id: 'modelId',
+    name: 'model-name',
+    description: 'a description',
+    sha256: '123456',
+  });
+  vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(false);
+  vi.mocked(modelsManager.createDownloader).mockReturnValue({
+    perform: async (_name: string) => {
+      await new Promise(resolve => setTimeout(resolve, 0)); // wait for random port to be set
+      throw new Error('an error');
+    },
+    onEvent: (listener: (e: ProgressEvent) => void) => {
+      listener({
+        status: 'progress',
+        id: 'model-name',
+        total: 100000,
+        value: 100000,
+      });
+    },
+  } as unknown as Downloader);
+  const res = await request(server.getListener()!).post('/api/pull').send({ model: 'model-name' }).expect(200);
+  const lines = res.text.split('\n');
+  expect(lines.length).toEqual(4);
+  expect(lines[0]).toEqual('{"status":"pulling manifest"}');
+  expect(lines[1]).toEqual('{"status":"pulling 123456","digest":"sha256:123456","total":100000,"completed":100000000}');
+  expect(lines[2]).toEqual('{"error":"Error: an error"}');
+  expect(lines[3]).toEqual('');
 });

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -166,6 +166,14 @@ export class CatalogManager extends Publisher<ApplicationCatalog> implements Dis
     return model;
   }
 
+  public getModelByName(modelName: string): ModelInfo {
+    const model = this.getModels().find(m => modelName === m.name);
+    if (!model) {
+      throw new Error(`No model found having name ${modelName}`);
+    }
+    return model;
+  }
+
   public getRecipes(): Recipe[] {
     return this.catalog.recipes;
   }

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -340,7 +340,7 @@ export class ModelsManager implements Disposable {
     });
   }
 
-  private createDownloader(model: ModelInfo, abortSignal: AbortSignal): Downloader {
+  public createDownloader(model: ModelInfo, abortSignal: AbortSignal): Downloader {
     if (!model.url) {
       throw new Error(`model ${model.id} does not have url defined.`);
     }

--- a/packages/backend/src/models/baseEvent.ts
+++ b/packages/backend/src/models/baseEvent.ts
@@ -30,6 +30,7 @@ export interface CompletionEvent extends BaseEvent {
 export interface ProgressEvent extends BaseEvent {
   status: 'progress';
   value: number;
+  total: number;
 }
 
 export const isCompletionEvent = (value: unknown): value is CompletionEvent => {

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -329,7 +329,12 @@ export class Studio {
     // Register the instance
     this.#rpcExtension.registerInstance<StudioApiImpl>(StudioApiImpl, this.#studioApi);
 
-    const apiServer = new ApiServer(this.#extensionContext, this.#modelsManager, this.#configurationRegistry);
+    const apiServer = new ApiServer(
+      this.#extensionContext,
+      this.#modelsManager,
+      this.#catalogManager,
+      this.#configurationRegistry,
+    );
     await apiServer.init();
     this.#extensionContext.subscriptions.push(apiServer);
   }

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -133,6 +133,7 @@ export class Downloader {
             id: this.requestedIdentifier,
             status: 'progress',
             value: progressValue,
+            total: totalFileSize,
           } as ProgressEvent);
         }
       });


### PR DESCRIPTION
### What does this PR do?

Adds a `/api/pull` endpoint to the API to download models

### Screenshot / video of UI


https://github.com/user-attachments/assets/bcc8fb65-cec6-4c79-b85d-6b55875d9f83


### What issues does this PR fix or reference?

Fixes #1583 

### How to test this PR?

Start AI Lab extension

```
$ OLLAMA_HOST=localhost:10434 ollama pull facebook/detr-resnet-101
// should download model
$ OLLAMA_HOST=localhost:10434 ollama pull facebook/detr-resnet-101
// should indicate success and not reload model
$ OLLAMA_HOST=localhost:10434 ollama pull unknown-model
// should fail with error message
```
<!-- Please explain steps to reproduce -->