### PR TITLE
chore: add cache-dependency-path to e2e-main.yaml

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -63,12 +63,6 @@ jobs:
           ref: main
           path: podman-desktop
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
-          package_json_file: ./podman-desktop/package.json
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -99,12 +93,6 @@ jobs:
         run: |
           # allow unprivileged user namespace
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
-          package_json_file: ./podman-desktop/package.json
 
       - name: Execute pnpm
         working-directory: ./podman-desktop

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -63,6 +63,12 @@ jobs:
           ref: main
           path: podman-desktop
 
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+          package_json_file: ./podman-desktop/package.json
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -73,7 +73,9 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-          cache-dependency-path: '**/pnpm-lock.yaml'
+          cache-dependency-path: |
+            podman-desktop/pnpm-lock.yaml
+            podman-desktop-extension-ai-lab/pnpm-lock.yaml
 
       - name: Update podman
         run: |

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -73,6 +73,7 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Update podman
         run: |

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -73,7 +73,9 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-          cache-dependency-path: ./podman-desktop/pnpm-lock.yaml
+          cache-dependency-path: |
+            ./podman-desktop
+            ./podman-desktop-extension-ai-lab
 
       - name: Update podman
         run: |

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -73,9 +73,7 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-          cache-dependency-path: |
-            podman-desktop/pnpm-lock.yaml
-            podman-desktop-extension-ai-lab/pnpm-lock.yaml
+          cache-dependency-path: ./podman-desktop/pnpm-lock.yaml
 
       - name: Update podman
         run: |


### PR DESCRIPTION
### What does this PR do?
Adds a value for cache-dependency-path in order to fix this error on the workflow:
`Error: Dependencies lock file is not found in /home/runner/work/podman-desktop-extension-ai-lab/podman-desktop-extension-ai-lab. Supported file patterns: pnpm-lock.yaml`
### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#1692 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->