### PR TITLE
refactor: make subscriber using the RPC channel for typechecking

### DIFF
--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import fs, { type Stats, type PathLike } from 'node:fs';
 import path from 'node:path';
 import { ModelsManager } from './modelsManager';
 import { env, process as coreProcess } from '@podman-desktop/api';
-import type { RunResult, TelemetryLogger, Webview, ContainerProviderConnection } from '@podman-desktop/api';
+import type { RunResult, TelemetryLogger, ContainerProviderConnection } from '@podman-desktop/api';
 import type { CatalogManager } from './catalogManager';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import * as utils from '../utils/utils';
@@ -36,6 +36,8 @@ import { VMType } from '@shared/src/models/IPodman';
 import { getPodmanMachineName } from '../utils/podman';
 import type { ConfigurationRegistry } from '../registries/ConfigurationRegistry';
 import { Uploader } from '../utils/uploader';
+import type { RpcExtension } from '@shared/src/messages/MessageProxy';
+import { MSG_NEW_MODELS_STATE } from '@shared/Messages';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -121,7 +123,7 @@ const configurationRegistryMock: ConfigurationRegistry = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  taskRegistry = new TaskRegistry({ postMessage: vi.fn().mockResolvedValue(undefined) } as unknown as Webview);
+  taskRegistry = new TaskRegistry({ fire: vi.fn().mockResolvedValue(undefined) } as unknown as RpcExtension);
 
   vi.mocked(configurationRegistryMock.getExtensionConfiguration).mockReturnValue({
     modelUploadDisabled: false,
@@ -194,8 +196,8 @@ test('getModelsInfo should get models in local directory', async () => {
   const manager = new ModelsManager(
     modelsDir,
     {
-      postMessage: vi.fn(),
-    } as unknown as Webview,
+      fire: vi.fn(),
+    } as unknown as RpcExtension,
     {
       getModels(): ModelInfo[] {
         return [
@@ -249,7 +251,7 @@ test('getModelsInfo should return an empty array if the models folder does not e
   }
   const manager = new ModelsManager(
     modelsDir,
-    {} as Webview,
+    {} as RpcExtension,
     {
       getModels(): ModelInfo[] {
         return [];
@@ -290,8 +292,8 @@ test('getLocalModelsFromDisk should return undefined Date and size when stat fai
   const manager = new ModelsManager(
     modelsDir,
     {
-      postMessage: vi.fn(),
-    } as unknown as Webview,
+      fire: vi.fn(),
+    } as unknown as RpcExtension,
     {
       getModels(): ModelInfo[] {
         return [{ id: 'model-id-1', name: 'model-id-1-model' } as ModelInfo];
@@ -350,8 +352,8 @@ test('getLocalModelsFromDisk should skip folders containing tmp files', async ()
   const manager = new ModelsManager(
     modelsDir,
     {
-      postMessage: vi.fn(),
-    } as unknown as Webview,
+      fire: vi.fn(),
+    } as unknown as RpcExtension,
     {
       getModels(): ModelInfo[] {
         return [{ id: 'model-id-1', name: 'model-id-1-model' } as ModelInfo];
@@ -378,7 +380,7 @@ test('loadLocalModels should post a message with the message on disk and on cata
   const now = new Date();
   mockFiles(now);
 
-  const postMessageMock = vi.fn();
+  const fireMock = vi.fn();
   let modelsDir: string;
   if (process.platform === 'win32') {
     modelsDir = 'C:\\home\\user\\aistudio\\models';
@@ -388,8 +390,8 @@ test('loadLocalModels should post a message with the message on disk and on cata
   const manager = new ModelsManager(
     modelsDir,
     {
-      postMessage: postMessageMock,
-    } as unknown as Webview,
+      fire: fireMock,
+    } as unknown as RpcExtension,
     {
       getModels: () => {
         return [
@@ -408,20 +410,17 @@ test('loadLocalModels should post a message with the message on disk and on cata
   );
   manager.init();
   await manager.loadLocalModels();
-  expect(postMessageMock).toHaveBeenNthCalledWith(1, {
-    id: 'new-models-state',
-    body: [
-      {
-        file: {
-          creation: now,
-          file: 'model-id-1-model',
-          size: 32000,
-          path: path.resolve(dirent[0].path, dirent[0].name),
-        },
-        id: 'model-id-1',
+  expect(fireMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ channel: MSG_NEW_MODELS_STATE.name }), [
+    {
+      file: {
+        creation: now,
+        file: 'model-id-1-model',
+        size: 32000,
+        path: path.resolve(dirent[0].path, dirent[0].name),
       },
-    ],
-  });
+      id: 'model-id-1',
+    },
+  ]);
 });
 
 test('deleteModel deletes the model folder', async () => {
@@ -435,12 +434,12 @@ test('deleteModel deletes the model folder', async () => {
   mockFiles(now);
   const rmSpy = vi.spyOn(fs.promises, 'rm');
   rmSpy.mockResolvedValue();
-  const postMessageMock = vi.fn();
+  const fireMock = vi.fn();
   const manager = new ModelsManager(
     modelsDir,
     {
-      postMessage: postMessageMock,
-    } as unknown as Webview,
+      fire: fireMock,
+    } as unknown as RpcExtension,
     {
       getModels: () => {
         return [
@@ -475,17 +474,14 @@ test('deleteModel deletes the model folder', async () => {
       maxRetries: 3,
     });
   }
-  expect(postMessageMock).toHaveBeenCalledTimes(4);
+  expect(fireMock).toHaveBeenCalledTimes(4);
   // check that a new state is sent with the model removed
-  expect(postMessageMock).toHaveBeenNthCalledWith(4, {
-    id: 'new-models-state',
-    body: [
-      {
-        id: 'model-id-1',
-        url: 'model-url',
-      },
-    ],
-  });
+  expect(fireMock).toHaveBeenNthCalledWith(4, expect.objectContaining({ channel: MSG_NEW_MODELS_STATE.name }), [
+    {
+      id: 'model-id-1',
+      url: 'model-url',
+    },
+  ]);
   expect(mocks.logUsageMock).toHaveBeenNthCalledWith(1, 'model.delete', { 'model.id': expect.any(String) });
 });
 
@@ -501,12 +497,12 @@ describe('deleting models', () => {
     mockFiles(now);
     const rmSpy = vi.spyOn(fs.promises, 'rm');
     rmSpy.mockRejectedValue(new Error('failed'));
-    const postMessageMock = vi.fn();
+    const fireMock = vi.fn();
     const manager = new ModelsManager(
       modelsDir,
       {
-        postMessage: postMessageMock,
-      } as unknown as Webview,
+        fire: fireMock,
+      } as unknown as RpcExtension,
       {
         getModels: () => {
           return [
@@ -541,36 +537,33 @@ describe('deleting models', () => {
         maxRetries: 3,
       });
     }
-    expect(postMessageMock).toHaveBeenCalledTimes(4);
+    expect(fireMock).toHaveBeenCalledTimes(4);
     // check that a new state is sent with the model non removed
-    expect(postMessageMock).toHaveBeenNthCalledWith(4, {
-      id: 'new-models-state',
-      body: [
-        {
-          id: 'model-id-1',
-          url: 'model-url',
-          file: {
-            creation: now,
-            file: 'model-id-1-model',
-            size: 32000,
-            path: path.resolve(dirent[0].path, dirent[0].name),
-          },
+    expect(fireMock).toHaveBeenNthCalledWith(4, expect.objectContaining({ channel: MSG_NEW_MODELS_STATE.name }), [
+      {
+        id: 'model-id-1',
+        url: 'model-url',
+        file: {
+          creation: now,
+          file: 'model-id-1-model',
+          size: 32000,
+          path: path.resolve(dirent[0].path, dirent[0].name),
         },
-      ],
-    });
+      },
+    ]);
     expect(mocks.showErrorMessageMock).toHaveBeenCalledOnce();
     expect(mocks.logErrorMock).toHaveBeenCalled();
   });
 
   test('delete local model should call catalogManager', async () => {
     vi.mocked(env).isWindows = false;
-    const postMessageMock = vi.fn();
+    const fireMock = vi.fn();
     const removeUserModelMock = vi.fn();
     const manager = new ModelsManager(
       'appdir',
       {
-        postMessage: postMessageMock,
-      } as unknown as Webview,
+        fire: fireMock,
+      } as unknown as RpcExtension,
       {
         getModels: () => {
           return [
@@ -631,8 +624,8 @@ describe('deleting models', () => {
     const manager = new ModelsManager(
       '/home/user/aistudio',
       {
-        postMessage: vi.fn().mockResolvedValue(undefined),
-      } as unknown as Webview,
+        fire: vi.fn().mockResolvedValue(undefined),
+      } as unknown as RpcExtension,
       {
         getModels: () => {
           return [
@@ -676,7 +669,7 @@ describe('downloadModel', () => {
     vi.mocked(cancellationTokenRegistryMock.createCancellationTokenSource).mockReturnValue(99);
     const manager = new ModelsManager(
       'appdir',
-      {} as Webview,
+      {} as RpcExtension,
       {
         getModels(): ModelInfo[] {
           return [];
@@ -712,7 +705,7 @@ describe('downloadModel', () => {
   test('retrieve model path if already on disk', async () => {
     const manager = new ModelsManager(
       'appdir',
-      {} as Webview,
+      {} as RpcExtension,
       {
         getModels(): ModelInfo[] {
           return [];
@@ -745,7 +738,7 @@ describe('downloadModel', () => {
   test('fail if model on disk has different sha of the expected value', async () => {
     const manager = new ModelsManager(
       'appdir',
-      {} as Webview,
+      {} as RpcExtension,
       {
         getModels(): ModelInfo[] {
           return [];
@@ -777,7 +770,7 @@ describe('downloadModel', () => {
 
     const manager = new ModelsManager(
       'appdir',
-      {} as Webview,
+      {} as RpcExtension,
       {
         getModels(): ModelInfo[] {
           return [];
@@ -815,7 +808,7 @@ describe('downloadModel', () => {
 
     const manager = new ModelsManager(
       'appdir',
-      {} as Webview,
+      {} as RpcExtension,
       {
         getModels(): ModelInfo[] {
           return [];
@@ -866,7 +859,7 @@ describe('getModelMetadata', () => {
   test('unknown model', async () => {
     const manager = new ModelsManager(
       'appdir',
-      {} as Webview,
+      {} as RpcExtension,
       {
         getModels: (): ModelInfo[] => [],
       } as CatalogManager,
@@ -885,7 +878,7 @@ describe('getModelMetadata', () => {
   test('remote model', async () => {
     const manager = new ModelsManager(
       'appdir',
-      {} as Webview,
+      {} as RpcExtension,
       {
         getModels: (): ModelInfo[] => [
           {
@@ -923,8 +916,8 @@ describe('getModelMetadata', () => {
     const manager = new ModelsManager(
       'appdir',
       {
-        postMessage: vi.fn(),
-      } as unknown as Webview,
+        fire: vi.fn(),
+      } as unknown as RpcExtension,
       {
         getModels: (): ModelInfo[] => [
           {
@@ -990,8 +983,8 @@ describe('uploadModelToPodmanMachine', () => {
     const manager = new ModelsManager(
       'appdir',
       {
-        postMessage: vi.fn(),
-      } as unknown as Webview,
+        fire: vi.fn(),
+      } as unknown as RpcExtension,
       {
         onUpdate: vi.fn(),
         getModels: () => [],
@@ -1023,8 +1016,8 @@ describe('uploadModelToPodmanMachine', () => {
     const manager = new ModelsManager(
       'appdir',
       {
-        postMessage: vi.fn(),
-      } as unknown as Webview,
+        fire: vi.fn(),
+      } as unknown as RpcExtension,
       {
         onUpdate: vi.fn(),
         getModels: () => [],

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 import type { LocalModelInfo } from '@shared/src/models/ILocalModelInfo';
 import fs from 'node:fs';
 import * as path from 'node:path';
-import { type Webview, fs as apiFs, type Disposable, env, type ContainerProviderConnection } from '@podman-desktop/api';
-import { Messages } from '@shared/Messages';
+import { fs as apiFs, type Disposable, env, type ContainerProviderConnection } from '@podman-desktop/api';
+import { MSG_NEW_MODELS_STATE } from '@shared/Messages';
 import type { CatalogManager } from './catalogManager';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import * as podmanDesktopApi from '@podman-desktop/api';
@@ -39,6 +39,7 @@ import { gguf } from '@huggingface/gguf';
 import type { PodmanConnection } from './podmanConnection';
 import { VMType } from '@shared/src/models/IPodman';
 import type { ConfigurationRegistry } from '../registries/ConfigurationRegistry';
+import type { RpcExtension } from '@shared/src/messages/MessageProxy';
 
 export class ModelsManager implements Disposable {
   #models: Map<string, ModelInfo>;
@@ -49,7 +50,7 @@ export class ModelsManager implements Disposable {
 
   constructor(
     private modelsDir: string,
-    private webview: Webview,
+    private rpcExtension: RpcExtension,
     private catalogManager: CatalogManager,
     private telemetry: podmanDesktopApi.TelemetryLogger,
     private taskRegistry: TaskRegistry,
@@ -104,10 +105,7 @@ export class ModelsManager implements Disposable {
 
   async sendModelsInfo(): Promise<void> {
     const models = this.getModelsInfo();
-    await this.webview.postMessage({
-      id: Messages.MSG_NEW_MODELS_STATE,
-      body: models,
-    });
+    await this.rpcExtension.fire(MSG_NEW_MODELS_STATE, models);
   }
 
   getModelsDirectory(): string {

--- a/packages/backend/src/registries/TaskRegistry.spec.ts
+++ b/packages/backend/src/registries/TaskRegistry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,50 +16,39 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { beforeEach, expect, test, vi } from 'vitest';
-import type { Webview } from '@podman-desktop/api';
 import { TaskRegistry } from './TaskRegistry';
+import type { RpcExtension } from '@shared/src/messages/MessageProxy';
 
-const mocks = vi.hoisted(() => ({
-  postMessageMock: vi.fn(),
-}));
+const rpcExtension = {
+  fire: vi.fn(),
+} as unknown as RpcExtension;
 
 beforeEach(() => {
   vi.resetAllMocks();
-  mocks.postMessageMock.mockResolvedValue(undefined);
+  vi.mocked(rpcExtension.fire).mockResolvedValue(true);
 });
 
 test('should not have any tasks by default', () => {
-  const taskRegistry = new TaskRegistry({
-    postMessage: mocks.postMessageMock,
-  } as unknown as Webview);
+  const taskRegistry = new TaskRegistry(rpcExtension);
   expect(taskRegistry.getTasks().length).toBe(0);
 });
 
 test('should notify when create task', () => {
-  const taskRegistry = new TaskRegistry({
-    postMessage: mocks.postMessageMock,
-  } as unknown as Webview);
-
+  const taskRegistry = new TaskRegistry(rpcExtension);
   taskRegistry.createTask('random', 'loading');
-
-  expect(mocks.postMessageMock).toHaveBeenCalled();
+  expect(rpcExtension.fire).toHaveBeenCalled();
 });
 
 test('should notify when update task', () => {
-  const taskRegistry = new TaskRegistry({
-    postMessage: mocks.postMessageMock,
-  } as unknown as Webview);
-
+  const taskRegistry = new TaskRegistry(rpcExtension);
   const task = taskRegistry.createTask('random', 'loading');
   taskRegistry.updateTask(task);
 
-  expect(mocks.postMessageMock).toHaveBeenCalledTimes(2);
+  expect(rpcExtension.fire).toHaveBeenCalledTimes(2);
 });
 
 test('should get tasks by label', () => {
-  const taskRegistry = new TaskRegistry({
-    postMessage: mocks.postMessageMock,
-  } as unknown as Webview);
+  const taskRegistry = new TaskRegistry(rpcExtension);
 
   taskRegistry.createTask('random-1', 'loading', { index: '1' });
   taskRegistry.createTask('random-2', 'loading', { index: '2' });
@@ -74,9 +63,7 @@ test('should get tasks by label', () => {
 });
 
 test('should delete tasks by label', () => {
-  const taskRegistry = new TaskRegistry({
-    postMessage: mocks.postMessageMock,
-  } as unknown as Webview);
+  const taskRegistry = new TaskRegistry(rpcExtension);
 
   taskRegistry.createTask('random-1', 'loading', { index: '1' });
   taskRegistry.createTask('random-2', 'loading', { index: '2' });
@@ -88,9 +75,7 @@ test('should delete tasks by label', () => {
 });
 
 test('should get tasks by multiple labels', () => {
-  const taskRegistry = new TaskRegistry({
-    postMessage: mocks.postMessageMock,
-  } as unknown as Webview);
+  const taskRegistry = new TaskRegistry(rpcExtension);
 
   taskRegistry.createTask('task-1', 'loading', { type: 'A', priority: 'high' });
   taskRegistry.createTask('task-2', 'loading', { type: 'B', priority: 'low' });

--- a/packages/backend/src/registries/TaskRegistry.ts
+++ b/packages/backend/src/registries/TaskRegistry.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import type { Task, TaskState } from '@shared/src/models/ITask';
-import { Messages } from '@shared/Messages';
-import type { Webview } from '@podman-desktop/api';
+import { MSG_TASKS_UPDATE } from '@shared/Messages';
+import type { RpcExtension } from '@shared/src/messages/MessageProxy';
 
 /**
  * A registry for managing tasks.
@@ -29,9 +29,9 @@ export class TaskRegistry {
 
   /**
    * Constructs a new TaskRegistry.
-   * @param webview The webview instance to use for communication.
+   * @param rpcExtension The rpc extension instance to use for communication.
    */
-  constructor(private webview: Webview) {}
+  constructor(private rpcExtension: RpcExtension) {}
 
   /**
    * Retrieves a task by its ID.
@@ -138,13 +138,8 @@ export class TaskRegistry {
   }
 
   private notify(): void {
-    this.webview
-      .postMessage({
-        id: Messages.MSG_TASKS_UPDATE,
-        body: this.getTasks(),
-      })
-      .catch((err: unknown) => {
-        console.error('error notifying tasks', err);
-      });
+    this.rpcExtension.fire(MSG_TASKS_UPDATE, this.getTasks()).catch((err: unknown) => {
+      console.error('error notifying tasks', err);
+    });
   }
 }

--- a/packages/frontend/src/stores/containerProviderConnections.ts
+++ b/packages/frontend/src/stores/containerProviderConnections.ts
@@ -15,13 +15,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { MSG_PODMAN_CONNECTION_UPDATE } from '@shared/Messages';
 import { RPCReadable } from '/@/stores/rpcReadable';
-import { Messages } from '@shared/Messages';
 import { studioClient } from '/@/utils/client';
 import type { ContainerProviderConnectionInfo } from '@shared/src/models/IContainerConnectionInfo';
 
 export const containerProviderConnections = RPCReadable<ContainerProviderConnectionInfo[]>(
   [],
-  [Messages.MSG_PODMAN_CONNECTION_UPDATE],
+  MSG_PODMAN_CONNECTION_UPDATE,
   studioClient.getContainerProviderConnection,
 );

--- a/packages/frontend/src/stores/inferenceServers.ts
+++ b/packages/frontend/src/stores/inferenceServers.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { RPCReadable } from '/@/stores/rpcReadable';
-import { Messages } from '@shared/Messages';
+import { MSG_INFERENCE_SERVERS_UPDATE } from '@shared/Messages';
 import { studioClient } from '/@/utils/client';
 import type { InferenceServer } from '@shared/src/models/IInference';
 
 export const inferenceServers = RPCReadable<InferenceServer[]>(
   [],
-  [Messages.MSG_INFERENCE_SERVERS_UPDATE],
+  MSG_INFERENCE_SERVERS_UPDATE,
   studioClient.getInferenceServers,
 );

--- a/packages/frontend/src/stores/instructlabSessions.ts
+++ b/packages/frontend/src/stores/instructlabSessions.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { RPCReadable } from '/@/stores/rpcReadable';
-import { Messages } from '@shared/Messages';
+import { MSG_INSTRUCTLAB_SESSIONS_UPDATE } from '@shared/Messages';
 import { instructlabClient } from '/@/utils/client';
 import type { InstructlabSession } from '@shared/src/models/instructlab/IInstructlabSession';
 
 export const instructlabSessions = RPCReadable<InstructlabSession[]>(
   [],
-  [Messages.MSG_INSTRUCTLAB_SESSIONS_UPDATE],
+  MSG_INSTRUCTLAB_SESSIONS_UPDATE,
   instructlabClient.getIsntructlabSessions,
 );

--- a/packages/frontend/src/stores/localRepositories.ts
+++ b/packages/frontend/src/stores/localRepositories.ts
@@ -1,11 +1,11 @@
 import type { Readable } from 'svelte/store';
-import { Messages } from '@shared/Messages';
+import { MSG_LOCAL_REPOSITORY_UPDATE } from '@shared/Messages';
 import { studioClient } from '/@/utils/client';
 import type { LocalRepository } from '@shared/src/models/ILocalRepository';
 import { RPCReadable } from '/@/stores/rpcReadable';
 
 export const localRepositories: Readable<LocalRepository[]> = RPCReadable<LocalRepository[]>(
   [],
-  [Messages.MSG_LOCAL_REPOSITORY_UPDATE],
+  MSG_LOCAL_REPOSITORY_UPDATE,
   studioClient.getLocalRepositories,
 );

--- a/packages/frontend/src/stores/modelsInfo.spec.ts
+++ b/packages/frontend/src/stores/modelsInfo.spec.ts
@@ -17,11 +17,11 @@
  ***********************************************************************/
 
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { Messages } from '@shared/Messages';
 import { rpcBrowser } from '../utils/client';
 import type { Unsubscriber } from 'svelte/store';
 import { modelsInfo } from './modelsInfo';
-import { createRpcChannel } from '@shared/src/messages/MessageProxy';
+import type { RpcChannel, createRpcChannel, type Listener } from '@shared/src/messages/MessageProxy';
+import { MSG_NEW_MODELS_STATE } from '@shared/Messages';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -35,8 +35,8 @@ vi.mock('../utils/client', async () => {
     const f = subscriber.get(msgId);
     f();
   };
-  const subscribeMethod = (msgId: string, f: (msg: unknown) => void): unknown => {
-    subscriber.set(msgId, f);
+  const subscribeMethod = (rpcChannel: RpcChannel<unknown>, f: Listener<unknown>): unknown => {
+    subscriber.set(rpcChannel.name, f);
     return {
       unsubscribe: (): void => {
         subscriber.clear();
@@ -82,9 +82,9 @@ test('check getLocalModels is called twice if event is fired (one at init, one f
   type MyModel = {
     send: (message: string) => Promise<void>;
   };
-  const channel = createRpcChannel<MyModel>('model');
+  const channel = createRpcChannel<MyModel>(MSG_NEW_MODELS_STATE.name);
   const proxy = rpcBrowser.getProxy<MyModel>(channel);
-  await proxy.send(Messages.MSG_NEW_MODELS_STATE);
+  await proxy.send(MSG_NEW_MODELS_STATE.name);
   // wait for the timeout in the debouncer
   await new Promise(resolve => setTimeout(resolve, 600));
   expect(mocks.getModelsInfoMock).toHaveBeenCalledTimes(2);

--- a/packages/frontend/src/stores/modelsInfo.ts
+++ b/packages/frontend/src/stores/modelsInfo.ts
@@ -18,7 +18,7 @@
 
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { studioClient } from '/@/utils/client';
-import { Messages } from '@shared/Messages';
+import { MSG_NEW_MODELS_STATE } from '@shared/Messages';
 import { RPCReadable } from './rpcReadable';
 
-export const modelsInfo = RPCReadable<ModelInfo[]>([], [Messages.MSG_NEW_MODELS_STATE], studioClient.getModelsInfo);
+export const modelsInfo = RPCReadable<ModelInfo[]>([], MSG_NEW_MODELS_STATE, studioClient.getModelsInfo);

--- a/packages/frontend/src/stores/snippetLanguages.ts
+++ b/packages/frontend/src/stores/snippetLanguages.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { Readable } from 'svelte/store';
-import { Messages } from '@shared/Messages';
+import { MSG_SUPPORTED_LANGUAGES_UPDATE } from '@shared/Messages';
 import { studioClient } from '/@/utils/client';
 import { RPCReadable } from '/@/stores/rpcReadable';
 import type { Language } from 'postman-code-generators';
 
 export const snippetLanguages: Readable<Language[]> = RPCReadable<Language[]>(
   [],
-  [Messages.MSG_SUPPORTED_LANGUAGES_UPDATE],
+  MSG_SUPPORTED_LANGUAGES_UPDATE,
   studioClient.getSnippetLanguages,
 );

--- a/packages/frontend/src/stores/tasks.ts
+++ b/packages/frontend/src/stores/tasks.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import { studioClient } from '/@/utils/client';
-import { Messages } from '@shared/Messages';
+import { MSG_TASKS_UPDATE } from '@shared/Messages';
 import { RPCReadable } from './rpcReadable';
 import type { Task } from '@shared/src/models/ITask';
 
-export const tasks = RPCReadable<Task[]>([], [Messages.MSG_TASKS_UPDATE], studioClient.getTasks);
+export const tasks = RPCReadable<Task[]>([], MSG_TASKS_UPDATE, studioClient.getTasks);

--- a/packages/shared/Messages.ts
+++ b/packages/shared/Messages.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,30 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Language } from 'postman-code-generators';
+import { createRpcChannel } from './src/messages/MessageProxy';
+import type { Task } from './src/models/ITask';
+import type { ModelInfo } from './src/models/IModelInfo';
+import type { ContainerProviderConnectionInfo } from './src/models/IContainerConnectionInfo';
+import type { InferenceServer } from './src/models/IInference';
+import type { InstructlabSession } from './src/models/instructlab/IInstructlabSession';
+import type { LocalRepository } from './src/models/ILocalRepository';
+
 export enum Messages {
   MSG_NEW_CATALOG_STATE = 'new-catalog-state',
-  MSG_TASKS_UPDATE = 'tasks-update',
-  MSG_NEW_MODELS_STATE = 'new-models-state',
   MSG_APPLICATIONS_STATE_UPDATE = 'applications-state-update',
-  MSG_LOCAL_REPOSITORY_UPDATE = 'local-repository-update',
-  MSG_INFERENCE_SERVERS_UPDATE = 'inference-servers-update',
   MSG_MONITORING_UPDATE = 'monitoring-update',
-  MSG_SUPPORTED_LANGUAGES_UPDATE = 'supported-languages-supported',
   MSG_CONVERSATIONS_UPDATE = 'conversations-update',
   MSG_GPUS_UPDATE = 'gpus-update',
   MSG_INFERENCE_PROVIDER_UPDATE = 'inference-provider-update',
   MSG_CONFIGURATION_UPDATE = 'configuration-update',
-  MSG_PODMAN_CONNECTION_UPDATE = 'podman-connecting-update',
-  MSG_INSTRUCTLAB_SESSIONS_UPDATE = 'instructlab-sessions-update',
   MSG_NAVIGATION_ROUTE_UPDATE = 'navigation-route-update',
 }
+export const MSG_TASKS_UPDATE = createRpcChannel<Task[]>('tasks-update');
+export const MSG_SUPPORTED_LANGUAGES_UPDATE = createRpcChannel<Language[]>('supported-languages-supported');
+export const MSG_NEW_MODELS_STATE = createRpcChannel<ModelInfo[]>('new-models-state');
+export const MSG_PODMAN_CONNECTION_UPDATE =
+  createRpcChannel<ContainerProviderConnectionInfo[]>('podman-connecting-update');
+export const MSG_INFERENCE_SERVERS_UPDATE = createRpcChannel<InferenceServer[]>('inference-servers-update');
+export const MSG_INSTRUCTLAB_SESSIONS_UPDATE = createRpcChannel<InstructlabSession[]>('instructlab-sessions-update');
+export const MSG_LOCAL_REPOSITORY_UPDATE = createRpcChannel<LocalRepository[]>('local-repository-update');

--- a/packages/shared/src/messages/MessageProxy.spec.ts
+++ b/packages/shared/src/messages/MessageProxy.spec.ts
@@ -213,12 +213,17 @@ describe('subscribe', () => {
     const rpcBrowser = new RpcBrowser(window, api);
     const messageListener = getMessageListener();
 
+    interface EventTest {
+      foo: string;
+    }
+    const rpcChannel = createRpcChannel<EventTest>('example');
+
     const listener = vi.fn();
-    rpcBrowser.subscribe('example', listener);
+    rpcBrowser.subscribe<EventTest>(rpcChannel, listener);
 
     messageListener({
       data: {
-        id: 'example',
+        id: rpcChannel.name,
         body: 'hello',
       },
     } as unknown as MessageEvent);
@@ -232,11 +237,15 @@ describe('subscribe', () => {
 
     const listeners = Array.from({ length: 10 }, _ => vi.fn());
 
-    listeners.forEach(listener => rpcBrowser.subscribe('example', listener));
+    interface EventTest {
+      foo: string;
+    }
+    const rpcChannel = createRpcChannel<EventTest>('example');
+    listeners.forEach(listener => rpcBrowser.subscribe(rpcChannel, listener));
 
     messageListener({
       data: {
-        id: 'example',
+        id: rpcChannel.name,
         body: 'hello',
       },
     } as unknown as MessageEvent);
@@ -252,12 +261,17 @@ describe('subscribe', () => {
 
     const [listenerA, listenerB] = [vi.fn(), vi.fn()];
 
-    const unsubscriberA = rpcBrowser.subscribe('example', listenerA);
-    const unsubscriberB = rpcBrowser.subscribe('example', listenerB);
+    interface EventTest {
+      foo: string;
+    }
+    const rpcChannel = createRpcChannel<EventTest>('example');
+
+    const unsubscriberA = rpcBrowser.subscribe(rpcChannel, listenerA);
+    const unsubscriberB = rpcBrowser.subscribe(rpcChannel, listenerB);
 
     messageListener({
       data: {
-        id: 'example',
+        id: rpcChannel.name,
         body: 'hello',
       },
     } as unknown as MessageEvent);
@@ -267,7 +281,7 @@ describe('subscribe', () => {
 
     messageListener({
       data: {
-        id: 'example',
+        id: rpcChannel.name,
         body: 'hello',
       },
     } as unknown as MessageEvent);
@@ -277,7 +291,7 @@ describe('subscribe', () => {
 
     messageListener({
       data: {
-        id: 'example',
+        id: rpcChannel.name,
         body: 'hello',
       },
     } as unknown as MessageEvent);


### PR DESCRIPTION
### What does this PR do?
- make subscriber using the RPC channel for typechecking
- also use fire() on backend side to send the data

ie: don't post data to the webview directly, use rpcExtension.fire(rpcChannel, data) (with typechecking)

on rpcBrowser side, subscribe(rpcChannel, data) and data has typechecking also

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/11326

### How to test this PR?

<!-- Please explain steps to reproduce -->
