### PR TITLE
Parse system environment if property is not set or does not exist

### DIFF
--- a/packages/backend/src/registries/ConfigurationRegistry.ts
+++ b/packages/backend/src/registries/ConfigurationRegistry.ts
@@ -50,7 +50,8 @@ export class ConfigurationRegistry extends Publisher<ExtensionConfiguration> imp
       experimentalGPU: this.#configuration.get<boolean>('experimentalGPU') ?? false,
       apiPort: this.#configuration.get<number>('apiPort') ?? API_PORT_DEFAULT,
       experimentalTuning: this.#configuration.get<boolean>('experimentalTuning') ?? false,
-      modelUploadDisabled: this.#configuration.get<boolean>('modelUploadDisabled') ?? false,
+      modelUploadDisabled:
+        this.#configuration.get<boolean>('modelUploadDisabled') ?? process.env.AI_LAB_MODEL_UPLOAD_DISABLED === 'true',
     };
   }
 


### PR DESCRIPTION
### What does this PR do?
* Allows for setting model upload hidden property using an environment variable

### Screenshot / video of UI
N/A
<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#1661 
<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?
N/A
<!-- Please explain steps to reproduce -->

### Extra context
This change was proposed, because at the time of fresh installation, pre-setting the property in settings.json would cause Podman Desktop to instantly crash at the moment the configuration storage tries to initialize. This environment variable allows us to circumvent that problem, especially on CI use