### PR TITLE
Trigger nightly windows e2e test on recipe catalog change merge

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -86,9 +86,6 @@ jobs:
   windows:
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
     env:
       MAPT_VERSION: v0.7.2
       MAPT_IMAGE: quay.io/redhat-developer/mapt

--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -16,10 +16,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Podman Desktop AI Lab E2E Nightly
+run-name: Podman Desktop AI Lab E2E Nightly ${{ github.event_name == 'push' && '[Recipe change]' || '' }}
 
 on:
   schedule:
     - cron:  '0 2 * * *'
+  push:
+    paths:
+      - 'packages/backend/src/assets/ai.json'
   workflow_dispatch:
     inputs:
       fork:
@@ -86,7 +90,7 @@ jobs:
       contents: read
       checks: write
     env:
-      MAPT_VERSION: v0.6.8
+      MAPT_VERSION: v0.7.2
       MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
@@ -117,7 +121,7 @@ jobs:
         DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-extension-ai-lab,FORK=containers,BRANCH=main'
         DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.0' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
-        DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.2-windows'
+        DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3-windows'
         DEFAULT_AZURE_VM_SIZE: 'Standard_D8as_v5'
       run: |
         echo "FORK=${{ github.event.inputs.fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
@@ -274,8 +278,8 @@ jobs:
 
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v5
-      if: always() # always run even if the previous step fails
       with:
+        annotate_only: false
         fail_on_failure: true
         include_passed: true
         detailed_summary: true


### PR DESCRIPTION
### What does this PR do?
* Updates versions of MAPT and pde2e image
* Adds push event trigger to e2e nightly windows workflow

### Screenshot / video of UI
N/A
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#2134 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
* can only be tested in fork
* change would have to be merged into main
* merging a change of `packages/backend/src/assets/ai.json` would trigger the workflow, run name should contain `[Recipe change]`
<!-- Please explain steps to reproduce -->
