### PR TITLE
feat(forms): improve reactivity on trackingId query

### DIFF
--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -94,7 +94,7 @@ onDestroy(() => {
       <!-- Recipes -->
       <Route path="/recipe/:id/*" firstmatch let:meta>
         <Route path="/start">
-          <StartRecipe recipeId={meta.params.id} />
+          <StartRecipe recipeId={meta.params.id} trackingId={meta.query.trackingId} />
         </Route>
         <Route path="/*">
           <Recipe recipeId={meta.params.id} />
@@ -122,7 +122,7 @@ onDestroy(() => {
 
       <Route path="/service/:id/*" let:meta>
         {#if meta.params.id === 'create'}
-          <CreateService />
+          <CreateService trackingId={meta.query.trackingId} />
         {:else}
           <ServiceDetails containerId={meta.params.id} />
         {/if}

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -225,7 +225,9 @@ test('tasks should be displayed after requestCreateInferenceServer', async () =>
     return (): void => {};
   });
 
-  render(CreateService);
+  render(CreateService, {
+    trackingId: 'dummyTrackingId',
+  });
 
   // wait for listener to be defined
   await vi.waitFor(() => {
@@ -273,7 +275,9 @@ test('form should be disabled when loading', async () => {
     return (): void => {};
   });
 
-  render(CreateService);
+  render(CreateService, {
+    trackingId: 'dummyTrackingId',
+  });
 
   // wait for listener to be defined
   await vi.waitFor(() => {

--- a/packages/frontend/src/pages/StartRecipe.spec.ts
+++ b/packages/frontend/src/pages/StartRecipe.spec.ts
@@ -357,6 +357,7 @@ test('Completed task should make the open details button visible', async () => {
 
   const { container } = render(StartRecipe, {
     recipeId: 'dummy-recipe-id',
+    trackingId: 'fake-tracking-id',
   });
 
   await vi.waitFor(() => {
@@ -380,6 +381,7 @@ test('trackingId in router query should use it to display related tasks', () => 
 
   render(StartRecipe, {
     recipeId: 'dummy-recipe-id',
+    trackingId: 'fake-tracking-id',
   });
   const button = screen.getByTitle(`Start ${fakeRecipe.name} recipe`);
   expect(button).toBeDisabled();


### PR DESCRIPTION
### What does this PR do?

Instead of collecting the `trackingId` using `router.location.query.get` the `App.svelte` provide it as a component property.

### Screenshot / video of UI

https://github.com/user-attachments/assets/764ae3f1-3437-43bd-a2d9-23a09b35dff2

> :information_source:  Video is a combination of https://github.com/containers/podman-desktop-extension-ai-lab/pull/1745 and this PR

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1781
Required for https://github.com/containers/podman-desktop-extension-ai-lab/pull/1745

### How to test this PR?

- [x] unit tests has been provided