### PR TITLE
fix: no running container never disappearing 

### DIFF
--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ test('button click should call createInferenceServer', async () => {
   });
 });
 
-test('containerProviderConnections should remove no running container errro', async () => {
+test('no containerProviderConnections should have no running container error', async () => {
   // mock an empty store
   vi.mocked(ConnectionStore).containerProviderConnections = readable([]);
 

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -194,6 +194,29 @@ test('containerProviderConnections should remove no running container errro', as
   expect(alert).toHaveTextContent('No running container engine found');
 });
 
+test('no container error should disappear if one get available', async () => {
+  // mock an empty store
+  const store = writable<ContainerProviderConnectionInfo[]>([]);
+  vi.mocked(ConnectionStore).containerProviderConnections = store;
+
+  const { getByRole, queryByRole } = render(CreateService);
+
+  // First we should have the error
+  await vi.waitFor(() => {
+    const alert = getByRole('alert');
+    expect(alert).toHaveTextContent('No running container engine found');
+  });
+
+  // let's fill the store
+  store.set([containerProviderConnection]);
+
+  // wait for error to be removed
+  await vi.waitFor(() => {
+    const alert = queryByRole('alert');
+    expect(alert).toBeNull();
+  });
+});
+
 test('tasks progress should not be visible by default', async () => {
   render(CreateService);
 

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -60,10 +60,6 @@ $effect(() => {
   if (!containerProviderConnection && startedContainerProviderConnectionInfo.length > 0) {
     containerProviderConnection = startedContainerProviderConnectionInfo[0];
   }
-
-  if (!containerProviderConnection) {
-    errorMsg = 'No running container engine found';
-  }
 });
 
 const onContainerPortInput = (event: Event): void => {
@@ -225,8 +221,8 @@ export function goToUpPage(): void {
             disabled={loading}
             required />
         </div>
-        {#if errorMsg !== undefined}
-          <ErrorMessage error={errorMsg} />
+        {#if errorMsg !== undefined || !containerProviderConnection}
+          <ErrorMessage error={errorMsg ?? 'No running container engine found'} />
         {/if}
         <footer>
           <div class="w-full flex flex-col">

--- a/packages/frontend/src/pages/StartRecipe.svelte
+++ b/packages/frontend/src/pages/StartRecipe.svelte
@@ -62,11 +62,6 @@ $effect(() => {
   if (!model && recipe && models.length > 0) {
     model = getFirstRecommended();
   }
-
-  // if no container provider connection found this is an error
-  if (!containerProviderConnection) {
-    errorMsg = 'No running container engine found';
-  }
 });
 
 const getFirstRecommended = (): ModelInfo | undefined => {
@@ -202,8 +197,8 @@ function handleOnClick(): void {
             {/if}
           </div>
 
-          {#if errorMsg !== undefined}
-            <ErrorMessage error={errorMsg} />
+          {#if errorMsg !== undefined || !containerProviderConnection}
+            <ErrorMessage error={errorMsg ?? 'No running container engine found'} />
           {/if}
           <footer>
             <div class="w-full flex flex-col">


### PR DESCRIPTION
### What does this PR do?

Make the `no running container` not appear when it should not be there.

Today the error is displayed when we do not need it, and never cleared. This PR makes is reactive, only be displayed when the condition are met.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/2363

Requires
- https://github.com/containers/podman-desktop-extension-ai-lab/pull/2365
- https://github.com/containers/podman-desktop-extension-ai-lab/pull/2364

### How to test this PR?

- [x] unit tests has been provided

**Reproduce**

- assert have multiple container engines
- Open AI-Lab
- Open New Service
- assert no error
