### PR TITLE
feat(UI): share tasks management logic between `CreateService` and `StartRecipe` 

### DIFF
--- a/packages/frontend/src/lib/progress/TrackedTasks.spec.ts
+++ b/packages/frontend/src/lib/progress/TrackedTasks.spec.ts
@@ -1,0 +1,101 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import TrackedTasks from '/@/lib/progress/TrackedTasks.svelte';
+
+vi.mock('../../utils/client', () => ({
+  studioClient: {
+    requestCancelToken: vi.fn(),
+  },
+}));
+
+test('empty task should not have any content', async () => {
+  const { queryByRole } = render(TrackedTasks, {
+    tasks: [],
+  });
+
+  const status = queryByRole('status');
+  expect(status).toBeNull();
+});
+
+test('task without matching trackingId should not have any content', async () => {
+  const { queryByRole } = render(TrackedTasks, {
+    tasks: [{
+      id: 'dummy-id',
+      name: 'Hello World',
+      state: 'loading',
+      labels: {
+        trackingId: 'dummyTrackingId',
+      },
+    }],
+    trackingId: 'notMatching',
+  });
+
+  const status = queryByRole('status');
+  expect(status).toBeNull();
+});
+
+test('task with matching trackingId should be visible', () => {
+  const { getByRole } = render(TrackedTasks, {
+    tasks: [{
+      id: 'dummy-id',
+      name: 'Hello World',
+      state: 'loading',
+      labels: {
+        trackingId: 'dummyTrackingId',
+      },
+    }],
+    trackingId: 'dummyTrackingId',
+  });
+
+  const status = getByRole('status');
+  expect(status).toBeInTheDocument();
+});
+
+test('onChange should provide task with matching trackingId', () => {
+  const onChangeMock = vi.fn();
+  render(TrackedTasks, {
+    tasks: [{
+      id: 'dummy-id',
+      name: 'Hello World',
+      state: 'loading',
+      labels: {
+        trackingId: 'dummyTrackingId',
+      },
+    },
+      {
+        id: 'dummy-id-2',
+        name: 'Hello World 2',
+        state: 'loading',
+      }],
+    trackingId: 'dummyTrackingId',
+    onChange: onChangeMock,
+  });
+
+  expect(onChangeMock).toHaveBeenCalledWith([{
+    id: 'dummy-id',
+    name: 'Hello World',
+    state: 'loading',
+    labels: {
+      trackingId: 'dummyTrackingId',
+    },
+  }]);
+});

