### PR TITLE
chore(ci): secrets: inherit, updating win11 to 24h2 in recipe catalog test

### DIFF
--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['11']
-        windows-featurepack: ['23h2-ent']
+        windows-featurepack: ['24h2-ent']
 
     steps:
     - name: Add PR check status

--- a/.github/workflows/recipe-catalog-change-trigger.yaml
+++ b/.github/workflows/recipe-catalog-change-trigger.yaml
@@ -66,3 +66,4 @@ jobs:
       trigger-workflow-commit-sha: ${{ needs.extract-context.outputs.commit-sha }}
       trigger-workflow-base-repo: ${{ needs.extract-context.outputs.base-repo }}
       ext_tests_options: 'EXT_RUN_TESTS_FROM_EXTENSION=1,EXT_RUN_TESTS_AS_ADMIN=0'
+    secrets: inherit


### PR DESCRIPTION
### What does this PR do?
* Adds secret inherit
* updates Windows 11 version to 24h2

### Screenshot / video of UI
N/A
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#2515 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
N/A
<!-- Please explain steps to reproduce -->
