### PR TITLE
feat: basic vllm support for hf cached models

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -101,6 +101,7 @@
   },
   "dependencies": {
     "@huggingface/gguf": "^0.1.12",
+    "@huggingface/hub": "^0.21.0",
     "express": "^4.21.2",
     "express-openapi-validator": "^5.3.9",
     "isomorphic-git": "^1.27.2",

--- a/packages/backend/src/assets/inference-images.json
+++ b/packages/backend/src/assets/inference-images.json
@@ -6,5 +6,8 @@
     "default": "ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat@sha256:20734e9d60f047d27e4c9cf6a3b663e0627d48bd06d0a73b968f9d81c82de2f1",
     "cuda": "ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat-cuda@sha256:798acced911527254601d0e39a90c5a29ecad82755f28594bea9a587ea9e6043",
     "vulkan": "ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat-vulkan@sha256:22e11661fe66ace7c30b419703305b803eb937da10e19c23cb6767f03578256c"
+  },
+  "vllm": {
+    "default": "quay.io/rh-ee-astefani/vllm:cpu-1734105797"
   }
 }

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -54,6 +54,7 @@ import { InstructlabApiImpl } from './instructlab-api-impl';
 import { NavigationRegistry } from './registries/NavigationRegistry';
 import { StudioAPI } from '@shared/src/StudioAPI';
 import { InstructlabAPI } from '@shared/src/InstructlabAPI';
