### PR TITLE
fix: display IntructLab dashboard and try independently of experiment…

### DIFF
--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -99,9 +99,6 @@ onDestroy(() => {
         </Route>
         {#if experimentalTuning}
           <!-- Tune with InstructLab -->
-          <Route path="/about-instructlab">
-            <AboutInstructLab />
-          </Route>
           <Route path="/tune/*" firstmatch>
             <Route path="/start">
               <NewInstructLabSession />
@@ -111,6 +108,9 @@ onDestroy(() => {
             </Route>
           </Route>
         {/if}
+        <Route path="/about-instructlab">
+          <AboutInstructLab />
+        </Route>
         <Route path="/instructlab/*" firstmatch>
           <Route path="/try">
             <StartInstructLabContainer />

--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -78,26 +78,26 @@ onDestroy(() => {
     </div>
     <SettingsNavItem icon={faGear} title="Local Server" selected={meta.url === '/local-server'} href="/local-server" />
 
+    <!-- Tuning -->
+    <div class="pl-3 mt-2 ml-[4px]">
+      <span class="text-[color:var(--pd-secondary-nav-header-text)]">TUNING</span>
+    </div>
+    <SettingsNavItem
+      icon={InstructLabIcon}
+      title="About InstructLab"
+      selected={meta.url.startsWith('/about-instructlab')}
+      href="/about-instructlab" />
     {#if experimentalTuning}
-      <!-- Tuning -->
-      <div class="pl-3 mt-2 ml-[4px]">
-        <span class="text-[color:var(--pd-secondary-nav-header-text)]">TUNING</span>
-      </div>
-      <SettingsNavItem
-        icon={InstructLabIcon}
-        title="About InstructLab"
-        selected={meta.url.startsWith('/about-instructlab')}
-        href="/about-instructlab" />
       <SettingsNavItem
         icon={faGaugeHigh}
         title="Tune with InstructLab"
         selected={meta.url.startsWith('/tune')}
         href="/tune" />
-      <SettingsNavItem
-        icon={faCircleDown}
-        title="Try InstructLab"
-        selected={meta.url.startsWith('/instructlab/try')}
-        href="/instructlab/try" />
     {/if}
+    <SettingsNavItem
+      icon={faCircleDown}
+      title="Try InstructLab"
+      selected={meta.url.startsWith('/instructlab/try')}
+      href="/instructlab/try" />
   </div>
 </nav>


### PR DESCRIPTION
…al tuning setting

Fixes #2582

### What does this PR do?

Display the navigation items independently from the experimental setting

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/7ea0e1fc-b7db-441f-bfba-c05a4cac8749)


### What issues does this PR fix or reference?

#2582 

### How to test this PR?

1. Ensure experimental tuning setting is removed from settings.json
2. Launch Podman Desktop
3. Select the AI Lab icon
4. Check the menus