### PR TITLE
fix: model format typo on import page

### DIFF
--- a/packages/frontend/src/pages/ImportModel.svelte
+++ b/packages/frontend/src/pages/ImportModel.svelte
@@ -135,7 +135,7 @@ export function goToUpPage(): void {
               class="w-full cursor-pointer flex-col px-4 py-8 border-2 border-dashed rounded flex justify-center items-center">
               <Fa size="1.1x" class="cursor-pointer text-[var(--pd-link)]" icon={faFileImport} />
               <span>Drag & Drop or <strong class="text-[var(--pd-link)]">Choose file</strong> to import</span>
-              <span class="opacity-50 text-sm">Supported format: .guff, .bin</span>
+              <span class="opacity-50 text-sm">Supported formats: .gguf, .bin</span>
             </button>
           {:else}
             <!-- showing path -->


### PR DESCRIPTION
### What does this PR do?
Fixes model format typo on the model import page in the AI lab extension. Currently, it shows .guff as a supported format whereas it should be .gguf
### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->
After the fix:
<img width="1162" alt="Screenshot 2024-09-11 at 1 08 29 PM" src="https://github.com/user-attachments/assets/3854bcc5-09bf-4c2f-8e9d-57155c7bec6e">

### What issues does this PR fix or reference?
Fixes #1634 

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
Build the AI lab extension and test it by running the following command from the Podman Desktop directory:
`pnpm watch --extension-folder ../podman-desktop-extension-ai-lab/packages/backend`
<!-- Please explain steps to reproduce -->