### PR TITLE
feat: initial support for GPU on linux

### DIFF
--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -380,6 +380,129 @@ describe('perform', () => {
     expect('gpu' in server.labels).toBeTruthy();
   });
 
+  test('UNKNOWN vmtype should use llamacpp.default image - if not gpu accelerated', async () => {
+    vi.mocked(podmanConnection.findRunningContainerProviderConnection).mockReturnValue({
+      ...dummyConnection,
+      vmType: VMType.UNKNOWN,
+    });
+
+    vi.mocked(configurationRegistry.getExtensionConfiguration).mockReturnValue({
+      experimentalGPU: true,
+      modelsPath: '',
+      apiPort: 10434,
+      experimentalTuning: false,
+      modelUploadDisabled: false,
+      showGPUPromotion: false,
+    });
+
+    vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
+      {
+        vram: 1024,
+        model: 'dummy-model',
+        vendor: GPUVendor.UNKNOWN,
+      },
+    ]);
+
+    const provider = new LlamaCppPython(taskRegistry, podmanConnection, gpuManager, configurationRegistry);
+
+    const server = await provider.perform({
+      port: 8000,
+      image: undefined,
+      labels: {},
+      modelsInfo: [DummyModel],
+      connection: undefined,
+    });
+
+    expect(getImageInfo).toHaveBeenCalledWith(expect.anything(), llamacpp.default, expect.any(Function));
+    expect(gpuManager.collectGPUs).toHaveBeenCalled();
+    expect('gpu' in server.labels).toBeFalsy();
+  });
+
+  test('UNKNOWN vmtype should use llamacpp.cuda image - if gpu accelerated and cdi configured', async () => {
+    vi.mocked(podmanConnection.findRunningContainerProviderConnection).mockReturnValue({
+      ...dummyConnection,
+      vmType: VMType.UNKNOWN,
+    });
+
+    vi.mocked(configurationRegistry.getExtensionConfiguration).mockReturnValue({
+      experimentalGPU: true,
+      modelsPath: '',
+      apiPort: 10434,
+      experimentalTuning: false,
+      modelUploadDisabled: false,
+      showGPUPromotion: false,
+    });
+
+    vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
+      {
+        vram: 1024,
+        model: 'dummy-model',
+        vendor: GPUVendor.NVIDIA,
+      },
+    ]);
+
+    class CDILlamaCppPython extends LlamaCppPython {
+      override isNvidiaCDIConfigured(): boolean {
+        return true;
+      }
+    }
+
+    const provider = new CDILlamaCppPython(taskRegistry, podmanConnection, gpuManager, configurationRegistry);
+    const server = await provider.perform({
+      port: 8000,
+      image: undefined,
+      labels: {},
+      modelsInfo: [DummyModel],
+      connection: undefined,
+    });
+
+    expect(getImageInfo).toHaveBeenCalledWith(expect.anything(), llamacpp.cuda, expect.any(Function));
+    expect(gpuManager.collectGPUs).toHaveBeenCalled();
+    expect('gpu' in server.labels).toBeTruthy();
+  });
+
+  test('UNKNOWN vmtype should use llamacpp.default image - if gpu but cdi not configured', async () => {
+    vi.mocked(podmanConnection.findRunningContainerProviderConnection).mockReturnValue({
+      ...dummyConnection,
+      vmType: VMType.UNKNOWN,
+    });
+
+    vi.mocked(configurationRegistry.getExtensionConfiguration).mockReturnValue({
+      experimentalGPU: true,
+      modelsPath: '',
+      apiPort: 10434,
+      experimentalTuning: false,
+      modelUploadDisabled: false,
+      showGPUPromotion: false,
+    });
+
+    vi.mocked(gpuManager.collectGPUs).mockResolvedValue([
+      {
+        vram: 1024,
+        model: 'dummy-model',
+        vendor: GPUVendor.NVIDIA,
+      },
+    ]);
+
+    class NoCDILlamaCppPython extends LlamaCppPython {
+      override isNvidiaCDIConfigured(): boolean {
+        return false;
+      }
+    }
+    const provider = new NoCDILlamaCppPython(taskRegistry, podmanConnection, gpuManager, configurationRegistry);
+    const server = await provider.perform({
+      port: 8000,
+      image: undefined,
+      labels: {},
+      modelsInfo: [DummyModel],
+      connection: undefined,
+    });
+
+    expect(getImageInfo).toHaveBeenCalledWith(expect.anything(), llamacpp.default, expect.any(Function));
+    expect(gpuManager.collectGPUs).toHaveBeenCalled();
+    expect('gpu' in server.labels).toBeFalsy();
+  });
+
   test('provided connection should be used for pulling the image', async () => {
     const connection: ContainerProviderConnectionInfo = {
       name: 'Dummy Podman',


### PR DESCRIPTION
### What does this PR do?

Adds initial support for GPU acceleration for linux. It requires a version of Podman which
includes this PR - https://github.com/podman-desktop/podman-desktop/pull/10251

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Refs: https://github.com/containers/podman-desktop-extension-ai-lab/issues/2162

### How to test this PR?

1. Unit tests are added.

2. With a version of podman which has https://github.com/podman-desktop/podman-desktop/pull/10251 landed, build a version of podman-desktop-extension-ai-lab with this PR and run podman desktop with the updated extension on Fedora with an NVIDIA GPU and NVIDIA CDI configured. Create a service and see that is is GPU accelerated and after the first chat request response are fast.
