### PR TITLE
feat: improving error message when no container engine is running

### DIFF
--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -209,6 +209,24 @@ test('button click should call createInferenceServer', async () => {
   });
 });
 
+test('create button should be disabled if no container engine running', async () => {
+  // mock no container connection available
+  mocks.getContainerConnectionInfoMock.mockReturnValue([]);
+  mocks.modelsInfoSubscribeMock.mockReturnValue([{ id: 'random', file: true }]);
+
+  const { getByTitle, getByRole } = render(CreateService);
+
+  const createBtn: HTMLElement = await vi.waitFor(() => {
+    const element = getByTitle('Create service');
+    expect(element).toBeDefined();
+    return element;
+  });
+  expect(createBtn).toBeDisabled();
+
+  const alert = getByRole('alert');
+  expect(alert).toHaveTextContent('No running container engine found');
+});
+
 test('tasks progress should not be visible by default', async () => {
   render(CreateService);
 

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -60,6 +60,10 @@ $effect(() => {
   if (!containerProviderConnection && startedContainerProviderConnectionInfo.length > 0) {
     containerProviderConnection = startedContainerProviderConnectionInfo[0];
   }
+
+  if (!containerProviderConnection) {
+    errorMsg = 'No running container engine found';
+  }
 });
 
 const onContainerPortInput = (event: Event): void => {
@@ -231,7 +235,7 @@ export function goToUpPage(): void {
                 title="Create service"
                 inProgress={loading}
                 on:click={submit}
-                disabled={!model || !containerPort}
+                disabled={!model || !containerPort || !containerProviderConnection}
                 icon={faPlusCircle}>
                 Create service
               </Button>


### PR DESCRIPTION
### What does this PR do?

Disabling the `Start Recipe` and `Create Service` if no running container engine found plus adding an error message.

### Screenshot / video of UI

**Recipes**

![image](https://github.com/user-attachments/assets/d970d1b6-5345-44ae-8c8e-185249db49e9)

**Inference Servers**

![image](https://github.com/user-attachments/assets/5124f5e3-b96e-4770-abdb-f861ce0ba643)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/2188

### How to test this PR?

- [x] unit tests has been provided

**Manually**

1. assert no podman machine running
2. go to recipe start form
3. assert start button disabled
4. repeat for inference service