+import { VLLM } from './workers/provider/VLLM';
 
 export class Studio {
   readonly #extensionContext: ExtensionContext;
@@ -258,6 +259,10 @@ export class Studio {
     );
     this.#extensionContext.subscriptions.push(
       this.#inferenceProviderRegistry.register(new WhisperCpp(this.#taskRegistry, this.#podmanConnection)),
+    );
+
+    this.#extensionContext.subscriptions.push(
+      this.#inferenceProviderRegistry.register(new VLLM(this.#taskRegistry, this.#podmanConnection)),
     );
 
     /**

--- a/packages/backend/src/workers/provider/VLLM.ts
+++ b/packages/backend/src/workers/provider/VLLM.ts
@@ -1,0 +1,148 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { InferenceProvider } from './InferenceProvider';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import type { PodmanConnection } from '../../managers/podmanConnection';
+import { type InferenceServer, InferenceType } from '@shared/src/models/IInference';
+import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
+import type { ContainerProviderConnection, MountConfig } from '@podman-desktop/api';
+import * as images from '../../assets/inference-images.json';
+import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
+import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
+import { basename, dirname } from 'node:path';
+import { join as joinposix } from 'node:path/posix';
+import { getLocalModelFile } from '../../utils/modelsUtils';
+
+export class VLLM extends InferenceProvider {
+  constructor(
+    taskRegistry: TaskRegistry,
+    private podmanConnection: PodmanConnection,
+  ) {
+    super(taskRegistry, InferenceType.VLLM, 'vllm');
+  }
+
+  dispose(): void {}
+
+  public enabled = (): boolean => true;
+
+  /**
+   * Here is an example
+   *
+   * podman run -it --rm
+   *  -v C:\Users\axels\.cache\huggingface\hub\models--mistralai--Mistral-7B-v0.1:/cache/models--mistralai--Mistral-7B-v0.1
+   *  -e HF_HUB_CACHE=/cache
+   *  localhost/vllm-cpu-env:latest
+   *  --model=/cache/models--mistralai--Mistral-7B-v0.1/snapshots/7231864981174d9bee8c7687c24c8344414eae6b
+   *
+   * @param config
+   */
+  override async perform(config: InferenceServerConfig): Promise<InferenceServer> {
+    if (config.modelsInfo.length !== 1)
+      throw new Error(`only one model is supported, received ${config.modelsInfo.length}`);
+
+    const modelInfo = config.modelsInfo[0];
+    if (modelInfo.backend !== InferenceType.VLLM) {
+      throw new Error(`VLLM requires models with backend type ${InferenceType.VLLM} got ${modelInfo.backend}.`);
+    }
+
+    if (modelInfo.file === undefined) {
+      throw new Error('The model info file provided is undefined');
+    }
+
+    console.log('[VLLM]', config);
+    console.log('[VLLM] modelInfo.file', modelInfo.file);
+
+    const fullPath = getLocalModelFile(modelInfo);
+
+    // modelInfo.file.path must be under the form $(HF_HUB_CACHE)/<repo-type>--<repo-id>/snapshots/<commit-hash>
+    const parent = dirname(fullPath);
+    const commitHash = basename(fullPath);
+    const name = basename(parent);
+    if (name !== 'snapshots') throw new Error('you must provide snapshot path for vllm');
+    const modelCache = dirname(parent);
+
+    let connection: ContainerProviderConnection | undefined;
+    if (config.connection) {
+      connection = this.podmanConnection.getContainerProviderConnection(config.connection);
+    } else {
+      connection = this.podmanConnection.findRunningContainerProviderConnection();
+    }
+
+    if (!connection) throw new Error('no running connection could be found');
+
+    const labels: Record<string, string> = {
+      ...config.labels,
+      [LABEL_INFERENCE_SERVER]: JSON.stringify(config.modelsInfo.map(model => model.id)),
+    };
+
+    const imageInfo = await this.pullImage(connection, config.image ?? images.vllm.default, labels);
+    // https://huggingface.co/docs/transformers/main/en/installation#offline-mode
+    // HF_HUB_OFFLINE in main
+    // TRANSFORMERS_OFFLINE for legacy
+    const envs: string[] = [`HF_HUB_CACHE=/cache`, 'TRANSFORMERS_OFFLINE=1', 'HF_HUB_OFFLINE=1'];
+
+    labels['api'] = `http://localhost:${config.port}/inference`;
+
+    const mounts: MountConfig = [
+      {
+        Target: `/cache/${modelInfo.id}`,
+        Source: modelCache,
+        Type: 'bind',
+      },
+    ];
+
+    const containerInfo = await this.createContainer(
+      imageInfo.engineId,
+      {
+        Image: imageInfo.Id,
+        Detach: true,
+        Labels: labels,
+        HostConfig: {
+          AutoRemove: false,
+          Mounts: mounts,
+          PortBindings: {
+            '8000/tcp': [
+              {
+                HostPort: `${config.port}`,
+              },
+            ],
+          },
+          SecurityOpt: [DISABLE_SELINUX_LABEL_SECURITY_OPTION],
+        },
+        Env: envs,
+        Cmd: [`--model=${joinposix('/cache', modelInfo.id, 'snapshots', commitHash)}`],
+      },
+      labels,
+    );
+
+    return {
+      models: [modelInfo],
+      status: 'running',
+      connection: {
+        port: config.port,
+      },
+      container: {
+        containerId: containerInfo.id,
+        engineId: containerInfo.engineId,
+      },
+      type: InferenceType.VLLM,
+      labels: labels,
+    };
+  }
+}

--- a/packages/frontend/src/lib/table/model/ModelColumnName.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnName.svelte
@@ -2,14 +2,20 @@
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { router } from 'tinro';
 
-export let object: ModelInfo;
+interface Props {
+  object: ModelInfo;
+}
+
+let { object }: Props = $props();
+
+let hf: boolean = $state(object.properties?.['origin'] === 'HF_CACHE');
 
 function openDetails(): void {
   router.goto(`/model/${object.id}`);
 }
 </script>
 
-<button class="flex flex-col w-full" title={object.name} on:click={openDetails} aria-label="Open Model Details">
+<button class="flex flex-col w-full" title={object.name} onclick={openDetails} aria-label="Open Model Details">
   <div
     class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis w-full text-left"
     aria-label="Model Name">
