### PR TITLE
fix(LlamaCppPython): nvidia inference server cannot restart

### DIFF
--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -296,6 +296,15 @@ describe('perform', () => {
       connection: undefined,
     });
 
+    expect(containerEngine.createContainer).toHaveBeenCalledWith(
+      DummyImageInfo.engineId,
+      expect.objectContaining({
+        Cmd: [
+          '-c',
+          '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && chmod 755 ./run.sh && ./run.sh',
+        ],
+      }),
+    );
     expect(gpuManager.collectGPUs).toHaveBeenCalled();
     expect(getImageInfo).toHaveBeenCalledWith(expect.anything(), llamacpp.cuda, expect.any(Function));
     expect('gpu' in server.labels).toBeTruthy();

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -123,7 +123,7 @@ export class LlamaCppPython extends InferenceProvider {
           entrypoint = '/usr/bin/sh';
           cmd = [
             '-c',
-            '/usr/bin/ln -s /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && chmod 755 ./run.sh && ./run.sh',
+            '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && chmod 755 ./run.sh && ./run.sh',
           ];
           break;
         case VMType.LIBKRUN:


### PR DESCRIPTION
### What does this PR do?

Fix the inference server not restarting on nvidia GPU

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1841

### How to test this PR?

- [x] unit test has been provided