### PR TITLE
feat: initial support for GPU on linux (TRACKING, replaced by separate PRs)

### DIFF
--- a/packages/backend/src/managers/GPUManager.ts
+++ b/packages/backend/src/managers/GPUManager.ts
@@ -53,6 +53,7 @@ export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
       case 'Intel Corporation':
         return GPUVendor.INTEL;
       case 'NVIDIA':
+      case 'NVIDIA Corporation':
         return GPUVendor.NVIDIA;
       case 'Apple':
         return GPUVendor.APPLE;


### PR DESCRIPTION
### What does this PR do?

Adds experimental support for GPU acceleration on Linux. It makes a key assumption which needs to be validated by people who know more about
the podman-desktop-extension-ai-lab than I do:
*  if the vmType is VMType.UNKNOWN, then the assuption is that we are running on linux and the vm type is unknown because there is no vm. This seemed reasonable to me as we should know the vmType on Windows or Mac.

There as also a few tweaks that were needed for my system:
1. a change to look for the first GPU that we know the type of. This was needed because my vm has 2 gpus, one of which is NVIDIA but it was not gpu[0].  This should have no effect in people only have 1 gpu.
2. a tweak to recognize and additional string as NVIDIA as that was what was being reported in my machine
3. one fix where vmType was being left as undefined instead of being set to VMType.UNKNOWN

It also requires some extensions in podman desktop which are in PR - https://github.com/podman-desktop/podman-desktop/pull/10166

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-ai-lab/issues/2162

### How to test this PR?

For live test, I tested this PR along with this PR to podman-desktop https://github.com/podman-desktop/podman-desktop/pull/10166, by creating a model service and validating that the service reported GPU acceleration, and used the GPU when requests were submitted to the service. I also tested with the chatbot Node.js recipe I was working on that it got GPU acceleration as well.
