### PR TITLE
chore: switch images of llama.cpp to the RamaLama images

### DIFF
--- a/packages/backend/src/assets/ai.json
+++ b/packages/backend/src/assets/ai.json
@@ -486,7 +486,7 @@
       "license": "Apache-2.0",
       "url": "https://huggingface.co/MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF/resolve/main/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf",
       "properties": {
-        "chatFormat": "chatml-function-calling"
+        "jinja": "true"
       },
       "memory": 4372811936,
       "backend": "llama-cpp"

--- a/packages/backend/src/assets/inference-images.json
+++ b/packages/backend/src/assets/inference-images.json
@@ -3,7 +3,7 @@
     "default": "quay.io/ramalama/ramalama-whisper-server@sha256:72bce4bed86e7f72e41c60960dd7b1fd9b5115328f520ddcae5dbdd689376995"
   },
   "llamacpp": {
-    "default": "quay.io/fbenoit/ramalama-llama-server:jinja-2025-03-27",
-    "cuda": "quay.io/fbenoit/ramalama-llama-server:jinja-2025-03-27"
+    "default": "quay.io/ramalama/ramalama-llama-server@sha256:1691c33380da557adb70df0bcbffbbf86a99d1acb271899322a1a060c5f3a408",
+    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:6d5dc45080ea0205d05f331224ac8dc8799e7ddbb1ea20dbad5bff281d4f7789"
   }
 }

--- a/packages/backend/src/assets/inference-images.json
+++ b/packages/backend/src/assets/inference-images.json
@@ -4,6 +4,6 @@
   },
   "llamacpp": {
     "default": "quay.io/ramalama/ramalama-llama-server@sha256:1691c33380da557adb70df0bcbffbbf86a99d1acb271899322a1a060c5f3a408",
-    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:6d5dc45080ea0205d05f331224ac8dc8799e7ddbb1ea20dbad5bff281d4f7789"
+    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:dff3819d163b719edcb8d5b225a2e26d8080ff51f8c96a1e9756b309e10d49dd"
   }
 }

--- a/packages/backend/src/assets/inference-images.json
+++ b/packages/backend/src/assets/inference-images.json
@@ -3,7 +3,7 @@
     "default": "quay.io/ramalama/ramalama-whisper-server@sha256:72bce4bed86e7f72e41c60960dd7b1fd9b5115328f520ddcae5dbdd689376995"
   },
   "llamacpp": {
-    "default": "quay.io/ramalama/ramalama-llama-server@sha256:1691c33380da557adb70df0bcbffbbf86a99d1acb271899322a1a060c5f3a408",
-    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:dff3819d163b719edcb8d5b225a2e26d8080ff51f8c96a1e9756b309e10d49dd"
+    "default": "quay.io/ramalama/ramalama-llama-server@sha256:cbadb36fbbc2abf9867a33e6dfe3f2df4a76774259b5d4d24d50f4fc7e525406",
+    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:cbadb36fbbc2abf9867a33e6dfe3f2df4a76774259b5d4d24d50f4fc7e525406"
   }
 }

--- a/packages/backend/src/assets/inference-images.json
+++ b/packages/backend/src/assets/inference-images.json
@@ -4,6 +4,6 @@
   },
   "llamacpp": {
     "default": "quay.io/ramalama/ramalama-llama-server@sha256:cbadb36fbbc2abf9867a33e6dfe3f2df4a76774259b5d4d24d50f4fc7e525406",
-    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:cbadb36fbbc2abf9867a33e6dfe3f2df4a76774259b5d4d24d50f4fc7e525406"
+    "cuda": "quay.io/ramalama/cuda-llama-server@sha256:56efc824e5b3ae6a6a11e9537ed9e2ac05f9f9fc6f2e81a55eb67b662c94fe95"
   }
 }

