### PR TITLE
chore: bump macos version from 12 to 14

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-22.04, macos-12]
+        os: [windows-2022, ubuntu-22.04, macos-14]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### What does this PR do?

updating to macos-14 as this is the version podman-desktop is using.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/2037

### How to test this PR?

- PR-check should be ✅ 
