### PR TITLE
fix(MessageProxy): timeout channels list

### DIFF
--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -26,6 +26,10 @@ import * as fs from 'node:fs';
 
 vi.mock('./managers/modelsManager');
 
+vi.mock('@shared/src/messages/NoTimeoutChannels', () => ({
+  noTimeoutChannels: [],
+}));
+
 const mockedExtensionContext = {
   subscriptions: [],
   storagePath: 'dummy-storage-path',

--- a/packages/frontend/src/stores/rpcReadable.spec.ts
+++ b/packages/frontend/src/stores/rpcReadable.spec.ts
@@ -52,6 +52,10 @@ vi.mock('../utils/client', async () => {
   };
 });
 
+vi.mock('@shared/src/messages/NoTimeoutChannels', () => ({
+  noTimeoutChannels: [],
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
 });

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -40,6 +40,10 @@ export interface ISubscribedMessage {
   body: any;
 }
 
+export function getChannel<T>(classType: { CHANNEL: string; prototype: T }, method: keyof T): string {
+  return `${classType.CHANNEL}-${String(method)}`;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UnaryRPC = (...args: any[]) => Promise<unknown>;
 
@@ -115,7 +119,7 @@ export class RpcExtension implements Disposable {
 
     methodNames.forEach(name => {
       const method = (instance[name as keyof T] as any).bind(instance);
-      this.register(`${classType.CHANNEL}-${name}`, method);
+      this.register(getChannel(classType, name as keyof T), method);
     });
   }
 
@@ -180,7 +184,7 @@ export class RpcBrowser {
         if (typeof prop === 'string') {
           return (...args: unknown[]) => {
             const channel = prop.toString();
-            return thisRef.invoke(`${classType.CHANNEL}-${channel}`, ...args);
+            return thisRef.invoke(getChannel(classType, channel as keyof T), ...args);
           };
         }
         return Reflect.get(target, prop, receiver);

--- a/packages/shared/src/messages/NoTimeoutChannels.ts
+++ b/packages/shared/src/messages/NoTimeoutChannels.ts
@@ -15,5 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { StudioAPI } from '../StudioAPI';
+import { getChannel } from './MessageProxy';
 
-export const noTimeoutChannels: string[] = ['openDialog'];
+export const noTimeoutChannels: string[] = [getChannel(StudioAPI, 'openDialog')];


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/containers/podman-desktop-extension-ai-lab/pull/1838, the `noTimeoutChannels` was not working anymore. It is an hardcoded list of channels that should not have a timeout. However we now prefix the channel for each api with the class `CHANNEL` property.

To avoid having `${StudioAPI.CHANNEL}-openDialog` I added a `getChannel` method, taking a class, a keyof this class, to ensure typescript prevent us from adding invalid channels.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1991

### How to test this PR?

- [x] unit tests has been added

**Manually**

1. Go to models liste page
2. Click on `import` (top right corner)
3. Wait 10 seconds
4. assert no timeout
