### PR TITLE
chore: bump macos version from 12 to 14 (#2038)

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-22.04, macos-12]
+        os: [windows-2022, ubuntu-22.04, macos-14]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### What does this PR do?

backport https://github.com/containers/podman-desktop-extension-ai-lab/pull/2038 to 1.3.x

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