--- a/packages/frontend/src/lib/progress/TrackedTasks.spec.ts
+++ b/packages/frontend/src/lib/progress/TrackedTasks.spec.ts
@@ -38,14 +38,16 @@ test('empty task should not have any content', async () => {
 
 test('task without matching trackingId should not have any content', async () => {
   const { queryByRole } = render(TrackedTasks, {
-    tasks: [{
-      id: 'dummy-id',
-      name: 'Hello World',
-      state: 'loading',
-      labels: {
-        trackingId: 'dummyTrackingId',
+    tasks: [
+      {
+        id: 'dummy-id',
+        name: 'Hello World',
+        state: 'loading',
+        labels: {
+          trackingId: 'dummyTrackingId',
+        },
       },
-    }],
+    ],
     trackingId: 'notMatching',
   });
 
@@ -55,14 +57,16 @@ test('task without matching trackingId should not have any content', async () =>
 
 test('task with matching trackingId should be visible', () => {
   const { getByRole } = render(TrackedTasks, {
-    tasks: [{
-      id: 'dummy-id',
-      name: 'Hello World',
-      state: 'loading',
-      labels: {
-        trackingId: 'dummyTrackingId',
+    tasks: [
+      {
+        id: 'dummy-id',
+        name: 'Hello World',
+        state: 'loading',
+        labels: {
+          trackingId: 'dummyTrackingId',
+        },
       },
-    }],
+    ],
     trackingId: 'dummyTrackingId',
   });
 
@@ -73,7 +77,27 @@ test('task with matching trackingId should be visible', () => {
 test('onChange should provide task with matching trackingId', () => {
   const onChangeMock = vi.fn();
   render(TrackedTasks, {
-    tasks: [{
+    tasks: [
+      {
+        id: 'dummy-id',
+        name: 'Hello World',
+        state: 'loading',
+        labels: {
+          trackingId: 'dummyTrackingId',
+        },
+      },
+      {
+        id: 'dummy-id-2',
+        name: 'Hello World 2',
+        state: 'loading',
+      },
+    ],
+    trackingId: 'dummyTrackingId',
+    onChange: onChangeMock,
+  });
+
+  expect(onChangeMock).toHaveBeenCalledWith([
+    {
       id: 'dummy-id',
       name: 'Hello World',
       state: 'loading',
@@ -81,21 +105,5 @@ test('onChange should provide task with matching trackingId', () => {
         trackingId: 'dummyTrackingId',
       },
     },
-      {
-        id: 'dummy-id-2',
-        name: 'Hello World 2',
-        state: 'loading',
-      }],
-    trackingId: 'dummyTrackingId',
-    onChange: onChangeMock,
-  });
-
-  expect(onChangeMock).toHaveBeenCalledWith([{
-    id: 'dummy-id',
-    name: 'Hello World',
-    state: 'loading',
-    labels: {
-      trackingId: 'dummyTrackingId',
-    },
-  }]);
+  ]);
 });

--- a/packages/frontend/src/lib/progress/TrackedTasks.svelte
+++ b/packages/frontend/src/lib/progress/TrackedTasks.svelte
@@ -5,9 +5,9 @@ import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
 
 interface Props {
   trackingId?: string;
-  tasks: Task[],
+  tasks: Task[];
   class?: string;
-  onChange?: (tasks: Task[]) => void,
+  onChange?: (tasks: Task[]) => void;
 }
 let { trackingId, tasks, onChange, class: classes }: Props = $props();
 
@@ -31,4 +31,3 @@ $effect(() => {
     <TasksProgress tasks={trackedTasks} />
   </div>
 {/if}
-

--- a/packages/frontend/src/lib/progress/TrackedTasks.svelte
+++ b/packages/frontend/src/lib/progress/TrackedTasks.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import type { Task } from '@shared/src/models/ITask';
+import { filterByLabel } from '/@/utils/taskUtils';
+import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
+
+interface Props {
+  trackingId?: string;
+  tasks: Task[],
+  class?: string;
+  onChange?: (tasks: Task[]) => void,
+}
+let { trackingId, tasks, onChange, class: classes }: Props = $props();
+
+let trackedTasks: Task[] = $derived.by(() => {
+  if (trackingId === undefined) {
+    return [];
+  }
+
+  return filterByLabel(tasks, {
+    trackingId: trackingId,
+  });
+});
+
+$effect(() => {
+  onChange?.($state.snapshot(trackedTasks));
+});
+</script>
+
+{#if trackedTasks.length > 0}
+  <div role="status" class={classes}>
+    <TasksProgress tasks={trackedTasks} />
+  </div>
+{/if}
+

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -19,7 +19,7 @@ import TrackedTasks from '/@/lib/progress/TrackedTasks.svelte';
 
 interface Props {
   // The tracking id is a unique identifier provided by the
-// backend when calling requestCreateInferenceServer
+  // backend when calling requestCreateInferenceServer
   trackingId?: string;
 }
 
@@ -32,9 +32,9 @@ let localModels: ModelInfo[] = $derived($modelsInfo.filter(model => model.file))
 let containerProviderConnection: ContainerProviderConnectionInfo | undefined = $state(undefined);
 
 // Filtered connections (started)
-let startedContainerProviderConnectionInfo: ContainerProviderConnectionInfo[] = $derived($containerProviderConnections.filter(
-  connection => connection.status === 'started',
-));
+let startedContainerProviderConnectionInfo: ContainerProviderConnectionInfo[] = $derived(
+  $containerProviderConnections.filter(connection => connection.status === 'started'),
+);
 
 // The containerPort is the bind value to form input
 let containerPort: number | undefined = $state(undefined);
@@ -134,11 +134,14 @@ function populateModelFromTasks(trackedTasks: Task[]): void {
 }
 
 onMount(() => {
-  studioClient.getHostFreePort().then((port) => {
-    containerPort = port;
-  }).catch((err: unknown) => {
-    console.error(err);
-  });
+  studioClient
+    .getHostFreePort()
+    .then(port => {
+      containerPort = port;
+    })
+    .catch((err: unknown) => {
+      console.error(err);
+    });
 
   // we might have a query parameter, then we should use it
   const queryModelId = router.location.query.get('model-id');
@@ -169,12 +172,14 @@ export function goToUpPage(): void {
       <!-- warning machine resources -->
       {#if containerProviderConnection}
         <div class="mx-5">
-          <ContainerConnectionWrapper model={$state.snapshot(model)} containerProviderConnection={$state.snapshot(containerProviderConnection)} />
+          <ContainerConnectionWrapper
+            model={$state.snapshot(model)}
+            containerProviderConnection={$state.snapshot(containerProviderConnection)} />
         </div>
       {/if}
 
       <!-- tasks tracked -->
-      <TrackedTasks onChange={processTasks} class="mx-5 mt-5" trackingId={trackingId} tasks={$tasks}/>
+      <TrackedTasks onChange={processTasks} class="mx-5 mt-5" trackingId={trackingId} tasks={$tasks} />
 
       <!-- form -->
       <div class="bg-[var(--pd-content-card-bg)] m-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg h-fit">

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -8,8 +8,6 @@ import { onMount } from 'svelte';
 import { studioClient } from '/@/utils/client';
 import { tasks } from '/@/stores/tasks';
 import type { Task } from '@shared/src/models/ITask';
-import { filterByLabel } from '/@/utils/taskUtils';
-import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
 import { inferenceServers } from '/@/stores/inferenceServers';
 import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 import { Button, ErrorMessage, FormPage, Input } from '@podman-desktop/ui-svelte';
@@ -17,54 +15,54 @@ import ModelSelect from '../lib/select/ModelSelect.svelte';
 import { containerProviderConnections } from '/@/stores/containerProviderConnections';
 import ContainerProviderConnectionSelect from '/@/lib/select/ContainerProviderConnectionSelect.svelte';
 import ContainerConnectionWrapper from '/@/lib/notification/ContainerConnectionWrapper.svelte';
-import { get } from 'svelte/store';
+import TrackedTasks from '/@/lib/progress/TrackedTasks.svelte';
 
-// The tracking id is a unique identifier provided by the
+interface Props {
+  // The tracking id is a unique identifier provided by the
 // backend when calling requestCreateInferenceServer
-export let trackingId: string | undefined = undefined;
-
-// List of the models available locally
-let localModels: ModelInfo[];
-$: localModels = $modelsInfo.filter(model => model.file);
-
-// The container provider connection to use
-let containerProviderConnection: ContainerProviderConnectionInfo | undefined = undefined;
-
-// Filtered connections (started)
-let startedContainerProviderConnectionInfo: ContainerProviderConnectionInfo[] = [];
-$: startedContainerProviderConnectionInfo = $containerProviderConnections.filter(
-  connection => connection.status === 'started',
-);
-
-// Select default connection
-$: if (containerProviderConnection === undefined && startedContainerProviderConnectionInfo.length > 0) {
-  containerProviderConnection = startedContainerProviderConnectionInfo[0];
+  trackingId?: string;
 }
 
+let { trackingId }: Props = $props();
+
+// List of the models available locally
+let localModels: ModelInfo[] = $derived($modelsInfo.filter(model => model.file));
+
+// The container provider connection to use
+let containerProviderConnection: ContainerProviderConnectionInfo | undefined = $state(undefined);
+
+// Filtered connections (started)
+let startedContainerProviderConnectionInfo: ContainerProviderConnectionInfo[] = $derived($containerProviderConnections.filter(
+  connection => connection.status === 'started',
+));
+
 // The containerPort is the bind value to form input
-let containerPort: number | undefined = undefined;
+let containerPort: number | undefined = $state(undefined);
 // The model is the bind value to ModelSelect form
-let model: ModelInfo | undefined = undefined;
+let model: ModelInfo | undefined = $state(undefined);
 // If the creation of a new inference service fail
-let errorMsg: string | undefined = undefined;
-// The trackedTasks are the tasks linked to the trackingId
-let trackedTasks: Task[];
-
-// has an error been raised
-let error: boolean = false;
-
+let errorMsg: string | undefined = $state(undefined);
 // The containerId will be included in the tasks when the creation
 // process will be completed
-let containerId: string | undefined = undefined;
-$: available = containerId && $inferenceServers.some(server => server.container.containerId);
+let containerId: string | undefined = $state(undefined);
+// available means the server is started
+let available: boolean = $derived(!!containerId && $inferenceServers.some(server => server.container.containerId));
+// loading state
+let loading = $derived(trackingId !== undefined && !errorMsg);
 
-$: loading = trackingId !== undefined && !error;
-
-$: {
+// Select default model
+$effect(() => {
   if (!model && localModels.length > 0) {
     model = localModels[0];
   }
-}
+});
+
+// Select default connection
+$effect(() => {
+  if (containerProviderConnection === undefined && startedContainerProviderConnectionInfo.length > 0) {
+    containerProviderConnection = startedContainerProviderConnectionInfo[0];
+  }
+});
 
 const onContainerPortInput = (event: Event): void => {
   const raw = (event.target as HTMLInputElement).value;
@@ -83,11 +81,10 @@ const submit = async (): Promise<void> => {
   if (containerPort === undefined) throw new Error('invalid container port');
 
   try {
-    error = false;
     const trackingId = await studioClient.requestCreateInferenceServer({
-      modelsInfo: [model],
-      port: containerPort,
-      connection: containerProviderConnection,
+      modelsInfo: [$state.snapshot(model)],
+      port: $state.snapshot(containerPort),
+      connection: $state.snapshot(containerProviderConnection),
     });
     router.location.query.set('trackingId', trackingId);
   } catch (err: unknown) {
@@ -107,19 +104,10 @@ const openServiceDetails = (): void => {
 };
 
 // Utility method to filter the tasks properly based on the tracking Id
-const processTasks = (tasks: Task[]): void => {
-  if (trackingId === undefined) {
-    trackedTasks = [];
-    return;
-  }
-
-  trackedTasks = filterByLabel(tasks, {
-    trackingId: trackingId,
-  });
-
+const processTasks = (trackedTasks: Task[]): void => {
   // Check for errors
   // hint: we do not need to display them as the TasksProgress component will
-  error = trackedTasks.find(task => task.error)?.error !== undefined;
+  errorMsg = trackedTasks.find(task => task.error)?.error;
 
   const task: Task | undefined = trackedTasks.find(task => 'containerId' in (task.labels ?? {}));
   if (task === undefined) return;
@@ -127,12 +115,12 @@ const processTasks = (tasks: Task[]): void => {
   containerId = task.labels?.['containerId'];
 
   // if we re-open the page, we might need to restore the model selected
-  populateModelFromTasks();
+  populateModelFromTasks(trackedTasks);
 };
 
 // This method uses the trackedTasks to restore the selected value of model
 // It is useful when the page has been restored
-function populateModelFromTasks(): void {
+function populateModelFromTasks(trackedTasks: Task[]): void {
   const task = trackedTasks.find(
     task => task.labels && 'model-id' in task.labels && typeof task.labels['model-id'] === 'string',
   );
@@ -145,26 +133,18 @@ function populateModelFromTasks(): void {
   model = mModel;
 }
 
-$: if (typeof trackingId === 'string' && trackingId.length > 0) {
-  refreshTasks();
-}
-
-function refreshTasks(): void {
-  processTasks(get(tasks));
-}
-
-onMount(async () => {
-  containerPort = await studioClient.getHostFreePort();
+onMount(() => {
+  studioClient.getHostFreePort().then((port) => {
+    containerPort = port;
+  }).catch((err: unknown) => {
+    console.error(err);
+  });
 
   // we might have a query parameter, then we should use it
   const queryModelId = router.location.query.get('model-id');
   if (queryModelId !== undefined && typeof queryModelId === 'string') {
     model = localModels.find(mModel => mModel.id === queryModelId);
   }
-
-  tasks.subscribe(tasks => {
-    processTasks(tasks);
-  });
 });
 
 export function goToUpPage(): void {
@@ -189,16 +169,12 @@ export function goToUpPage(): void {
       <!-- warning machine resources -->
       {#if containerProviderConnection}
         <div class="mx-5">
-          <ContainerConnectionWrapper model={model} containerProviderConnection={containerProviderConnection} />
+          <ContainerConnectionWrapper model={$state.snapshot(model)} containerProviderConnection={$state.snapshot(containerProviderConnection)} />
         </div>
       {/if}
 
       <!-- tasks tracked -->
-      {#if trackedTasks?.length > 0}
-        <div class="mx-5 mt-5" role="status">
-          <TasksProgress tasks={trackedTasks} />
-        </div>
-      {/if}
+      <TrackedTasks onChange={processTasks} class="mx-5 mt-5" trackingId={trackingId} tasks={$tasks}/>
 
       <!-- form -->
       <div class="bg-[var(--pd-content-card-bg)] m-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg h-fit">

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -50,16 +50,14 @@ let available: boolean = $derived(!!containerId && $inferenceServers.some(server
 // loading state
 let loading = $derived(trackingId !== undefined && !errorMsg);
 
-// Select default model
 $effect(() => {
+  // Select default model
   if (!model && localModels.length > 0) {
     model = localModels[0];
   }
-});
 
-// Select default connection
-$effect(() => {
-  if (containerProviderConnection === undefined && startedContainerProviderConnectionInfo.length > 0) {
+  // Select default connection
+  if (!containerProviderConnection && startedContainerProviderConnectionInfo.length > 0) {
     containerProviderConnection = startedContainerProviderConnectionInfo[0];
   }
 });

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -22,7 +22,7 @@ import ContainerConnectionWrapper from '/@/lib/notification/ContainerConnectionW
 import TrackedTasks from '/@/lib/progress/TrackedTasks.svelte';
 
 interface Props {
-  recipeId: string,
+  recipeId: string;
   // The tracking id is a unique identifier provided by the
   // backend when calling requestPullApplication
   trackingId?: string;
@@ -35,15 +35,15 @@ let recipe: Recipe | undefined = $derived($catalog.recipes.find(r => r.id === re
 // The container provider connection to use
 let containerProviderConnection: ContainerProviderConnectionInfo | undefined = $state(undefined);
 // Filtered connections (started)
-let startedContainerProviderConnectionInfo: ContainerProviderConnectionInfo[] = $derived($containerProviderConnections.filter(
-  connection => connection.status === 'started',
-));
+let startedContainerProviderConnectionInfo: ContainerProviderConnectionInfo[] = $derived(
+  $containerProviderConnections.filter(connection => connection.status === 'started'),
+);
 // recipe local path
 let localPath: LocalRepository | undefined = $derived(findLocalRepositoryByRecipeId($localRepositories, recipe?.id));
 // Filter all models based on backend property
-let models: ModelInfo[] = $derived($modelsInfo.filter(
-  model => (model.backend ?? InferenceType.NONE) === (recipe?.backend ?? InferenceType.NONE),
-));
+let models: ModelInfo[] = $derived(
+  $modelsInfo.filter(model => (model.backend ?? InferenceType.NONE) === (recipe?.backend ?? InferenceType.NONE)),
+);
 // Hold the selected model
 let model: ModelInfo | undefined = $state(undefined);
 // loading state
@@ -145,7 +145,7 @@ function handleOnClick(): void {
       {/if}
 
       <!-- tasks tracked -->
-      <TrackedTasks onChange={processTasks} class="mx-5 mt-5" trackingId={trackingId} tasks={$tasks}/>
+      <TrackedTasks onChange={processTasks} class="mx-5 mt-5" trackingId={trackingId} tasks={$tasks} />
 
       {#if recipe}
         <!-- form -->

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -51,15 +51,12 @@ let loading = $state(false);
 // All tasks are successful (not any in error)
 let completed: boolean = $state(false);
 
-// Select default connection
 $effect(() => {
-  if (containerProviderConnection === undefined && startedContainerProviderConnectionInfo.length > 0) {
+  // Select default connection
+  if (!containerProviderConnection && startedContainerProviderConnectionInfo.length > 0) {
     containerProviderConnection = startedContainerProviderConnectionInfo[0];
   }
-});
-
-// Select default model
-$effect(() => {
+  // Select default model
   if (!model && recipe && models.length > 0) {
     model = getFirstRecommended();
   }

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -12,68 +12,58 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { InferenceType } from '@shared/src/models/IInference';
 import { studioClient } from '/@/utils/client';
 import type { Task } from '@shared/src/models/ITask';
-import { filterByLabel } from '/@/utils/taskUtils';
 import { tasks } from '/@/stores/tasks';
-import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
-import { onMount } from 'svelte';
 import { router } from 'tinro';
 import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 import { containerProviderConnections } from '/@/stores/containerProviderConnections';
 import ModelSelect from '/@/lib/select/ModelSelect.svelte';
 import ContainerProviderConnectionSelect from '/@/lib/select/ContainerProviderConnectionSelect.svelte';
 import ContainerConnectionWrapper from '/@/lib/notification/ContainerConnectionWrapper.svelte';
-import { get } from 'svelte/store';
+import TrackedTasks from '/@/lib/progress/TrackedTasks.svelte';
 
-export let recipeId: string;
-// The tracking id is a unique identifier provided by the
-// backend when calling requestPullApplication
-export let trackingId: string | undefined = undefined;
+interface Props {
+  recipeId: string,
+  // The tracking id is a unique identifier provided by the
+  // backend when calling requestPullApplication
+  trackingId?: string;
+}
 
-let recipe: Recipe | undefined;
-$: recipe = $catalog.recipes.find(r => r.id === recipeId);
+let { recipeId, trackingId }: Props = $props();
+
+let recipe: Recipe | undefined = $derived($catalog.recipes.find(r => r.id === recipeId));
 
 // The container provider connection to use
-let containerProviderConnection: ContainerProviderConnectionInfo | undefined = undefined;
-
+let containerProviderConnection: ContainerProviderConnectionInfo | undefined = $state(undefined);
 // Filtered connections (started)
-let startedContainerProviderConnectionInfo: ContainerProviderConnectionInfo[] = [];
-$: startedContainerProviderConnectionInfo = $containerProviderConnections.filter(
+let startedContainerProviderConnectionInfo: ContainerProviderConnectionInfo[] = $derived($containerProviderConnections.filter(
   connection => connection.status === 'started',
-);
+));
+// recipe local path
+let localPath: LocalRepository | undefined = $derived(findLocalRepositoryByRecipeId($localRepositories, recipe?.id));
+// Filter all models based on backend property
+let models: ModelInfo[] = $derived($modelsInfo.filter(
+  model => (model.backend ?? InferenceType.NONE) === (recipe?.backend ?? InferenceType.NONE),
+));
+// Hold the selected model
+let model: ModelInfo | undefined = $state(undefined);
+// loading state
+let loading = $state(false);
+// All tasks are successful (not any in error)
+let completed: boolean = $state(false);
 
 // Select default connection
-$: if (containerProviderConnection === undefined && startedContainerProviderConnectionInfo.length > 0) {
-  containerProviderConnection = startedContainerProviderConnectionInfo[0];
-}
-
-// recipe local path
-let localPath: LocalRepository | undefined = undefined;
-$: localPath = findLocalRepositoryByRecipeId($localRepositories, recipe?.id);
-
-// Filter all models based on backend property
-let models: ModelInfo[] = [];
-$: models = $modelsInfo.filter(
-  model => (model.backend ?? InferenceType.NONE) === (recipe?.backend ?? InferenceType.NONE),
-);
-
-// Hold the selected model
-let value: ModelInfo | undefined = undefined;
-
-$: {
-  // let's select a default model
-  if (value === undefined && recipe && models.length > 0) {
-    value = getFirstRecommended();
+$effect(() => {
+  if (containerProviderConnection === undefined && startedContainerProviderConnectionInfo.length > 0) {
+    containerProviderConnection = startedContainerProviderConnectionInfo[0];
   }
-}
+});
 
-// The trackedTasks are the tasks linked to the trackingId
-let trackedTasks: Task[];
-
-// Some tasks are running
-let loading: boolean = false;
-
-// All tasks are successful (not any in error)
-let completed: boolean = false;
+// Select default model
+$effect(() => {
+  if (!model && recipe && models.length > 0) {
+    model = getFirstRecommended();
+  }
+});
 
 const getFirstRecommended = (): ModelInfo | undefined => {
   if (!recipe || !models) return undefined;
@@ -84,66 +74,42 @@ const getFirstRecommended = (): ModelInfo | undefined => {
   return model;
 };
 
-const processTasks = (tasks: Task[]): void => {
-  if (trackingId === undefined) {
-    trackedTasks = [];
-    return;
-  }
+const processTasks = (trackedTasks: Task[]): void => {
+  // if one task is in loading we are still loading
+  loading = !!trackingId && trackedTasks.some(task => task.state === 'loading');
 
-  trackedTasks = filterByLabel(tasks, {
-    trackingId: trackingId,
-  });
-
-  // if any task is still in loading state - we are not yet finished
-  loading = trackedTasks.some(task => task.state === 'loading');
-
-  // if all task are successful
-  completed = trackedTasks.every(task => task.state === 'success');
+  // if all task are successful we are successful
+  completed = !!trackingId && trackedTasks.every(task => task.state === 'success');
 
   // if we re-open the page, we might need to restore the model selected
-  populateModelFromTasks();
+  populateModelFromTasks(trackedTasks);
 };
 
 // This method uses the trackedTasks to restore the selected value of model
 // It is useful when the page has been restored
-function populateModelFromTasks(): void {
+function populateModelFromTasks(trackedTasks: Task[]): void {
   const task = trackedTasks.find(
     task => task.labels && 'model-id' in task.labels && typeof task.labels['model-id'] === 'string',
   );
   const modelId = task?.labels?.['model-id'];
   if (!modelId) return;
 
-  const model = models.find(model => model.id === modelId);
-  if (!model) return;
+  const nModel = models.find(model => model.id === modelId);
+  if (!nModel) return;
 
-  value = model;
+  model = nModel;
 }
 
 async function submit(): Promise<void> {
-  if (!recipe || !value) return;
+  if (!recipe || !model) return;
 
-  loading = true;
   const trackingId = await studioClient.requestPullApplication({
-    recipeId: recipe.id,
-    modelId: value.id,
-    connection: containerProviderConnection,
+    recipeId: $state.snapshot(recipe.id),
+    modelId: $state.snapshot(model.id),
+    connection: $state.snapshot(containerProviderConnection),
   });
   router.location.query.set('trackingId', trackingId);
 }
-
-$: if (typeof trackingId === 'string' && trackingId.length > 0) {
-  refreshTasks();
-}
-
-function refreshTasks(): void {
-  processTasks(get(tasks));
-}
-
-onMount(() => {
-  return tasks.subscribe(tasks => {
-    processTasks(tasks);
-  });
-});
 
 export function goToUpPage(): void {
   router.goto('/recipes');
@@ -173,17 +139,13 @@ function handleOnClick(): void {
         <div class="mx-5">
           <ContainerConnectionWrapper
             checkContext="recipe"
-            model={value}
-            containerProviderConnection={containerProviderConnection} />
+            model={$state.snapshot(model)}
+            containerProviderConnection={$state.snapshot(containerProviderConnection)} />
         </div>
       {/if}
 
       <!-- tasks tracked -->
-      {#if trackedTasks?.length > 0}
-        <div class="mx-5 mt-5" role="status">
-          <TasksProgress tasks={trackedTasks} />
-        </div>
-      {/if}
+      <TrackedTasks onChange={processTasks} class="mx-5 mt-5" trackingId={trackingId} tasks={$tasks}/>
 
       {#if recipe}
         <!-- form -->
@@ -219,8 +181,8 @@ function handleOnClick(): void {
             <!-- model form -->
             <label for="select-model" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
               >Model</label>
-            <ModelSelect bind:value={value} disabled={loading} recommended={recipe.recommended} models={models} />
-            {#if value && value.file === undefined}
+            <ModelSelect bind:value={model} disabled={loading} recommended={recipe.recommended} models={models} />
+            {#if model && model.file === undefined}
               <div class="text-gray-800 text-sm flex items-center">
                 <Fa class="mr-2" icon={faWarning} />
                 <span role="alert"
@@ -238,7 +200,7 @@ function handleOnClick(): void {
                   title="Start {recipe.name} recipe"
                   inProgress={loading}
                   on:click={submit}
-                  disabled={!value || loading}
+                  disabled={!model || loading}
                   icon={faRocket}>
                   Start {recipe.name} recipe
                 </Button>


### PR DESCRIPTION
### What does this PR do?

I was struggling with https://github.com/containers/podman-desktop-extension-ai-lab/issues/1811 and the only fix that I found was to rewrite and share the tasks management code between the recipe and service form.

Thus adding a `TrackedTasks` component, however to make it works nicely I was forced to either add a lot of svelte4 reactive ($) statement, or move it to runes. (I choose the runes)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1811
Part of https://github.com/containers/podman-desktop-extension-ai-lab/issues/1789

### How to test this PR?

- [x] unit tests for `TrackedTasks`  has been added
- [x] existing tests for `CreateService` ad `StartRecipe` ensure no regression (I was shocked nothing broke)  

You can manually check nothing change by starting some recipes, and some inference servers