### PR TITLE
feat: improve GPU support when multiple GPUs

### DIFF
--- a/packages/backend/src/managers/GPUManager.spec.ts
+++ b/packages/backend/src/managers/GPUManager.spec.ts
@@ -105,3 +105,25 @@ test('NVIDIA controller should return intel vendor', async () => {
     },
   ]);
 });
+
+test('NVIDIA controller can have vendor "NVIDIA Corporation"', async () => {
+  vi.mocked(graphics).mockResolvedValue({
+    controllers: [
+      {
+        vendor: 'NVIDIA Corporation',
+        model: 'NVIDIA GeForce GTX 1060 6GB',
+        vram: 6144,
+      } as unknown as Systeminformation.GraphicsControllerData,
+    ],
+    displays: [],
+  });
+
+  const manager = new GPUManager(webviewMock);
+  expect(await manager.collectGPUs()).toStrictEqual([
+    {
+      vendor: GPUVendor.NVIDIA,
+      model: 'NVIDIA GeForce GTX 1060 6GB',
+      vram: 6144,
+    },
+  ]);
+});

--- a/packages/backend/src/managers/GPUManager.ts
+++ b/packages/backend/src/managers/GPUManager.ts
@@ -53,6 +53,7 @@ export class GPUManager extends Publisher<IGPUInfo[]> implements Disposable {
       case 'Intel Corporation':
         return GPUVendor.INTEL;
       case 'NVIDIA':
+      case 'NVIDIA Corporation':
         return GPUVendor.NVIDIA;
       case 'Apple':
         return GPUVendor.APPLE;

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -197,9 +197,10 @@ export class LlamaCppPython extends InferenceProvider {
     if (this.configurationRegistry.getExtensionConfiguration().experimentalGPU) {
       const gpus: IGPUInfo[] = await this.gpuManager.collectGPUs();
       if (gpus.length === 0) throw new Error('no gpu was found.');
-      if (gpus.length > 1)
-        console.warn(`found ${gpus.length} gpus: using multiple GPUs is not supported. Using ${gpus[0].model}.`);
-      gpu = gpus[0];
+
+      // Look for a GPU that is of a known type, use the first one found.
+      // Fall back to the first one if no GPUs are of known type.
+      gpu = gpus.find(({ vendor }) => vendor !== GPUVendor.UNKNOWN) ?? gpus[0];
     }
 
     let connection: ContainerProviderConnection | undefined = undefined;


### PR DESCRIPTION
### What does this PR do?

If there are multiple GPUs use the first one that is of known type instead of first GPU. If no GPUs of are known type fall back to the first GPU as before.

Add another string for vendor that is accepted as an NVIDIA GPU when doing GPU detection based on what was seen on linux with an NVIDIA 4070 Ti Super

The VM in which I did testing for potential GPU support on linux (https://github.com/containers/podman-desktop-extension-ai-lab/pull/2180) had 2 CPUs, one of which is NVIDIA but it was not gpu[0]. This should have no effect in people only have 1 gpu. With this change I could use the second GPU.

### Screenshot / video of UI

N/A

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop-extension-ai-lab/issues/2214


### How to test this PR?

Run unit tests as updated