### PR TITLE
feat: makes copy button extend tooltip

### DIFF
--- a/packages/frontend/src/lib/button/CopyButton.spec.ts
+++ b/packages/frontend/src/lib/button/CopyButton.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { expect, test, vi, beforeEach } from 'vitest';
+import { expect, test, vi, beforeEach, describe } from 'vitest';
 
 import { render, within, fireEvent, waitFor } from '@testing-library/svelte';
 import CopyButton from '/@/lib/button/CopyButton.svelte';
@@ -47,5 +47,87 @@ test('clicking on the content should call copyToClipboard', async () => {
 
   await waitFor(() => {
     expect(studioClient.copyToClipboard).toHaveBeenCalledWith('dummy-content');
+  });
+});
+
+describe('tooltips properties should be propagated', () => {
+  test('top property', async () => {
+    const { container } = render(CopyButton, {
+      content: 'dummy-content',
+      top: true,
+    });
+
+    const toolTip = container.querySelector('.tooltip.top');
+    expect(toolTip).toBeDefined();
+  });
+
+  test('topLeft property', async () => {
+    const { container } = render(CopyButton, {
+      content: 'dummy-content',
+      topLeft: true,
+    });
+
+    const toolTip = container.querySelector('.tooltip.top-left');
+    expect(toolTip).toBeDefined();
+  });
+
+  test('topRight property', async () => {
+    const { container } = render(CopyButton, {
+      content: 'dummy-content',
+      topRight: true,
+    });
+
+    const toolTip = container.querySelector('.tooltip.top-right');
+    expect(toolTip).toBeDefined();
+  });
+
+  test('right property', async () => {
+    const { container } = render(CopyButton, {
+      content: 'dummy-content',
+      right: true,
+    });
+
+    const toolTip = container.querySelector('.tooltip.right');
+    expect(toolTip).toBeDefined();
+  });
+
+  test('bottom property', async () => {
+    const { container } = render(CopyButton, {
+      content: 'dummy-content',
+      bottom: true,
+    });
+
+    const toolTip = container.querySelector('.tooltip.bottom');
+    expect(toolTip).toBeDefined();
+  });
+
+  test('bottomLeft property', async () => {
+    const { container } = render(CopyButton, {
+      content: 'dummy-content',
+      bottomLeft: true,
+    });
+
+    const toolTip = container.querySelector('.tooltip.bottom-left');
+    expect(toolTip).toBeDefined();
+  });
+
+  test('bottomRight property', async () => {
+    const { container } = render(CopyButton, {
+      content: 'dummy-content',
+      bottomLeft: true,
+    });
+
+    const toolTip = container.querySelector('.tooltip.bottom-right');
+    expect(toolTip).toBeDefined();
+  });
+
+  test('left property', async () => {
+    const { container } = render(CopyButton, {
+      content: 'dummy-content',
+      left: true,
+    });
+
+    const toolTip = container.querySelector('.tooltip.left');
+    expect(toolTip).toBeDefined();
   });
 });

--- a/packages/frontend/src/lib/button/CopyButton.svelte
+++ b/packages/frontend/src/lib/button/CopyButton.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { studioClient } from '/@/utils/client';
-import type { Snippet } from 'svelte';
+import type { ComponentProps } from 'svelte';
 
-let {
-  content,
-  class: classes,
-  children,
-}: { class: string | undefined; content: string; children: Snippet | undefined } = $props();
+interface Props extends Omit<ComponentProps<Tooltip>, 'tip'> {
+  class?: string;
+  content: string;
+}
+
+let { content, class: classes, children, ...restProps }: Props = $props();
 let status: 'idle' | 'copied' = $state('idle');
 
 function copy(content: string): void {
@@ -31,7 +32,7 @@ function handleClick(): void {
 }
 </script>
 
-<Tooltip bottom tip={status === 'idle' ? 'Copy' : 'Copied'}>
+<Tooltip {...restProps} tip={status === 'idle' ? 'Copy' : 'Copied'}>
   <button onmouseleave={reset} onclick={handleClick} class={`${classes} cursor-copy`}>
     {#if children}
       {@render children()}


### PR DESCRIPTION
### What does this PR do?

Following a comment by @gastoner in https://github.com/containers/podman-desktop-extension-ai-lab/pull/1840#pullrequestreview-2357412526 we should be able to decide when using the CopyButton where the tooltip will be visible.

As the `CopyButton` is a wrapper around the ToolTip, it makes sense it extends its props  

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] unit tests has been provided