### PR TITLE
fix(ui): svelte select clear event

### DIFF
--- a/packages/frontend/src/lib/select/Select.spec.ts
+++ b/packages/frontend/src/lib/select/Select.spec.ts
@@ -121,3 +121,38 @@ test('selecting value should call onchange callback', async () => {
     });
   });
 });
+
+test('clearing value should call onchange callback with undefined', async () => {
+  const onChangeMock = vi.fn();
+  const { container } = render(Select, {
+    label: 'Select Item',
+    items: [
+      {
+        label: 'Dummy Item 1',
+        value: 'item-1',
+      },
+      {
+        label: 'Dummy Item 2',
+        value: 'item-2',
+      },
+    ],
+    value: {
+      label: 'Dummy Item 2',
+      value: 'item-2',
+    },
+    onchange: onChangeMock,
+  });
+
+  // get clear HTMLElement
+  const clear = container.querySelector('button[class~="clear-select"]');
+  // ensure we have two options
+  expect(clear).not.toBeNull();
+  if (!clear) throw new Error('clear is null');
+
+  await fireEvent.click(clear);
+
+  await vi.waitFor(() => {
+    expect(onChangeMock).toHaveBeenCalledWith(undefined);
+    expect(onChangeMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/frontend/src/lib/select/Select.svelte
+++ b/packages/frontend/src/lib/select/Select.svelte
@@ -15,6 +15,11 @@ function handleOnChange(e: CustomEvent<T | undefined>): void {
   value = e.detail;
   onchange?.(value);
 }
+
+function handleOnClear(): void {
+  value = undefined;
+  onchange?.(value);
+}
 </script>
 
 <Select
@@ -22,6 +27,7 @@ function handleOnChange(e: CustomEvent<T | undefined>): void {
   name={name}
   disabled={disabled}
   value={value}
+  on:clear={handleOnClear}
   on:change={handleOnChange}
   --item-color={'var(--pd-dropdown-item-text)'}
   --item-is-active-color={'var(--pd-dropdown-item-text)'}


### PR DESCRIPTION
### What does this PR do?

The `Select` component from `svelte-select` do not emit a change event when the clear is triggered. This PR add a clear listener to capture and propagate it.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1791

### How to test this PR?

- [x] unit tests has been provided