### PR TITLE
fix(wsl): model mounting

### DIFF
--- a/packages/backend/src/utils/modelsUtils.ts
+++ b/packages/backend/src/utils/modelsUtils.ts
@@ -32,6 +32,19 @@ export function getLocalModelFile(modelInfo: ModelInfo): string {
 }
 
 /**
+ * Return the path to mount where the model is located
+ * @param modelInfo
+ */
+export function getMountPath(modelInfo: ModelInfo): string {
+  if (modelInfo.file === undefined) throw new Error('model is not available locally.');
+  // if the model is uploaded we need to use posix join
+  if (modelInfo.file.path === MACHINE_BASE_FOLDER) {
+    return posix.join(MACHINE_BASE_FOLDER, modelInfo.file.file);
+  }
+  return join(modelInfo.file.path, modelInfo.file.file);
+}
+
+/**
  * Given a model info object return the theoretical path where the model
  * should be in the podman machine
  * @param modelInfo

--- a/packages/backend/src/utils/modelsUtils.ts
+++ b/packages/backend/src/utils/modelsUtils.ts
@@ -20,7 +20,7 @@ import { join, posix } from 'node:path';
 import { getPodmanCli } from './podman';
 import { process } from '@podman-desktop/api';
 
-export const MACHINE_BASE_FOLDER = '/home/user/ai-lab/models/';
+export const MACHINE_BASE_FOLDER = '/home/user/ai-lab/models';
 
 /**
  * Given a model info object return the path where is it located locally

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -24,7 +24,7 @@ import type {
 } from '@podman-desktop/api';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { InferenceProvider } from './InferenceProvider';
-import { getLocalModelFile, getModelPropertiesForEnvironment } from '../../utils/modelsUtils';
+import { getModelPropertiesForEnvironment, getMountPath } from '../../utils/modelsUtils';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
 import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
@@ -83,7 +83,7 @@ export class LlamaCppPython extends InferenceProvider {
     };
 
     // get model mount settings
-    const filename = getLocalModelFile(modelInfo);
+    const filename = getMountPath(modelInfo);
     const target = `/models/${modelInfo.file.file}`;
 
     // mount the file directory to avoid adding other files to the containers

--- a/packages/backend/src/workers/provider/WhisperCpp.ts
+++ b/packages/backend/src/workers/provider/WhisperCpp.ts
@@ -25,7 +25,7 @@ import type { ContainerProviderConnection, MountConfig } from '@podman-desktop/a
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../../utils/utils';
 import { whispercpp } from '../../assets/inference-images.json';
 import type { PodmanConnection } from '../../managers/podmanConnection';
-import { getLocalModelFile } from '../../utils/modelsUtils';
+import { getMountPath } from '../../utils/modelsUtils';
 
 export class WhisperCpp extends InferenceProvider {
   constructor(
@@ -69,7 +69,7 @@ export class WhisperCpp extends InferenceProvider {
     if (!connection) throw new Error('no running connection could be found');
 
     // get model mount settings
-    const filename = getLocalModelFile(modelInfo);
+    const filename = getMountPath(modelInfo);
     const target = `/models/${modelInfo.file.file}`;
 
     // mount the file directory to avoid adding other files to the containers


### PR DESCRIPTION
### What does this PR do?

Replace the `getLocalModelFile` by the new `getMountPath`.

The `getMountPath` ensure that **uploaded** model get the path properly joined using posix and not platform specific join.
The `getLocalModelFile` must be used only to get the local model file.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/2366

### How to test this PR?

- [x] unit tests are covering the changes
