### PR TITLE
feat: allow disabling model upload

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
         "ai-lab.modelUploadDisabled": {
           "type": "boolean",
           "default": false,
-          "description": "Disable the model Upload to the podman machine",
+          "description": "Disable the model upload to the podman machine",
           "hidden": true
         },
         "ai-lab.experimentalGPU": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,12 @@
           "default": "",
           "description": "Custom path where to download models. Note: The extension must be restarted for changes to take effect. (Default is blank)"
         },
+        "ai-lab.modelUploadDisabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable the model Upload to the podman machine",
+          "hidden": true
+        },
         "ai-lab.experimentalGPU": {
           "type": "boolean",
           "default": false,

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -26,7 +26,7 @@ const CONFIGURATION_SECTIONS: string[] = [
   'ai-lab.experimentalGPU',
   'ai-lab.apiPort',
   'ai-lab.experimentalTuning',
-  'ai-lab.windows.disableWSLUpload',
+  'ai-lab.modelUploadDisabled',
 ];
 
 const API_PORT_DEFAULT = 10434;

--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -26,6 +26,7 @@ const CONFIGURATION_SECTIONS: string[] = [
   'ai-lab.experimentalGPU',
   'ai-lab.apiPort',
   'ai-lab.experimentalTuning',
+  'ai-lab.windows.disableWSLUpload',
 ];
 
 const API_PORT_DEFAULT = 10434;
@@ -49,6 +50,7 @@ export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> imp
       experimentalGPU: this.#configuration.get<boolean>('experimentalGPU') ?? false,
       apiPort: this.#configuration.get<number>('apiPort') ?? API_PORT_DEFAULT,
       experimentalTuning: this.#configuration.get<boolean>('experimentalTuning') ?? false,
+      modelUploadDisabled: this.#configuration.get<boolean>('modelUploadDisabled') ?? false,
     };
   }
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -212,6 +212,7 @@ export class Studio {
       this.#taskRegistry,
       this.#cancellationTokenRegistry,
       this.#podmanConnection,
+      this.#configurationRegistry,
     );
     this.#modelsManager.init();
     this.#extensionContext.subscriptions.push(this.#modelsManager);

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -97,6 +97,7 @@ beforeEach(() => {
     modelsPath: 'model-path',
     apiPort: 10434,
     experimentalTuning: false,
+    modelUploadDisabled: false,
   });
   vi.mocked(podmanConnection.findRunningContainerProviderConnection).mockReturnValue(dummyConnection);
   vi.mocked(podmanConnection.getContainerProviderConnection).mockReturnValue(dummyConnection);
@@ -275,6 +276,7 @@ describe('perform', () => {
       modelsPath: '',
       apiPort: 10434,
       experimentalTuning: false,
+      modelUploadDisabled: false,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
@@ -306,6 +308,7 @@ describe('perform', () => {
       modelsPath: '',
       apiPort: 10434,
       experimentalTuning: false,
+      modelUploadDisabled: false,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
@@ -339,6 +342,7 @@ describe('perform', () => {
       modelsPath: '',
       apiPort: 10434,
       experimentalTuning: false,
+      modelUploadDisabled: false,
     });
 
     vi.mocked(gpuManager.collectGPUs).mockResolvedValue([

--- a/packages/shared/src/models/IExtensionConfiguration.ts
+++ b/packages/shared/src/models/IExtensionConfiguration.ts
@@ -21,4 +21,5 @@ export interface ExtensionConfiguration {
   modelsPath: string;
   apiPort: number;
   experimentalTuning: boolean;
+  modelUploadDisabled: boolean;
 }


### PR DESCRIPTION
### What does this PR do?

This PR add an hidden configuration allowing to disable the model upload to the podman machine. 

### Screenshot / video of UI

| Enabled (default) | Disabled |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c2a94bc4-2d8f-4b7b-9588-cc2b868f6eb5) | ![Screenshot from 2024-09-04 15-19-03](https://github.com/user-attachments/assets/55d5a9bf-d02b-4e1a-9b43-a4b24ec1f63e) |

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1661

### How to test this PR?

- [x] unit tests has been provided

**Manually**

Inside the `~/.local/share/containers/podman-desktop/configuration/settings.json` add the following **before starting podman-desktop**

```json
  "ai-lab.modelUploadDisabled": true,
```

- start podman-desktop
- start an inference server
- no model upload task
- go to container details
- assert mount path is host machine and not wsl (windows)