### PR TITLE
fix(CreateService): should use query `model-id` to select default model

### DIFF
--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -441,10 +441,9 @@ test('model-id query should be used to select default model', async () => {
 
   await vi.waitFor(() => {
     expect(studioClient.requestCreateInferenceServer).toHaveBeenCalledWith({
-      modelsInfo: [expect.objectContaining({id: 'model-id-2'})],
+      modelsInfo: [expect.objectContaining({ id: 'model-id-2' })],
       port: 8888,
       connection: containerProviderConnection,
     });
   });
 });
-

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -359,7 +359,6 @@ test('should display connectionInfo message if there is no running connection', 
     } as unknown as ModelInfo,
   ]);
   vi.mocked(modelsInfoStore).modelsInfo = modelsInfoList;
-  router.location.query.set('model-id', 'id');
   render(CreateService);
 
   await vi.waitFor(() => {
@@ -383,7 +382,6 @@ test('should display connectionInfo message if there is a podman connection with
     } as unknown as ModelInfo,
   ]);
   vi.mocked(modelsInfoStore).modelsInfo = modelsInfoList;
-  router.location.query.set('model-id', 'id');
   render(CreateService);
 
   await vi.waitFor(() => {
@@ -404,7 +402,6 @@ test('there should be NO banner if there is a running podman connection having e
     } as unknown as ModelInfo,
   ]);
   vi.mocked(modelsInfoStore).modelsInfo = modelsInfoList;
-  router.location.query.set('model-id', 'id');
   render(CreateService);
 
   await vi.waitFor(() => {
@@ -412,3 +409,42 @@ test('there should be NO banner if there is a running podman connection having e
     expect(banner).not.toBeInTheDocument();
   });
 });
+
+test('model-id query should be used to select default model', async () => {
+  const modelsInfoList = writable<ModelInfo[]>([
+    {
+      id: 'model-id-1',
+      file: {
+        file: 'file',
+        path: '/path',
+      },
+    } as unknown as ModelInfo,
+    {
+      id: 'model-id-2',
+      file: {
+        file: 'file',
+        path: '/path',
+      },
+    } as unknown as ModelInfo,
+  ]);
+  vi.mocked(modelsInfoStore).modelsInfo = modelsInfoList;
+  router.location.query.set('model-id', 'model-id-2');
+
+  render(CreateService);
+  const createBtn = screen.getByTitle('Create service');
+
+  await vi.waitFor(() => {
+    expect(createBtn).toBeEnabled();
+  });
+
+  await fireEvent.click(createBtn);
+
+  await vi.waitFor(() => {
+    expect(studioClient.requestCreateInferenceServer).toHaveBeenCalledWith({
+      modelsInfo: [expect.objectContaining({id: 'model-id-2'})],
+      port: 8888,
+      connection: containerProviderConnection,
+    });
+  });
+});
+

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -156,6 +156,12 @@ function refreshTasks(): void {
 onMount(async () => {
   containerPort = await studioClient.getHostFreePort();
 
+  // we might have a query parameter, then we should use it
+  const queryModelId = router.location.query.get('model-id');
+  if (queryModelId !== undefined && typeof queryModelId === 'string') {
+    model = localModels.find(mModel => mModel.id === queryModelId);
+  }
+
   tasks.subscribe(tasks => {
     processTasks(tasks);
   });


### PR DESCRIPTION
### What does this PR do?

https://github.com/containers/podman-desktop-extension-ai-lab/pull/1782 introduced a regression (my bad) where the default model selection was ignoring the query parameter `model-id`.

### Screenshot / video of UI

https://github.com/user-attachments/assets/02471e82-6c78-45c9-a973-142a881063e7

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1790

### How to test this PR?

- [x] unit tets