### PR TITLE
chore: rename recipes catalog to recipe catalog

### DIFF
--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -56,7 +56,7 @@ onDestroy(() => {
     </div>
     <SettingsNavItem
       icon={copyFaBookOpenIcon}
-      title="Recipes Catalog"
+      title="Recipe Catalog"
       selected={meta.url === '/recipes'}
       href="/recipes" />
     <SettingsNavItem icon={faServer} title="Running" selected={meta.url === '/applications'} href="/applications" />


### PR DESCRIPTION
chore: rename recipes catalog to recipe catalog

### What does this PR do?

Searching up the grammar, Recipes Catalog is grammatically incorrect
according to multiple sources and should be Recipe Catalog.

Courtesy of llama3 LLM as well as grammarly AI:

`"Recipe" acts as an attributive noun, describing the
type of catalog, and doesn't need to be plural. "Recipe Catalog" implies
a catalog that is specifically for recipes."`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
