### PR TITLE
fix: only mount model file to inference container

### DIFF
--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -32,6 +32,7 @@ import type { InferenceServer } from '@shared/src/models/IInference';
 import { InferenceType } from '@shared/src/models/IInference';
 import { llamacpp } from '../../assets/inference-images.json';
 import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
+import { join } from 'node:path';
 
 vi.mock('@podman-desktop/api', () => ({
   containerEngine: {
@@ -208,7 +209,7 @@ describe('perform', () => {
         AutoRemove: false,
         Mounts: [
           {
-            Source: 'dummy-path/dummy-file.guff',
+            Source: join('dummy-path', 'dummy-file.guff'),
             Target: '/models/dummy-file.guff',
             Type: 'bind',
           },

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -208,8 +208,8 @@ describe('perform', () => {
         AutoRemove: false,
         Mounts: [
           {
-            Source: 'dummy-path',
-            Target: '/models',
+            Source: 'dummy-path/dummy-file.guff',
+            Target: '/models/dummy-file.guff',
             Type: 'bind',
           },
         ],

--- a/packages/backend/src/workers/provider/WhisperCpp.spec.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.spec.ts
@@ -235,4 +235,33 @@ test('provided connection should be used for pulling the image', async () => {
   expect(getImageInfo).toHaveBeenCalledWith(connectionMock, 'localhost/whisper-cpp:custom', expect.any(Function));
   expect(podmanConnection.getContainerProviderConnection).toHaveBeenCalledWith(connection);
   expect(podmanConnection.findRunningContainerProviderConnection).not.toHaveBeenCalled();
+  // ensure the create container is called with appropriate arguments
+  expect(containerEngine.createContainer).toHaveBeenCalledWith('dummy-engine-id', {
+    Detach: true,
+    Env: ['MODEL_PATH=/models/random-file', 'HOST=0.0.0.0', 'PORT=8000'],
+    HostConfig: {
+      AutoRemove: false,
+      Mounts: [
+        {
+          Source: 'path-to-file/random-file',
+          Target: '/models/random-file',
+          Type: 'bind',
+        },
+      ],
+      PortBindings: {
+        '8000/tcp': [
+          {
+            HostPort: '8888',
+          },
+        ],
+      },
+      SecurityOpt: ['label=disable'],
+    },
+    Image: 'dummy-image-id',
+    Labels: {
+      'ai-lab-inference-server': '["whisper-cpp"]',
+      api: 'http://localhost:8888/inference',
+      hello: 'world',
+    },
+  });
 });

--- a/packages/backend/src/workers/provider/WhisperCpp.spec.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.spec.ts
@@ -27,6 +27,7 @@ import { getImageInfo } from '../../utils/inferenceUtils';
 import type { PodmanConnection } from '../../managers/podmanConnection';
 import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 import { VMType } from '@shared/src/models/IPodman';
+import { join } from 'node:path';
 
 vi.mock('@podman-desktop/api', () => ({
   containerEngine: {
@@ -243,7 +244,7 @@ test('provided connection should be used for pulling the image', async () => {
       AutoRemove: false,
       Mounts: [
         {
-          Source: 'path-to-file/random-file',
+          Source: join('path-to-file', 'random-file'),
           Target: '/models/random-file',
           Type: 'bind',
         },


### PR DESCRIPTION
### What does this PR do?

Currently we are mounting the parent directory of the model to `/model` and provide the env `MODEL_PATH=/model/${filename}`. This has some issue, has we mount all the content of the parent folder of the gguf files inside the container.

This is mostly not an issue expect for the imported models, let's say you import a model from your Download folder, and let's say you have 5000 files in the download folder: big problem coming.

The problem has been reported by @slemeur 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/1992

### How to test this PR?

- [x] unit tests has been added

**manually**

1. checkout and start podman studio with ai-lab 
2. start an inference server
3. assert model mounted is properly done

![image](https://github.com/user-attachments/assets/9bdc7624-6809-41f3-b19b-24bbfa2566b5)
