### PR TITLE
Unplanned feature update mapt and enable nightly tests as admin

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -46,6 +46,11 @@ on:
         description: 'Run E2E tests from extension'
         type: string
         required: true
+      ext_tests_run_as_admin:
+        default: '1'
+        description: 'Run E2E tests as admin'
+        type: string
+        required: true
       npm_target:
         default: 'test:e2e'
         description: 'npm target to run tests'
@@ -116,6 +121,7 @@ jobs:
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true,ELECTRON_ENABLE_INSPECT=true'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
         DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-extension-ai-lab,FORK=containers,BRANCH=main'
+        DEFAULT_EXT_TESTS_RUN_AS_ADMIN: '1'
         DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.2' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
         DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3-windows'
@@ -128,6 +134,7 @@ jobs:
         echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
         echo "PDE2E_IMAGE_VERSION=${{ github.event.inputs.pde2e_image_version || env.DEFAULT_PDE2E_IMAGE_VERSION }}" >> $GITHUB_ENV
         echo "EXT_TESTS=${{ github.event.inputs.ext_tests || env.DEFAULT_EXT_TESTS }}" >> $GITHUB_ENV
+        echo "EXT_TESTS_RUN_AS_ADMIN=${{ github.event.inputs.ext_tests_run_as_admin || env.DEFAULT_EXT_TESTS_RUN_AS_ADMIN }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.ext_repo_options || env.DEFAULT_EXT_REPO_OPTIONS }}" | awk -F ',' \
@@ -253,6 +260,7 @@ jobs:
                 -start ${{ env.PODMAN_START }} \
                 -userNetworking ${{ env.PODMAN_NETWORKING }} \
                 -envVars ${{ env.ENV_VARS }} \
+                -runAsAdmin ${{ env.EXT_TESTS_RUN_AS_ADMIN }}
         # check logs
         podman logs -f pde2e-runner-run
 

--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -298,5 +298,5 @@ jobs:
         name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}
         path: |
           results/*
-          !results/**/*.gguf
-          !results/**/*.bin
+          !./**/*.gguf
+          !./**/*.bin

--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -302,3 +302,19 @@ jobs:
           results/*
           !./**/*.gguf
           !./**/*.bin
+          !./**/output/videos/*
+          !./**/output/traces/*
+
+    - name: Upload test videos
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}-videos
+        path: ./**/output/videos/*
+
+    - name: Upload test traces
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}-traces
+        path: ./**/output/traces/*

--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -94,6 +94,7 @@ jobs:
     env:
       MAPT_VERSION: v0.7.4
       MAPT_IMAGE: quay.io/redhat-developer/mapt
+      MAPT_EXCLUDED_REGIONS: 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest'
     strategy:
       fail-fast: false
       matrix:
@@ -159,6 +160,7 @@ jobs:
             --windows-featurepack '${{ matrix.windows-featurepack }}' \
             --vmsize '${{ env.AZURE_VM_SIZE }}' \
             --tags project=podman-desktop \
+            --spot-excluded-regions ${{ env.MAPT_EXCLUDED_REGIONS }} \
             --spot
         # Check logs
         podman logs -f windows-create

--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -52,7 +52,7 @@ on:
         type: string
         required: true
       podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.3.0/podman-5.3.0-setup.exe'
+        default: 'https://github.com/containers/podman/releases/download/v5.3.2/podman-5.3.2-setup.exe'
         description: 'podman remote setup exe'
         type: string
         required: true
@@ -67,7 +67,7 @@ on:
         type: string
         required: true
       pde2e_image_version:
-        default: 'v0.0.2-windows'
+        default: 'v0.0.3-windows'
         description: 'PDE2E runner, builder, podman image versions'
         type: string
         required: true
@@ -87,7 +87,7 @@ jobs:
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
     env:
-      MAPT_VERSION: v0.7.2
+      MAPT_VERSION: v0.7.4
       MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
@@ -116,7 +116,7 @@ jobs:
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true,ELECTRON_ENABLE_INSPECT=true'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
         DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-extension-ai-lab,FORK=containers,BRANCH=main'
-        DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.0' }}"
+        DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.2' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
         DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3-windows'
         DEFAULT_AZURE_VM_SIZE: 'Standard_D8as_v5'

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -130,3 +130,19 @@ jobs:
             ./**/tests/**/output/
             !./**/*.gguf
             !./**/*.bin
+            !./**/output/videos/*
+            !./**/output/traces/*
+
+      - name: Upload test videos
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-tests-videos
+          path: ./**/output/videos/*
+
+      - name: Upload test traces
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-tests-traces
+          path: ./**/output/traces/*

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -162,3 +162,19 @@ jobs:
             ./**/tests/**/output/
             !./**/*.gguf
             !./**/*.bin
+            !./**/output/videos/*
+            !./**/output/traces/*
+
+      - name: Upload test videos
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-pr-check-videos
+          path: ./**/output/videos/*
+
+      - name: Upload test traces
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-pr-check-traces
+          path: ./**/output/traces/*


### PR DESCRIPTION
### What does this PR do?
* Fixes path of the model files (yet again)
* Adds run tests as admin parameter to the nightly windows pipeline
* Updates default variables and MAPT version to 0.7.4
* Adds excluded regions to Azure spot acquisition
* Splits artifacts into multiple separate uploads - results, traces, videos

### Screenshot / video of UI
N/A
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#2442 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
