### PR TITLE
feat: adding monaco support

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -34,6 +34,7 @@
     "@types/humanize-duration": "^3.27.4",
     "@typescript-eslint/eslint-plugin": "8.24.1",
     "jsdom": "^26.0.0",
+    "monaco-editor": "^0.52.2",
     "postcss": "^8.5.3",
     "postcss-load-config": "^6.0.1",
     "svelte": "5.20.2",

--- a/packages/frontend/src/App.spec.ts
+++ b/packages/frontend/src/App.spec.ts
@@ -35,6 +35,8 @@ vi.mock('tinro', () => ({
     },
   },
 }));
+// mock monaco
+vi.mock('/@/lib/monaco-editor/MonacoEditor.svelte');
 
 vi.mock('./stores/extensionConfiguration.ts', () => ({
   configuration: {

--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
@@ -10,9 +10,18 @@ interface Props extends HTMLAttributes<HTMLElement> {
   language: string;
   readOnly?: boolean;
   onChange?: (content: string) => void;
+  noMinimap?: boolean;
 }
 
-let { content = $bindable(), language, readOnly = false, onChange, class: className, ...restProps }: Props = $props();
+let {
+  content = $bindable(),
+  language,
+  readOnly = false,
+  onChange,
+  class: className,
+  noMinimap,
+  ...restProps
+}: Props = $props();
 
 let editorInstance: Monaco.editor.IStandaloneCodeEditor;
 let editorContainer: HTMLElement;
@@ -63,6 +72,9 @@ onMount(async () => {
         readOnly: readOnly,
         theme: 'podmanDesktopTheme',
         glyphMargin: true, // Enable glyph margin
+        minimap: {
+          enabled: !noMinimap,
+        },
       });
 
       editorInstance.onDidChangeModelContent(() => {

--- a/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
+++ b/packages/frontend/src/lib/monaco-editor/MonacoEditor.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import './monaco';
+import type { HTMLAttributes } from 'svelte/elements';
+
+interface Props extends HTMLAttributes<HTMLElement> {
+  content: string;
+  // supported languages https://github.com/microsoft/monaco-editor/tree/main/src/basic-languages
+  language: string;
+  readOnly?: boolean;
+  onChange?: (content: string) => void;
+}
+
+let { content = $bindable(), language, readOnly = false, onChange, class: className, ...restProps }: Props = $props();
+
+let editorInstance: Monaco.editor.IStandaloneCodeEditor;
+let editorContainer: HTMLElement;
+
+function getTerminalBg(): string {
+  const app = document.getElementById('app');
+  if (!app) throw new Error('cannot found app element');
+  const style = window.getComputedStyle(app);
+
+  let color = style.getPropertyValue('--pd-terminal-background').trim();
+
+  // convert to 6 char RGB value since some things don't support 3 char format
+  if (color?.length < 6) {
+    color = color
+      .split('')
+      .map(c => {
+        return c === '#' ? c : c + c;
+      })
+      .join('');
+  }
+  return color;
+}
+
+onMount(async () => {
+  const terminalBg = getTerminalBg();
+  const isDarkTheme: boolean = terminalBg === '#000000';
+
+  // solution from https://github.com/vitejs/vite/discussions/1791#discussioncomment-9281911
+  import('monaco-editor/esm/vs/editor/editor.api')
+    .then(monaco => {
+      // define custom theme
+      monaco.editor.defineTheme('podmanDesktopTheme', {
+        base: isDarkTheme ? 'vs-dark' : 'vs',
+        inherit: true,
+        rules: [{ token: 'custom-color', background: terminalBg }],
+        colors: {
+          'editor.background': terminalBg,
+          // make the --vscode-focusBorder transparent
+          focusBorder: '#00000000',
+        },
+      });
+
+      editorInstance = monaco.editor.create(editorContainer, {
+        value: content,
+        language: language,
+        automaticLayout: true,
+        scrollBeyondLastLine: false,
+        readOnly: readOnly,
+        theme: 'podmanDesktopTheme',
+        glyphMargin: true, // Enable glyph margin
+      });
+
+      editorInstance.onDidChangeModelContent(() => {
+        content = editorInstance.getValue();
+        onChange?.(content);
+      });
+    })
+    .catch(console.error);
+});
+
+onDestroy(() => {
+  editorInstance?.dispose();
+});
+</script>
+
+<div class="h-full w-full {className}" {...restProps} bind:this={editorContainer}></div>

--- a/packages/frontend/src/lib/monaco-editor/monaco.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco.ts
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+
+self.MonacoEnvironment = {
+  getWorker(_: unknown): Worker {
+    return new editorWorker();
+  },
+};
+
+monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);

--- a/packages/frontend/src/lib/monaco-editor/monaco.ts
+++ b/packages/frontend/src/lib/monaco-editor/monaco.ts
@@ -25,4 +25,4 @@ self.MonacoEnvironment = {
   },
 };
 
-monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
+monaco.languages.typescript?.typescriptDefaults?.setEagerModelSync(true);

--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -232,7 +232,7 @@ describe('snippets', () => {
     await vi.waitFor(() => {
       expect(MonacoEditor).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ content: DUMMY_SNIPPET, language: 'curl', readOnly: true }),
+        expect.objectContaining({ content: DUMMY_SNIPPET, language: 'curl', readOnly: true, noMinimap: true }),
       );
     });
   });

--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -25,6 +25,7 @@ import type { Language } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import MonacoEditor from '../lib/monaco-editor/MonacoEditor.svelte';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -32,6 +33,10 @@ const mocks = vi.hoisted(() => {
     getSnippetLanguagesMock: vi.fn(),
   };
 });
