### PR TITLE
chore: add missing nav border

### DIFF
--- a/packages/frontend/src/lib/Navigation.spec.ts
+++ b/packages/frontend/src/lib/Navigation.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { screen, render } from '@testing-library/svelte';
+import Navigation from './Navigation.svelte';
+import type { TinroRouteMeta } from 'tinro';
+
+vi.mock('../utils/client', async () => ({
+  studioClient: {
+    getExtensionConfiguration: vi.fn().mockResolvedValue({}),
+  },
+  rpcBrowser: {
+    subscribe: (): unknown => {
+      return {
+        unsubscribe: (): void => {},
+      };
+    },
+  },
+}));
+
+test('Expect panel to have correct styling', async () => {
+  render(Navigation, { meta: { url: 'test' } as TinroRouteMeta });
+
+  const panel = screen.getByLabelText('PreferencesNavigation');
+  expect(panel).toBeInTheDocument();
+  expect(panel).toHaveClass('bg-[var(--pd-secondary-nav-bg)]');
+  expect(panel).toHaveClass('border-[var(--pd-global-nav-bg-border)]');
+  expect(panel).toHaveClass('border-r-[1px]');
+});

--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -24,7 +24,7 @@ onDestroy(() => {
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)]"
+  class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <a href="/" title="Navigate to dashboard" class="pt-4 pl-3 px-5 mb-10 flex items-center ml-[4px]">


### PR DESCRIPTION
### What does this PR do?

Just adds the missing right border to the navigation to avoid it visually blending into the page and for consistency with Podman Desktop.

### Screenshot / video of UI

Before:
<img width="291" alt="Screenshot 2024-10-16 at 2 33 45 PM" src="https://github.com/user-attachments/assets/781ee3e2-d79d-4b06-92dd-523bb5cf3d44">

After:
<img width="291" alt="Screenshot 2024-10-16 at 2 38 08 PM" src="https://github.com/user-attachments/assets/902eb620-6ee4-456c-bd49-22f899bcb395">

### What issues does this PR fix or reference?

Fixes #1946.

### How to test this PR?

Quick visual check, unit test pass.