### PR TITLE
chore(test): moving aria-label to upper level

### DIFF
--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -227,13 +227,12 @@ function handleOnChange(): void {
                   {#if service.status === 'running'}
                     <div class="flex flex-col gap-y-2">
                       <span class="text-sm text-[var(--pd-content-card-text)]">Inference Endpoint URL</span>
-                      <div class="flex items-center gap-x-4">
+                      <div class="flex items-center gap-x-4" aria-label="Endpoint URL">
                         <!-- API URL -->
                         {#if 'api' in service.labels}
                           <CopyButton
                             top
                             class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center"
-                            aria-label="Endpoint URL"
                             content={service.labels['api']}>
                             {service.labels['api']}
                             <Fa class="ml-2" icon={faCopy} />

--- a/tests/playwright/src/ai-lab-extension.spec.ts
+++ b/tests/playwright/src/ai-lab-extension.spec.ts
@@ -181,6 +181,7 @@ test.describe.serial(`AI Lab extension installation and verification`, { tag: '@
         await modelServiceDetailsPage.waitForLoad();
 
         await playExpect(modelServiceDetailsPage.modelName).toContainText(modelName);
+        await playExpect(modelServiceDetailsPage.inferenceServerType).toContainText('Inference');
       });
 
       test(`Delete model service for ${modelName}`, async () => {


### PR DESCRIPTION
### What does this PR do?
Adds one more validation to the service creation test and moves aria-label for endpoint url to upper level.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-ai-lab/issues/2100