+
+vi.mock('../lib/monaco-editor/MonacoEditor.svelte', () => ({
+  default: vi.fn(),
+}));
 
 vi.mock('../stores/inferenceServers', () => ({
   inferenceServers: {
@@ -215,6 +220,21 @@ describe('snippets', () => {
       'curl',
       'cURL',
     );
+  });
+
+  test('generated snippet should be sent to the monaco component', async () => {
+    const DUMMY_SNIPPET = 'dummy generated snippet';
+    vi.mocked(studioClient.createSnippet).mockResolvedValue(DUMMY_SNIPPET);
+    render(InferenceServerDetails, {
+      containerId: 'dummyContainerId',
+    });
+
+    await vi.waitFor(() => {
+      expect(MonacoEditor).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ content: DUMMY_SNIPPET, language: 'curl', readOnly: true }),
+      );
+    });
   });
 
   test('copy snippet should call copyToClipboard', async () => {

--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -25,7 +25,7 @@ import type { Language } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
-import MonacoEditor from '../lib/monaco-editor/MonacoEditor.svelte';
+import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -34,7 +34,7 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('../lib/monaco-editor/MonacoEditor.svelte', () => ({
+vi.mock('/@/lib/monaco-editor/MonacoEditor.svelte', () => ({
   default: vi.fn(),
 }));
 

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -22,6 +22,7 @@ import { Button, DetailsPage, Tooltip, Link } from '@podman-desktop/ui-svelte';
 import CopyButton from '/@/lib/button/CopyButton.svelte';
 import type { RequestOptions } from '@shared/src/models/RequestOptions';
 import { filesize } from 'filesize';
+import MonacoEditor from '../lib/monaco-editor/MonacoEditor.svelte';
 
 export let containerId: string | undefined = undefined;
 
@@ -118,22 +119,6 @@ $: {
     generate('curl', 'cURL').catch(err =>
       console.error(`Error generating snippet for language curl variant cURL:`, err),
     );
-  }
-}
-
-let code: HTMLElement;
-
-$: {
-  if (code) {
-    code.addEventListener('copy', event => {
-      studioClient
-        .telemetryLogUsage('snippet.copy', {
-          cpyButton: false,
-          language: selectedLanguage,
-          variant: selectedVariant,
-        })
-        .catch(err => console.error(`Error reporting telemetry:`, err));
-    });
   }
 }
 
@@ -368,11 +353,11 @@ function handleOnChange(): void {
 
                 {#if snippet !== undefined}
                   <div
-                    class="bg-[var(--pd-details-empty-cmdline-bg)] text-[var(--pd-details-empty-cmdline-text)] rounded-md w-full p-4 mt-2 relative"
+                    class="bg-[var(--pd-details-empty-cmdline-bg)] text-[var(--pd-details-empty-cmdline-text)] rounded-md w-full p-4 mt-2 relative h-[400px]"
                     aria-label="Code Snippet">
-                    <code class="whitespace-break-spaces text-sm" bind:this={code}>
-                      {snippet}
-                    </code>
+                    {#key snippet}
+                      <MonacoEditor class="h-full" readOnly content={snippet} language={selectedLanguage} />
+                    {/key}
                     <div class="absolute right-4 top-4 z-10">
                       <Button icon={copied ? faCheck : faCopy} type="secondary" title="Copy" on:click={copySnippet} />
                     </div>

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -356,7 +356,7 @@ function handleOnChange(): void {
                     class="bg-[var(--pd-details-empty-cmdline-bg)] text-[var(--pd-details-empty-cmdline-text)] rounded-md w-full p-4 mt-2 relative h-[400px]"
                     aria-label="Code Snippet">
                     {#key snippet}
-                      <MonacoEditor class="h-full" readOnly content={snippet} language={selectedLanguage} />
+                      <MonacoEditor class="h-full" readOnly content={snippet} language={selectedLanguage} noMinimap />
                     {/key}
                     <div class="absolute right-4 top-4 z-10">
                       <Button icon={copied ? faCheck : faCopy} type="secondary" title="Copy" on:click={copySnippet} />

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -22,7 +22,7 @@ import { Button, DetailsPage, Tooltip, Link } from '@podman-desktop/ui-svelte';
 import CopyButton from '/@/lib/button/CopyButton.svelte';
 import type { RequestOptions } from '@shared/src/models/RequestOptions';
 import { filesize } from 'filesize';
-import MonacoEditor from '../lib/monaco-editor/MonacoEditor.svelte';
+import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
 
 export let containerId: string | undefined = undefined;
 

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -21,7 +21,8 @@
      * of JS in `.svelte` files.
      */
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+    "types": ["@testing-library/jest-dom", "vite/client"]
   },
   "include": [
     "src/**/*.d.ts",

--- a/packages/frontend/vite.config.js
+++ b/packages/frontend/vite.config.js
@@ -46,7 +46,13 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     globals: true,
     environment: 'jsdom',
-    alias: [{ find: '@testing-library/svelte', replacement: '@testing-library/svelte/svelte5' }],
+    alias: [
+      { find: '@testing-library/svelte', replacement: '@testing-library/svelte/svelte5' },
+      {
+        find: /^monaco-editor$/,
+        replacement: `${PACKAGE_ROOT}/../../node_modules/monaco-editor/esm/vs/editor/editor.api`,
+      },
+    ],
     deps: {
       inline: [],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0
+      monaco-editor:
+        specifier: ^0.52.2
+        version: 0.52.2
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -3424,6 +3427,9 @@ packages:
 
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+
+  monaco-editor@0.52.2:
+    resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -8260,6 +8266,8 @@ snapshots:
       minimist: 1.2.8
 
   moment@2.30.1: {}
+
+  monaco-editor@0.52.2: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
### What does this PR do?

Tentative to add the Monaco Editor to AI Lab. We cannot do dynamic import because it crashes (no idea why, probably related to the way we manage webview webserver.)

### Known issues

- Cannot use the Monaco editor in tests (vitest) got lots of errors (The Podman Destkop Monaco Editor seems to also have some similar issues, because it has no tests too.)
- Some languages (javascript) are not recognised (probably some naming issues, this should be in a follow-up PR)

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/2e8cd6da-e577-4550-b3ae-b6491049979c)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/858

### How to test this PR?

1. Start an inference service
2. Go to inference details page
3. assert monaco editor in readonly.