### PR TITLE
fix: failure in WSLUploader if models folder has spaces

### DIFF
--- a/packages/backend/src/utils/modelsUtils.ts
+++ b/packages/backend/src/utils/modelsUtils.ts
@@ -62,7 +62,7 @@ export function getRemoteModelFile(modelInfo: ModelInfo): string {
  */
 export async function isModelUploaded(machine: string, modelInfo: ModelInfo): Promise<boolean> {
   try {
-    const remotePath = getRemoteModelFile(modelInfo);
+    const remotePath = getRemoteModelFile(modelInfo).replace(/ /g, '\\ ');
     await process.exec(getPodmanCli(), ['machine', 'ssh', machine, 'stat', remotePath]);
     return true;
   } catch (err: unknown) {

--- a/packages/backend/src/workers/uploader/WSLUploader.spec.ts
+++ b/packages/backend/src/workers/uploader/WSLUploader.spec.ts
@@ -131,6 +131,40 @@ describe('upload', () => {
     ]);
   });
 
+  test('copy model if not exists on podman machine with space handling', async () => {
+    vi.mocked(process.exec).mockRejectedValueOnce('error');
+    await wslUploader.perform({
+      connection: connectionMock,
+      model: {
+        id: 'dummyId',
+        file: { path: 'C:\\Users\\podman folder', file: 'dummy.guff' },
+      } as unknown as ModelInfo,
+    });
+    expect(process.exec).toBeCalledWith('podman.exe', [
+      'machine',
+      'ssh',
+      'machine2',
+      'stat',
+      '/home/user/ai-lab/models/dummy.guff',
+    ]);
+    expect(process.exec).toBeCalledWith('podman.exe', [
+      'machine',
+      'ssh',
+      'machine2',
+      'mkdir',
+      '-p',
+      '/home/user/ai-lab/models',
+    ]);
+    expect(process.exec).toBeCalledWith('podman.exe', [
+      'machine',
+      'ssh',
+      'machine2',
+      'cp',
+      '/mnt/c/Users/podman\\ folder/dummy.guff',
+      '/home/user/ai-lab/models/dummy.guff',
+    ]);
+  });
+
   test('do not copy model if it exists on podman machine', async () => {
     vi.mocked(process.exec).mockResolvedValue({} as RunResult);
     await wslUploader.perform({

--- a/packages/backend/src/workers/uploader/WSLUploader.ts
+++ b/packages/backend/src/workers/uploader/WSLUploader.ts
@@ -39,11 +39,12 @@ export class WSLUploader extends WindowsWorker<UploaderOptions, string> {
     const driveLetter = localPath.charAt(0);
     const convertToMntPath = localPath
       .replace(`${driveLetter}:\\`, `/mnt/${driveLetter.toLowerCase()}/`)
-      .replace(/\\/g, '/');
+      .replace(/\\/g, '/')
+      .replace(/ /g, '\\ ');
 
     // check if model already loaded on the podman machine
     const existsRemote = await isModelUploaded(machineName, options.model);
-    const remoteFile = getRemoteModelFile(options.model);
+    const remoteFile = getRemoteModelFile(options.model).replace(/ /g, '\\ ');
 
     // if not exists remotely it copies it from the local path
     if (!existsRemote) {


### PR DESCRIPTION
Fixes #2394

### What does this PR do?

Handle cases where the model file path has spaces when uploading on WSL

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#2394 

### How to test this PR?

This must be executed only on Windows/WSL

1. Create a folder with spaces
2. Configure it as the Podman AI Lab models folder
3. Download a model
4. Start inference server
