### PR TITLE
fix: redirect url on model download

### DIFF
--- a/packages/backend/src/utils/downloader.spec.ts
+++ b/packages/backend/src/utils/downloader.spec.ts
@@ -187,3 +187,26 @@ test('perform download successfully', async () => {
   });
   expect(promises.rm).not.toHaveBeenCalled();
 });
+
+
+class DownloaderTest extends Downloader {
+  public override getRedirect(location: string): string {
+    return super.getRedirect(location);
+  }
+}
+
+const SITE_EXAMPLE = 'https://example.com/hello';
+const SITE_DUMMY = 'https://dummy.com/world';
+
+test('redirect should use location if parsable', () => {
+  const downloader = new DownloaderTest(SITE_EXAMPLE, '/home/file.guff');
+  const result = downloader.getRedirect(SITE_DUMMY);
+  expect(result).toBe(SITE_DUMMY);
+});
+
+test('redirect should concat base url and location if not parsable', () => {
+  const downloader = new DownloaderTest(SITE_EXAMPLE, '/home/file.guff');
+  const result = downloader.getRedirect('/world');
+  expect(result).toBe('https://example.com/world');
+});
+

--- a/packages/backend/src/utils/downloader.spec.ts
+++ b/packages/backend/src/utils/downloader.spec.ts
@@ -188,7 +188,6 @@ test('perform download successfully', async () => {
   expect(promises.rm).not.toHaveBeenCalled();
 });
 
-
 class DownloaderTest extends Downloader {
   public override getRedirect(location: string): string {
     return super.getRedirect(location);
@@ -209,4 +208,3 @@ test('redirect should concat base url and location if not parsable', () => {
   const result = downloader.getRedirect('/world');
   expect(result).toBe('https://example.com/world');
 });
-

--- a/packages/backend/src/utils/downloader.spec.ts
+++ b/packages/backend/src/utils/downloader.spec.ts
@@ -189,7 +189,7 @@ test('perform download successfully', async () => {
 });
 
 class DownloaderTest extends Downloader {
-  public override getRedirect(url :string, location: string): string {
+  public override getRedirect(url: string, location: string): string {
     return super.getRedirect(url, location);
   }
 }

--- a/packages/backend/src/utils/downloader.spec.ts
+++ b/packages/backend/src/utils/downloader.spec.ts
@@ -189,8 +189,8 @@ test('perform download successfully', async () => {
 });
 
 class DownloaderTest extends Downloader {
-  public override getRedirect(location: string): string {
-    return super.getRedirect(location);
+  public override getRedirect(url :string, location: string): string {
+    return super.getRedirect(url, location);
   }
 }
 
@@ -199,12 +199,12 @@ const SITE_DUMMY = 'https://dummy.com/world';
 
 test('redirect should use location if parsable', () => {
   const downloader = new DownloaderTest(SITE_EXAMPLE, '/home/file.guff');
-  const result = downloader.getRedirect(SITE_DUMMY);
+  const result = downloader.getRedirect(SITE_EXAMPLE, SITE_DUMMY);
   expect(result).toBe(SITE_DUMMY);
 });
 
 test('redirect should concat base url and location if not parsable', () => {
   const downloader = new DownloaderTest(SITE_EXAMPLE, '/home/file.guff');
-  const result = downloader.getRedirect('/world');
+  const result = downloader.getRedirect(SITE_EXAMPLE, '/world');
   expect(result).toBe('https://example.com/world');
 });

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -94,11 +94,10 @@ export class Downloader {
    * @protected
    */
   protected getRedirect(location: string): string {
-    if(URL.canParse(location))
-      return location;
+    if (URL.canParse(location)) return location;
 
     const origin = new URL(this.url).origin;
-    if(URL.canParse(location, origin)) return new URL(location, origin).href;
+    if (URL.canParse(location, origin)) return new URL(location, origin).href;
 
     console.warn(`malformed location: cannot parse ${location}`);
     return location;

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -89,17 +89,17 @@ export class Downloader {
 
   /**
    * This file takes as argument a location, either a full url or a path
-   * if a path is provided, the base url will be used as origin.
+   * if a path is provided, the url will be used as origin.
+   * @param url
    * @param location
    * @protected
    */
-  protected getRedirect(location: string): string {
+  protected getRedirect(url :string, location: string): string {
     if (URL.canParse(location)) return location;
 
-    const origin = new URL(this.url).origin;
+    const origin = new URL(url).origin;
     if (URL.canParse(location, origin)) return new URL(location, origin).href;
 
-    console.warn(`malformed location: cannot parse ${location}`);
     return location;
   }
 
@@ -117,8 +117,7 @@ export class Downloader {
     https.get(url, { signal: this.abortSignal }, resp => {
       // Determine the total size
       if (resp.headers.location) {
-        const redirect = this.getRedirect(resp.headers.location);
-        console.warn(`follow redirect to ${redirect}`);
+        const redirect = this.getRedirect(url, resp.headers.location);
         this.followRedirects(redirect, callback);
         return;
       }

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -94,7 +94,7 @@ export class Downloader {
    * @param location
    * @protected
    */
-  protected getRedirect(url :string, location: string): string {
+  protected getRedirect(url: string, location: string): string {
     if (URL.canParse(location)) return location;
 
     const origin = new URL(url).origin;


### PR DESCRIPTION
### What does this PR do?

When redirecting through the location header, website may provide only the path (E.g. `/hello`) when we expect a full url. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1651

### How to test this PR?

- [x] unit tests has been provided