--- a/packages/backend/src/assets/inference-images.json
+++ b/packages/backend/src/assets/inference-images.json
@@ -3,8 +3,7 @@
     "default": "quay.io/ramalama/ramalama-whisper-server@sha256:72bce4bed86e7f72e41c60960dd7b1fd9b5115328f520ddcae5dbdd689376995"
   },
   "llamacpp": {
-    "default": "ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat@sha256:2eb6cd7a4c4f76e54eeb88465281f4ff2a8f7b7e49db893a579a8f6842f69eb1",
-    "cuda": "ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat-cuda@sha256:e4b57e52c31b379b4a73f8e9536bc130fdea665d88dbd05643350295b3402a2f",
-    "vulkan": "ghcr.io/containers/podman-desktop-extension-ai-lab-playground-images/ai-lab-playground-chat-vulkan@sha256:6a93b247099643f4f8c78ee9896c2ce4e9a455af114a69be09c16ad36aa51fd2"
+    "default": "quay.io/fbenoit/ramalama-llama-server:jinja-2025-03-27",
+    "cuda": "quay.io/fbenoit/ramalama-llama-server:jinja-2025-03-27"
   }
 }

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -80,7 +80,7 @@ export async function withDefaultConfiguration(
     modelsInfo: options.modelsInfo,
     connection: options.connection,
     inferenceProvider: options.inferenceProvider,
-    gpuLayers: options.gpuLayers ?? -1,
+    gpuLayers: options.gpuLayers ?? 999,
   };
 }
 

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -306,7 +306,7 @@ describe('perform', () => {
       expect.objectContaining({
         Cmd: [
           '-c',
-          '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && chmod 755 ./run.sh && ./run.sh',
+          '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && /usr/bin/llama-server.sh',
         ],
       }),
     );
@@ -354,7 +354,7 @@ describe('perform', () => {
       expect.objectContaining({
         Cmd: [
           '-c',
-          '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && chmod 755 ./run.sh && ./run.sh',
+          '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && /usr/bin/llama-server.sh',
         ],
       }),
     );
@@ -402,7 +402,7 @@ describe('perform', () => {
       expect.objectContaining({
         Cmd: [
           '-c',
-          '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && chmod 755 ./run.sh && ./run.sh',
+          '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && /usr/bin/llama-server.sh',
         ],
       }),
     );

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -204,7 +204,7 @@ describe('perform', () => {
       HealthCheck: {
         Interval: SECOND * 5,
         Retries: 20,
-        Test: ['CMD-SHELL', 'curl -sSf localhost:8000/docs > /dev/null'],
+        Test: ['CMD-SHELL', 'curl -sSf localhost:8000 > /dev/null'],
       },
       HostConfig: {
         AutoRemove: false,
@@ -444,7 +444,7 @@ describe('perform', () => {
     expect('gpu' in server.labels).toBeFalsy();
   });
 
-  test('LIBKRUN vmtype should uses llamacpp.vulkan image', async () => {
+  test('LIBKRUN vmtype should uses llamacpp.default image with gpu layers 999', async () => {
     vi.mocked(podmanConnection.findRunningContainerProviderConnection).mockReturnValue({
       ...dummyConnection,
       vmType: VMType.LIBKRUN,
@@ -476,9 +476,16 @@ describe('perform', () => {
       connection: undefined,
     });
 
-    expect(getImageInfo).toHaveBeenCalledWith(expect.anything(), llamacpp.vulkan, expect.any(Function));
+    expect(getImageInfo).toHaveBeenCalledWith(expect.anything(), llamacpp.default, expect.any(Function));
     expect(gpuManager.collectGPUs).toHaveBeenCalled();
     expect('gpu' in server.labels).toBeTruthy();
+
+    expect(containerEngine.createContainer).toHaveBeenCalledWith(
+      DummyImageInfo.engineId,
+      expect.objectContaining({
+        Env: expect.arrayContaining(['GPU_LAYERS=999']),
+      }),
+    );
   });
 
   test('UNKNOWN vmtype should use llamacpp.default image - if not gpu accelerated', async () => {

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -130,7 +130,7 @@ export class LlamaCppPython extends InferenceProvider {
           entrypoint = '/usr/bin/sh';
           cmd = [
             '-c',
-            '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && chmod 755 ./run.sh && ./run.sh',
+            '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && /usr/bin/llama-server.sh',
           ];
           break;
         case VMType.LIBKRUN:
@@ -156,10 +156,6 @@ export class LlamaCppPython extends InferenceProvider {
           });
 
           user = '0';
-
-          entrypoint = '/usr/bin/sh';
-
-          cmd = ['-c', 'chmod 755 ./run.sh && ./run.sh'];
 
           break;
       }

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -169,13 +169,7 @@ export class LlamaCppPython extends InferenceProvider {
 
         // label the container
         labels['gpu'] = gpu.model;
-
-        // set the number of layers to offload to the GPU in case of LibKrun
-        if (vmType === VMType.LIBKRUN || vmType === VMType.LIBKRUN_LABEL) {
-          envs.push(`GPU_LAYERS=999`);
-        } else {
-          envs.push(`GPU_LAYERS=${config.gpuLayers}`);
-        }
+        envs.push(`GPU_LAYERS=${config.gpuLayers ?? 999}`);
       } else {
         console.warn(`gpu ${gpu.model} is not supported on ${vmType}.`);
       }

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -49,7 +49,7 @@ export interface InferenceServerConfig {
   /**
    * Number of layers to offload to the GPU
    * @default undefined the GPU will not be used
-   * -1 to offload all the layers
+   * 999 to offload all the layers
    */
   gpuLayers?: number;
 }


### PR DESCRIPTION
### What does this PR do?
switch to the RamaLama images

Use default images for macOS with gpuLayers=999 (as RamaLama does for libkrun/macOS) rather than using vulkan images
(vulkan images are failing with libKrun (unstable on my end))

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/2630

### How to test this PR?

try to start a playground/service for a model