### PR TITLE
fix: fix light mode for download models panel

### DIFF
--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -120,9 +120,9 @@ async function importModel(): Promise<void> {
       {#if !loading}
         {#if pullingTasks.length > 0}
           <div class="w-full px-5">
-            <Card classes="bg-charcoal-800 mt-4">
+            <Card classes="bg-[var(--pd-content-card-bg)] mt-4">
               <div slot="content" class="font-normal p-2 w-full">
-                <div class=" mb-2">Downloading models</div>
+                <div class="text-[var(--pd-content-card-title)] mb-2">Downloading models</div>
                 <TasksProgress tasks={pullingTasks} />
               </div>
             </Card>


### PR DESCRIPTION
### What does this PR do?

It enables light mode for the download models tasks panel

### Screenshot / video of UI

before 
![old_download](https://github.com/user-attachments/assets/7aabc493-7650-490e-b80f-a56cadc8cdc3)

after 
![image](https://github.com/user-attachments/assets/faa2bd5e-faae-4e20-9ce1-7fc05bd92e48)


### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. download a model