### PR TITLE
feat: add optional language and frameworks fields to recipes

### DIFF
--- a/packages/backend/src/utils/catalogUtils.spec.ts
+++ b/packages/backend/src/utils/catalogUtils.spec.ts
@@ -145,6 +145,8 @@ describe('sanitize', () => {
           readme: '',
           recommended: ['hf.instructlab.granite-7b-lab-GGUF', 'hf.instructlab.merlinite-7b-lab-GGUF'],
           backend: 'llama-cpp',
+          language: 'lang1',
+          frameworks: ['fw1'],
         },
       ],
       models: [
@@ -168,6 +170,8 @@ describe('sanitize', () => {
     expect(catalog.version).equals(CatalogFormat.CURRENT);
     expect(catalog.models[0].backend).toBeUndefined();
     expect(catalog.models[0].name).equals('Mistral-7B-Instruct-v0.3-Q4_K_M');
+    expect(catalog.recipes[0].language).equals('lang1');
+    expect(catalog.recipes[0].frameworks).toStrictEqual(['fw1']);
   });
 });
 

--- a/packages/backend/src/utils/catalogUtils.spec.ts
+++ b/packages/backend/src/utils/catalogUtils.spec.ts
@@ -145,7 +145,7 @@ describe('sanitize', () => {
           readme: '',
           recommended: ['hf.instructlab.granite-7b-lab-GGUF', 'hf.instructlab.merlinite-7b-lab-GGUF'],
           backend: 'llama-cpp',
-          language: 'lang1',
+          languages: ['lang1'],
           frameworks: ['fw1'],
         },
       ],
@@ -170,7 +170,7 @@ describe('sanitize', () => {
     expect(catalog.version).equals(CatalogFormat.CURRENT);
     expect(catalog.models[0].backend).toBeUndefined();
     expect(catalog.models[0].name).equals('Mistral-7B-Instruct-v0.3-Q4_K_M');
-    expect(catalog.recipes[0].language).equals('lang1');
+    expect(catalog.recipes[0].languages).toStrictEqual(['lang1']);
     expect(catalog.recipes[0].frameworks).toStrictEqual(['fw1']);
   });
 });

--- a/packages/backend/src/utils/catalogUtils.ts
+++ b/packages/backend/src/utils/catalogUtils.ts
@@ -144,6 +144,8 @@ export function sanitizeRecipe(recipe: unknown): Recipe {
       basedir: 'basedir' in recipe && typeof recipe.basedir === 'string' ? recipe.basedir : undefined,
       recommended: 'recommended' in recipe && isStringArray(recipe.recommended) ? recipe.recommended : undefined,
       backend: 'backend' in recipe && typeof recipe.backend === 'string' ? recipe.backend : undefined,
+      language: 'language' in recipe && typeof recipe.language === 'string' ? recipe.language : undefined,
+      frameworks: 'frameworks' in recipe && isStringArray(recipe.frameworks) ? recipe.frameworks : undefined,
     };
   throw new Error('invalid recipe format');
 }

--- a/packages/backend/src/utils/catalogUtils.ts
+++ b/packages/backend/src/utils/catalogUtils.ts
@@ -144,7 +144,7 @@ export function sanitizeRecipe(recipe: unknown): Recipe {
       basedir: 'basedir' in recipe && typeof recipe.basedir === 'string' ? recipe.basedir : undefined,
       recommended: 'recommended' in recipe && isStringArray(recipe.recommended) ? recipe.recommended : undefined,
       backend: 'backend' in recipe && typeof recipe.backend === 'string' ? recipe.backend : undefined,
-      language: 'language' in recipe && typeof recipe.language === 'string' ? recipe.language : undefined,
+      languages: 'languages' in recipe && isStringArray(recipe.languages) ? recipe.languages : undefined,
       frameworks: 'frameworks' in recipe && isStringArray(recipe.frameworks) ? recipe.frameworks : undefined,
     };
   throw new Error('invalid recipe format');

--- a/packages/shared/src/models/IRecipe.ts
+++ b/packages/shared/src/models/IRecipe.ts
@@ -57,6 +57,6 @@ export interface Recipe {
    * server the recipe requires
    */
   backend?: string;
-  language?: string;
+  languages?: string[];
   frameworks?: string[];
 }

--- a/packages/shared/src/models/IRecipe.ts
+++ b/packages/shared/src/models/IRecipe.ts
@@ -57,4 +57,6 @@ export interface Recipe {
    * server the recipe requires
    */
   backend?: string;
+  language?: string;
+  frameworks?: string[];
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Add optional language and frameworks fields to recipes. 

I don't know if we want to increase the catalog version number when adding optional fields. @axel7083 @jeffmaury WDYT?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to #1693 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
