### PR TITLE
chore: remove usage of stats constructor

### DIFF
--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -166,7 +166,7 @@ function mockFiles(now: Date): void {
     return true;
   });
   const statSyncSpy = vi.spyOn(fs, 'statSync');
-  const info = new fs.Stats();
+  const info: Stats = {} as Stats;
   info.size = 32000;
   info.mtime = now;
   statSyncSpy.mockReturnValue(info);


### PR DESCRIPTION
### What does this PR do?
the constructor is removed in Node.js v22 so avoid its usage

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop-extension-ai-lab/pull/2681

### How to test this PR?

<!-- Please explain steps to reproduce -->
