### PR TITLE
fix(vitest): remove circular dependencies

### DIFF
--- a/packages/shared/src/messages/MessageProxy.spec.ts
+++ b/packages/shared/src/messages/MessageProxy.spec.ts
@@ -17,9 +17,10 @@
  ***********************************************************************/
 
 import { test, expect, vi, describe, beforeEach, afterEach } from 'vitest';
-import { getChannel, RpcBrowser, RpcExtension } from './MessageProxy';
+import { RpcBrowser, RpcExtension } from './MessageProxy';
 import type { Webview } from '@podman-desktop/api';
 import * as defaultNoTimeoutChannels from './NoTimeoutChannels';
+import { getChannel } from './utils';
 
 let webview: Webview;
 let window: Window;

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -19,6 +19,7 @@
 
 import type { Webview, Disposable } from '@podman-desktop/api';
 import { noTimeoutChannels } from './NoTimeoutChannels';
+import { getChannel } from './utils';
 
 export interface IMessage {
   id: number;
@@ -38,10 +39,6 @@ export interface IMessageResponse extends IMessageRequest {
 export interface ISubscribedMessage {
   id: string;
   body: any;
-}
-
-export function getChannel<T>(classType: { CHANNEL: string; prototype: T }, method: keyof T): string {
-  return `${classType.CHANNEL}-${String(method)}`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/shared/src/messages/utils.ts
+++ b/packages/shared/src/messages/utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { StudioAPI } from '../StudioAPI';
-import { getChannel } from './utils';
 
-export const noTimeoutChannels: string[] = [getChannel(StudioAPI, 'openDialog')];
+export function getChannel<T>(classType: { CHANNEL: string; prototype: T }, method: keyof T): string {
+  return `${classType.CHANNEL}-${String(method)}`;
+}


### PR DESCRIPTION
### What does this PR do?

vitest mocking system got crazy when circular dependencies are happening.

Here we had a function `getChannel` defined in `MessageProxy`. The `noTimeoutChannels` was importing it, but the `MessageProxy` were also importing the noTImeoutChannels, making mocking go crazy in specific cases.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/containers/podman-desktop-extension-ai-lab/pull/2345

### How to test this PR?

- Pipeline should be green
