### PR TITLE
chore: fix unaligned navigation bar

### DIFF
--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -7,12 +7,20 @@ import { onDestroy, onMount } from 'svelte';
 import { configuration } from '../stores/extensionConfiguration';
 import type { ExtensionConfiguration } from '@shared/src/models/IExtensionConfiguration';
 import type { Unsubscriber } from 'svelte/store';
+import type { IconDefinition } from '@fortawesome/free-regular-svg-icons';
 
 export let meta: TinroRouteMeta;
 let experimentalTuning: boolean = false;
 let cfgUnsubscribe: Unsubscriber;
 
+// By default, faBookOpen is 576x512, but we want it to be 512x512
+// we cannot modify the width and height in SettingsNavItem so just modify the icon instead
+let copyFaBookOpenIcon: IconDefinition | undefined = undefined;
+
 onMount(() => {
+  copyFaBookOpenIcon = structuredClone(faBookOpen);
+  copyFaBookOpenIcon.icon[0] = 512;
+
   cfgUnsubscribe = configuration.subscribe((val: ExtensionConfiguration | undefined) => {
     experimentalTuning = val?.experimentalTuning ?? false;
   });
@@ -35,14 +43,18 @@ onDestroy(() => {
   <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
     <!-- AI Apps -->
     <span class="pl-3 ml-[4px] text-[color:var(--pd-secondary-nav-header-text)]">AI APPS</span>
-    <SettingsNavItem icon={faBookOpen} title="Recipes Catalog" selected={meta.url === '/recipes'} href="/recipes" />
+    <SettingsNavItem
+      icon={copyFaBookOpenIcon}
+      title="Recipes Catalog"
+      selected={meta.url === '/recipes'}
+      href="/recipes" />
     <SettingsNavItem icon={faServer} title="Running" selected={meta.url === '/applications'} href="/applications" />
 
     <!-- Models -->
     <div class="pl-3 mt-2 ml-[4px]">
       <span class="text-[color:var(--pd-secondary-nav-header-text)]">MODELS</span>
     </div>
-    <SettingsNavItem icon={faBookOpen} title="Catalog" selected={meta.url === '/models'} href="/models" />
+    <SettingsNavItem icon={copyFaBookOpenIcon} title="Catalog" selected={meta.url === '/models'} href="/models" />
     <SettingsNavItem icon={faRocket} title="Services" selected={meta.url === '/services'} href="/services" />
     <SettingsNavItem icon={faMessage} title="Playgrounds" selected={meta.url === '/playgrounds'} href="/playgrounds" />
 


### PR DESCRIPTION
chore: fix unaligned navigation bar

### What does this PR do?

The icons are not aligned because the "faBookOpen" icon is actually
576x512 and not the usual 512x512, causing the icons to be misaligned.

Inspection of faBookOpen:

```html
<svg aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" class="svelte-fa svelte-fa-base mr-4 svelte-l34xo3" viewBox="0 0 576 512">
```

This PR modifies the icon size to actually be 512px width to avoid
misalignment

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

**Look at the "open book" icons and text vs the ones below**

Before:
![Screenshot 2024-10-29 at 9 03 25 AM](https://github.com/user-attachments/assets/0f86ce91-a68e-4bce-9af3-09c1db3dfb33)

After:
![Screenshot 2024-10-29 at 9 01 32 AM](https://github.com/user-attachments/assets/b1750f42-f2e0-41cf-a31a-726a8c4480fb)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop-extension-ai-lab/issues/989

### How to test this PR?

<!-- Please explain steps to reproduce -->

See that it has been aligned

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
