### PR TITLE
fix: message proxy support multiple subscribers

### DIFF
--- a/packages/frontend/src/stores/rpcReadable.spec.ts
+++ b/packages/frontend/src/stores/rpcReadable.spec.ts
@@ -37,7 +37,7 @@ vi.mock('../utils/client', async () => {
     postMessage: (message: unknown) => {
       if (message && typeof message === 'object' && 'channel' in message) {
         const f = rpcBrowser.subscribers.get(message.channel as string);
-        f?.('');
+        f?.forEach(listener => listener(''));
       }
     },
   } as unknown as PodmanDesktopApi;


### PR DESCRIPTION
### What does this PR do?

Resolving the following todo

https://github.com/containers/podman-desktop-extension-ai-lab/blob/4fa1055395388041e564be175e509abf7aa909e9/packages/shared/src/messages/MessageProxy.ts#L223

When creating a store we can provide a list of events

https://github.com/containers/podman-desktop-extension-ai-lab/blob/40d97c3043461a2773dedfcb500d16aad5d5992b/packages/frontend/src/stores/localRepositories.ts#L9

The `RPCReadable` implemention will subscribe to the MessageProxy using the provided channel.

What happen if two store try to subscribe to the same event ? Only the last one is kept.

https://github.com/containers/podman-desktop-extension-ai-lab/blob/40d97c3043461a2773dedfcb500d16aad5d5992b/packages/shared/src/messages/MessageProxy.ts#L213

This PR change it by having a `Set` instead to be able to manage several listeners.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Found this problem while working on https://github.com/containers/podman-desktop-extension-ai-lab/issues/1851

### How to test this PR?

- [x] unit tests has been provided