@@ -19,7 +25,10 @@ function openDetails(): void {
     <span class="text-sm text-[var(--pd-table-body-text)]" aria-label="Model Info"
       >{object.registry} - {object.license}</span>
   {/if}
-  {#if !object.registry && !object.license && !object.url}
+  {#if hf}
+    <span class="text-sm text-[var(--pd-table-body-text)]" aria-label="Imported Model Info"
+      >Loaded from hugging face cache</span>
+  {:else if !object.registry && !object.license && !object.url}
     <span class="text-sm text-[var(--pd-table-body-text)]" aria-label="Imported Model Info">Imported by User</span>
   {/if}
 </button>

--- a/packages/shared/src/models/IInference.ts
+++ b/packages/shared/src/models/IInference.ts
@@ -21,6 +21,7 @@ export enum InferenceType {
   LLAMA_CPP = 'llama-cpp',
   WHISPER_CPP = 'whisper-cpp',
   NONE = 'none',
+  VLLM = 'vllm',
 }
 
 export type InferenceServerStatus = 'stopped' | 'running' | 'deleting' | 'stopping' | 'error' | 'starting';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@huggingface/gguf':
         specifier: ^0.1.12
         version: 0.1.12
+      '@huggingface/hub':
+        specifier: ^0.21.0
+        version: 0.21.0
       express:
         specifier: ^4.21.2
         version: 4.21.2
@@ -1190,6 +1193,13 @@ packages:
   '@huggingface/gguf@0.1.12':
     resolution: {integrity: sha512-m+u/ms28wE74v2VVCTncfI/KB2v897MRMOoRuYSU62P85fJ6/B2exMlHCNyAXkgDLeXBWDivXl4gPq+XbHmkaA==}
     engines: {node: '>=20'}
+
+  '@huggingface/hub@0.21.0':
+    resolution: {integrity: sha512-DpitNhqobMJLTv8dUq/EMtrz1dpfs3UrSVCxe1aKpjLAdOs6Gm6rqrinUFNvC9G88RIRzIYzojUtYUqlkKwKnA==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tasks@0.13.13':
+    resolution: {integrity: sha512-jaU91/x9mn3q1pwHMzpUiXICqME56LgDgza/nyt4h3Jp6k84YW931YFK5ri32qBDHmtjn/1dR4OMw85+dx87dA==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5885,6 +5895,12 @@ snapshots:
       '@fortawesome/fontawesome-common-types': 6.7.1
 
   '@huggingface/gguf@0.1.12': {}
+
+  '@huggingface/hub@0.21.0':
+    dependencies:
+      '@huggingface/tasks': 0.13.13
+
+  '@huggingface/tasks@0.13.13': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
### What does this PR do?

Quick POC showing integration of VLLM in AI Lab.

VLLM only support `.safetensors` models. AI Lab only support the GGUF models, this PR show how the amazing `@huggingface/hub` library can be used to read the downloaded models from the cache and mount them to create an inference server.

I build and push myself an image `quay.io/rh-ee-astefani/vllm:cpu-1734105797` this image has been built following the instruction in https://docs.vllm.ai/en/latest/getting_started/cpu-installation.html#quick-start-using-dockerfile

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/3f1dab9b-6891-4dea-ad2c-9a99de62fd17)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. install the `huggingface` cli tool (See [Installation](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli))
2. Run `huggingface-cli download Qwen/Qwen2.5-0.5B-Instruct` (it will download a model)
3. Start/Restart AI Lab, the hugging face models are loaded on startup.
4. Assert `Qwen/Qwen2.5-0.5B-Instruct` is in the `imported` section of the models catalog
5. Click on `Create Model service`
![image](https://github.com/user-attachments/assets/7ff88d20-20cd-4f18-87dd-63af4a80b11a)
7. Click on `Create Service`
![image](https://github.com/user-attachments/assets/a6cab690-7320-4e4a-ac26-dca1a9e68f41)
8. assert service is created
![image](https://github.com/user-attachments/assets/f8d73162-cdbe-4956-82b2-29d0aaa8ed69)
9. Open Podman Desktop containers page
10. assert your cpu-vllm container is running
11. Wait for the server to be up and running (can take a few minutes)
12. checks models list
![image](https://github.com/user-attachments/assets/5638cdf4-cc9a-43af-a9d8-a1940e57d079)
13. check basic request 
![image](https://github.com/user-attachments/assets/3ab13aa4-965d-4a85-a3ad-89b40a82ad6e)


