### PR TITLE
chore: fix scripts to use pnpm and not npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "npm": ">=10.2.3"
   },
   "scripts": {
-    "build": "concurrently \"cd packages/frontend && npm run build\" \"cd packages/backend && npm run build\"",
-    "watch": "concurrently \"cd packages/frontend && npm run watch\" \"cd packages/backend && npm run watch\"",
+    "build": "concurrently \"cd packages/frontend && pnpm run build\" \"cd packages/backend && pnpm run build\"",
+    "watch": "concurrently \"cd packages/frontend && pnpm run watch\" \"cd packages/backend && pnpm run watch\"",
     "format:check": "prettier --check \"**/src/**/*.{ts,svelte}\"",
     "format:fix": "prettier --write \"**/src/**/*.{ts,svelte}\"",
     "lint:check": "eslint . --cache",
@@ -21,13 +21,13 @@
     "test:backend": "vitest run -r packages/backend --passWithNoTests --coverage",
     "test:frontend": "vitest -c packages/frontend/vite.config.js run packages/frontend --passWithNoTests --coverage",
     "test:shared": "vitest run -r packages/shared --passWithNoTests --coverage",
-    "test:unit": "npm run test:backend && npm run test:shared && npm run test:frontend",
-    "test:e2e": "cd tests/playwright && npm run test:e2e",
-    "test:e2e:smoke": "cd tests/playwright && npm run test:e2e:smoke",
+    "test:unit": "pnpm run test:backend && pnpm run test:shared && pnpm run test:frontend",
+    "test:e2e": "cd tests/playwright && pnpm run test:e2e",
+    "test:e2e:smoke": "cd tests/playwright && pnpm run test:e2e:smoke",
     "typecheck:shared": "tsc --noEmit --project packages/shared",
     "typecheck:frontend": "tsc --noEmit --project packages/frontend",
-    "typecheck:backend": "cd packages/backend && npm run typecheck",
-    "typecheck": "npm run typecheck:shared && npm run typecheck:frontend && npm run typecheck:backend",
+    "typecheck:backend": "cd packages/backend && pnpm run typecheck",
+    "typecheck": "pnpm run typecheck:shared && pnpm run typecheck:frontend && pnpm run typecheck:backend",
     "prepare": "husky"
   },
   "resolutions": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -91,13 +91,13 @@
   },
   "scripts": {
     "generate": "npx openapi-typescript ../../api/openapi.yaml -o src-generated/openapi.ts",
-    "build": "npm run generate && vite build",
+    "build": "pnpm run generate && vite build",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
-    "watch": "npm run generate && npx vite --mode development build -w",
-    "typecheck": "npm run generate && tsc --noEmit"
+    "watch": "pnpm run generate && npx vite --mode development build -w",
+    "typecheck": "pnpm run generate && tsc --noEmit"
   },
   "dependencies": {
     "@huggingface/gguf": "^0.1.12",


### PR DESCRIPTION
### What does this PR do?
I have errors when running the scripts telling me that pnpm is the package manager while it is trying to execute npm

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

errors on my end

### How to test this PR?

workflows should work as before
