### PR TITLE
feat: make AI lab providing swagger UI for the openAI docs (#2703)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
   "dependencies": {
     "js-yaml": "^4.1.0"
   },
+  "scarfSettings": {
+    "enabled": false
+  },
   "pnpm": {
     "overrides": {
       "postman-collection>semver": "^7.5.2"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -110,6 +110,8 @@
     "postman-code-generators": "^1.14.1",
     "postman-collection": "^5.0.1",
     "semver": "^7.7.1",
+    "swagger-ui-dist": "^5.20.1",
+    "swagger-ui-express": "^5.0.1",
     "systeminformation": "^5.25.11",
     "xml-js": "^1.6.11"
   },
@@ -122,6 +124,8 @@
     "@types/node": "^22",
     "@types/postman-collection": "^3.5.10",
     "@types/supertest": "^6.0.3",
+    "@types/swagger-ui-dist": "^3.30.5",
+    "@types/swagger-ui-express": "^4.1.8",
     "openapi-typescript": "^7.6.1",
     "supertest": "^7.1.0",
     "vitest": "^3.0.5"

--- a/packages/backend/src/assets/openai.json
+++ b/packages/backend/src/assets/openai.json
@@ -1,0 +1,2061 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAI API",
+    "version": "0.3.2"
+  },
+  "servers": [
+    {
+      "url": "",
+      "description": "description"
+    }
+  ],
+  "paths": {
+    "/v1/completions": {
+      "post": {
+        "tags": ["OpenAI V1"],
+        "summary": "Completion",
+        "operationId": "create_completion_v1_completions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCompletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateCompletionResponse"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CreateCompletionResponse"
+                    }
+                  ],
+                  "title": "Completion response, when stream=False"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "title": "Server Side Streaming response, when stream=True. See SSE format: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format",
+                  "example": "data: {... see CreateCompletionResponse ...} \\n\\n data: ... \\n\\n ... data: [DONE]"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/embeddings": {
+      "post": {
+        "tags": ["OpenAI V1"],
+        "summary": "Embedding",
+        "operationId": "create_embedding_v1_embeddings_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateEmbeddingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/chat/completions": {
+      "post": {
+        "tags": ["OpenAI V1"],
+        "summary": "Chat",
+        "operationId": "create_chat_completion_v1_chat_completions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateChatCompletionRequest"
+              },
+              "examples": {
+                "normal": {
+                  "summary": "Chat Completion",
+                  "value": {
+                    "model": "gpt-3.5-turbo",
+                    "messages": [
+                      {
+                        "role": "system",
+                        "content": "You are a helpful assistant."
+                      },
+                      {
+                        "role": "user",
+                        "content": "What is the capital of France?"
+                      }
+                    ]
+                  }
+                },
+                "json_mode": {
+                  "summary": "JSON Mode",
+                  "value": {
+                    "model": "gpt-3.5-turbo",
+                    "messages": [
+                      {
+                        "role": "system",
+                        "content": "You are a helpful assistant."
+                      },
+                      {
+                        "role": "user",
+                        "content": "Who won the world series in 2020"
+                      }
+                    ],
+                    "response_format": {
+                      "type": "json_object"
+                    }
+                  }
+                },
+                "tool_calling": {
+                  "summary": "Tool Calling",
+                  "value": {
+                    "model": "gpt-3.5-turbo",
+                    "messages": [
+                      {
+                        "role": "system",
+                        "content": "You are a helpful assistant."
+                      },
+                      {
+                        "role": "user",
+                        "content": "Extract Jason is 30 years old."
+                      }
+                    ],
+                    "tools": [
+                      {
+                        "type": "function",
+                        "function": {
+                          "name": "User",
+                          "description": "User record",
+                          "parameters": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "age": {
+                                "type": "number"
+                              }
+                            },
+                            "required": ["name", "age"]
+                          }
+                        }
+                      }
+                    ],
+                    "tool_choice": {
+                      "type": "function",
+                      "function": {
+                        "name": "User"
+                      }
+                    }
+                  }
+                },
+                "logprobs": {
+                  "summary": "Logprobs",
+                  "value": {
+                    "model": "gpt-3.5-turbo",
+                    "messages": [
+                      {
+                        "role": "system",
+                        "content": "You are a helpful assistant."
+                      },
+                      {
+                        "role": "user",
+                        "content": "What is the capital of France?"
+                      }
+                    ],
+                    "logprobs": true,
+                    "top_logprobs": 10
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateChatCompletionResponse"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CreateChatCompletionResponse"
+                    }
+                  ],
+                  "title": "Completion response, when stream=False"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string",
+                  "title": "Server Side Streaming response, when stream=TrueSee SSE format: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format",
+                  "example": "data: {... see CreateChatCompletionResponse ...} \\n\\n data: ... \\n\\n ... data: [DONE]"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "tags": ["OpenAI V1"],
+        "summary": "Models",
+        "operationId": "get_models_v1_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelList"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/extras/tokenize": {
+      "post": {
+        "tags": ["Extras"],
+        "summary": "Tokenize",
+        "operationId": "tokenize_extras_tokenize_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenizeInputRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenizeInputResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/extras/tokenize/count": {
+      "post": {
+        "tags": ["Extras"],
+        "summary": "Tokenize Count",
+        "operationId": "count_query_tokens_extras_tokenize_count_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenizeInputRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenizeInputCountResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/extras/detokenize": {
+      "post": {
+        "tags": ["Extras"],
+        "summary": "Detokenize",
+        "operationId": "detokenize_extras_detokenize_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DetokenizeInputRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetokenizeInputResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ChatCompletionFunction": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "parameters": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "items": {},
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "object",
+            "title": "Parameters"
+          }
+        },
+        "type": "object",
+        "required": ["name", "parameters"],
+        "title": "ChatCompletionFunction"
+      },
+      "ChatCompletionMessageToolCall": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "type": {
+            "type": "string",
+            "const": "function",
+            "title": "Type"
+          },
+          "function": {
+            "$ref": "#/components/schemas/ChatCompletionMessageToolCallFunction"
+          }
+        },
+        "type": "object",
+        "required": ["id", "type", "function"],
+        "title": "ChatCompletionMessageToolCall"
+      },
+      "ChatCompletionMessageToolCallFunction": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "arguments": {
+            "type": "string",
+            "title": "Arguments"
+          }
+        },
+        "type": "object",
+        "required": ["name", "arguments"],
+        "title": "ChatCompletionMessageToolCallFunction"
+      },
+      "ChatCompletionNamedToolChoice": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "function",
+            "title": "Type"
+          },
+          "function": {
+            "$ref": "#/components/schemas/ChatCompletionNamedToolChoiceFunction"
+          }
+        },
+        "type": "object",
+        "required": ["type", "function"],
+        "title": "ChatCompletionNamedToolChoice"
+      },
+      "ChatCompletionNamedToolChoiceFunction": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": ["name"],
+        "title": "ChatCompletionNamedToolChoiceFunction"
+      },
+      "ChatCompletionRequestAssistantMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "const": "assistant",
+            "title": "Role"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "tool_calls": {
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionMessageToolCall"
+            },
+            "type": "array",
+            "title": "Tool Calls"
+          },
+          "function_call": {
+            "$ref": "#/components/schemas/ChatCompletionRequestAssistantMessageFunctionCall"
+          }
+        },
+        "type": "object",
+        "required": ["role", "content"],
+        "title": "ChatCompletionRequestAssistantMessage"
+      },
+      "ChatCompletionRequestAssistantMessageFunctionCall": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "arguments": {
+            "type": "string",
+            "title": "Arguments"
+          }
+        },
+        "type": "object",
+        "required": ["name", "arguments"],
+        "title": "ChatCompletionRequestAssistantMessageFunctionCall"
+      },
+      "ChatCompletionRequestFunctionCallOption": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": ["name"],
+        "title": "ChatCompletionRequestFunctionCallOption"
+      },
+      "ChatCompletionRequestFunctionMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "const": "function",
+            "title": "Role"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": ["role", "content", "name"],
+        "title": "ChatCompletionRequestFunctionMessage"
+      },
+      "ChatCompletionRequestMessageContentPartImage": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "image_url",
+            "title": "Type"
+          },
+          "image_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartImageImageUrl"
+              }
+            ],
+            "title": "Image Url"
+          }
+        },
+        "type": "object",
+        "required": ["type", "image_url"],
+        "title": "ChatCompletionRequestMessageContentPartImage"
+      },
+      "ChatCompletionRequestMessageContentPartImageImageUrl": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "detail": {
+            "type": "string",
+            "enum": ["auto", "low", "high"],
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": ["url"],
+        "title": "ChatCompletionRequestMessageContentPartImageImageUrl"
+      },
+      "ChatCompletionRequestMessageContentPartText": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "text",
+            "title": "Type"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": ["type", "text"],
+        "title": "ChatCompletionRequestMessageContentPartText"
+      },
+      "ChatCompletionRequestResponseFormat": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["text", "json_object"],
+            "title": "Type"
+          },
+          "schema": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Schema"
+          }
+        },
+        "type": "object",
+        "required": ["type"],
+        "title": "ChatCompletionRequestResponseFormat"
+      },
+      "ChatCompletionRequestSystemMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "const": "system",
+            "title": "Role"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": ["role", "content"],
+        "title": "ChatCompletionRequestSystemMessage"
+      },
+      "ChatCompletionRequestToolMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "const": "tool",
+            "title": "Role"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "tool_call_id": {
+            "type": "string",
+            "title": "Tool Call Id"
+          }
+        },
+        "type": "object",
+        "required": ["role", "content", "tool_call_id"],
+        "title": "ChatCompletionRequestToolMessage"
+      },
+      "ChatCompletionRequestUserMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "const": "user",
+            "title": "Role"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartImage"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": ["role", "content"],
+        "title": "ChatCompletionRequestUserMessage"
+      },
+      "ChatCompletionResponseChoice": {
+        "properties": {
+          "index": {
+            "type": "integer",
+            "title": "Index"
+          },
+          "message": {
+            "$ref": "#/components/schemas/ChatCompletionResponseMessage"
+          },
+          "logprobs": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CompletionLogprobs"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "finish_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finish Reason"
+          }
+        },
+        "type": "object",
+        "required": ["index", "message", "logprobs", "finish_reason"],
+        "title": "ChatCompletionResponseChoice"
+      },
+      "ChatCompletionResponseFunctionCall": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "arguments": {
+            "type": "string",
+            "title": "Arguments"
+          }
+        },
+        "type": "object",
+        "required": ["name", "arguments"],
+        "title": "ChatCompletionResponseFunctionCall"
+      },
+      "ChatCompletionResponseMessage": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "tool_calls": {
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionMessageToolCall"
+            },
+            "type": "array",
+            "title": "Tool Calls"
+          },
+          "role": {
+            "type": "string",
+            "enum": ["assistant", "function"],
+            "title": "Role"
+          },
+          "function_call": {
+            "$ref": "#/components/schemas/ChatCompletionResponseFunctionCall"
+          }
+        },
+        "type": "object",
+        "required": ["content", "role"],
+        "title": "ChatCompletionResponseMessage"
+      },
+      "ChatCompletionTool": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "function",
+            "title": "Type"
+          },
+          "function": {
+            "$ref": "#/components/schemas/ChatCompletionToolFunction"
+          }
+        },
+        "type": "object",
+        "required": ["type", "function"],
+        "title": "ChatCompletionTool"
+      },
+      "ChatCompletionToolFunction": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "parameters": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "items": {},
+                  "type": "array"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "object",
+            "title": "Parameters"
+          }
+        },
+        "type": "object",
+        "required": ["name", "parameters"],
+        "title": "ChatCompletionToolFunction"
+      },
+      "CompletionChoice": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "index": {
+            "type": "integer",
+            "title": "Index"
+          },
+          "logprobs": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CompletionLogprobs"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "finish_reason": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["stop", "length"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finish Reason"
+          }
+        },
+        "type": "object",
+        "required": ["text", "index", "logprobs", "finish_reason"],
+        "title": "CompletionChoice"
+      },
+      "CompletionLogprobs": {
+        "properties": {
+          "text_offset": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Text Offset"
+          },
+          "token_logprobs": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Token Logprobs"
+          },
+          "tokens": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tokens"
+          },
+          "top_logprobs": {
+            "items": {
+              "anyOf": [
+                {
+                  "additionalProperties": {
+                    "type": "number"
+                  },
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Top Logprobs"
+          }
+        },
+        "type": "object",
+        "required": ["text_offset", "token_logprobs", "tokens", "top_logprobs"],
+        "title": "CompletionLogprobs"
+      },
+      "CompletionUsage": {
+        "properties": {
+          "prompt_tokens": {
+            "type": "integer",
+            "title": "Prompt Tokens"
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "title": "Completion Tokens"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "title": "Total Tokens"
+          }
+        },
+        "type": "object",
+        "required": ["prompt_tokens", "completion_tokens", "total_tokens"],
+        "title": "CompletionUsage"
+      },
+      "CreateChatCompletionRequest": {
+        "properties": {
+          "messages": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestSystemMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestUserMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestAssistantMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestToolMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ChatCompletionRequestFunctionMessage"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Messages",
+            "description": "A list of messages to generate completions for.",
+            "default": []
+          },
+          "functions": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatCompletionFunction"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Functions",
+            "description": "A list of functions to apply to the generated completions."
+          },
+          "function_call": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["none", "auto"]
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionRequestFunctionCallOption"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Function Call",
+            "description": "A function to apply to the generated completions."
+          },
+          "tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatCompletionTool"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tools",
+            "description": "A list of tools to apply to the generated completions."
+          },
+          "tool_choice": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["none", "auto", "required"]
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionNamedToolChoice"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Choice",
+            "description": "A tool to apply to the generated completions."
+          },
+          "max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tokens",
+            "description": "The maximum number of tokens to generate. Defaults to inf"
+          },
+          "min_tokens": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Min Tokens",
+            "description": "The minimum number of tokens to generate. It may return fewer tokens if another condition is met (e.g. max_tokens, stop).",
+            "default": 0
+          },
+          "logprobs": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logprobs",
+            "description": "Whether to output the logprobs or not. Default is True",
+            "default": false
+          },
+          "top_logprobs": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top Logprobs",
+            "description": "The number of logprobs to generate. If None, no logprobs are generated. logprobs need to set to True."
+          },
+          "temperature": {
+            "type": "number",
+            "title": "Temperature",
+            "description": "Adjust the randomness of the generated text.\n\nTemperature is a hyperparameter that controls the randomness of the generated text. It affects the probability distribution of the model's output tokens. A higher temperature (e.g., 1.5) makes the output more random and creative, while a lower temperature (e.g., 0.5) makes the output more focused, deterministic, and conservative. The default value is 0.8, which provides a balance between randomness and determinism. At the extreme, a temperature of 0 will always pick the most likely next token, leading to identical outputs in each run.",
+            "default": 0.8
+          },
+          "top_p": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Top P",
+            "description": "Limit the next token selection to a subset of tokens with a cumulative probability above a threshold P.\n\nTop-p sampling, also known as nucleus sampling, is another text generation method that selects the next token from a subset of tokens that together have a cumulative probability of at least p. This method provides a balance between diversity and quality by considering both the probabilities of tokens and the number of tokens to sample from. A higher value for top_p (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.",
+            "default": 0.95
+          },
+          "min_p": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Min P",
+            "description": "Sets a minimum base probability threshold for token selection.\n\nThe Min-P sampling method was designed as an alternative to Top-P, and aims to ensure a balance of quality and variety. The parameter min_p represents the minimum probability for a token to be considered, relative to the probability of the most likely token. For example, with min_p=0.05 and the most likely token having a probability of 0.9, logits with a value less than 0.045 are filtered out.",
+            "default": 0.05
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stop",
+            "description": "A list of tokens at which to stop generation. If None, no stop tokens are used."
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "description": "Whether to stream the results as they are generated. Useful for chatbots.",
+            "default": false
+          },
+          "stream_options": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StreamOptions"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Options for streaming response. Only set this when you set stream: true."
+          },
+          "presence_penalty": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 2.0,
+                "minimum": -2.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Presence Penalty",
+            "description": "Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
+            "default": 0.0
+          },
+          "frequency_penalty": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 2.0,
+                "minimum": -2.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Penalty",
+            "description": "Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.",
+            "default": 0.0
+          },
+          "logit_bias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logit Bias"
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed"
+          },
+          "response_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionRequestResponseFormat"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "description": "The model to use for generating completions."
+          },
+          "n": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N",
+            "default": 1
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          },
+          "top_k": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Top K",
+            "description": "Limit the next token selection to the K most probable tokens.\n\nTop-k sampling is a text generation method that selects the next token only from the top k most likely tokens predicted by the model. It helps reduce the risk of generating low-probability or nonsensical tokens, but it may also limit the diversity of the output. A higher value for top_k (e.g., 100) will consider more tokens and lead to more diverse text, while a lower value (e.g., 10) will focus on the most probable tokens and generate more conservative text.",
+            "default": 40
+          },
+          "repeat_penalty": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Repeat Penalty",
+            "description": "A penalty applied to each token that is already generated. This helps prevent the model from repeating itself.\n\nRepeat penalty is a hyperparameter used to penalize the repetition of token sequences during text generation. It helps prevent the model from generating repetitive or monotonous text. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient.",
+            "default": 1.1
+          },
+          "logit_bias_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["input_ids", "tokens"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logit Bias Type"
+          },
+          "mirostat_mode": {
+            "type": "integer",
+            "maximum": 2.0,
+            "minimum": 0.0,
+            "title": "Mirostat Mode",
+            "description": "Enable Mirostat constant-perplexity algorithm of the specified version (1 or 2; 0 = disabled)",
+            "default": 0
+          },
+          "mirostat_tau": {
+            "type": "number",
+            "maximum": 10.0,
+            "minimum": 0.0,
+            "title": "Mirostat Tau",
+            "description": "Mirostat target entropy, i.e. the target perplexity - lower values produce focused and coherent text, larger values produce more diverse and less coherent text",
+            "default": 5.0
+          },
+          "mirostat_eta": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.001,
+            "title": "Mirostat Eta",
+            "description": "Mirostat learning rate",
+            "default": 0.1
+          },
+          "grammar": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grammar"
+          }
+        },
+        "type": "object",
+        "title": "CreateChatCompletionRequest",
+        "examples": [
+          {
+            "messages": [
+              {
+                "content": "You are a helpful assistant.",
+                "role": "system"
+              },
+              {
+                "content": "What is the capital of France?",
+                "role": "user"
+              }
+            ]
+          }
+        ]
+      },
+      "CreateChatCompletionResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "chat.completion",
+            "title": "Object"
+          },
+          "created": {
+            "type": "integer",
+            "title": "Created"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "choices": {
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionResponseChoice"
+            },
+            "type": "array",
+            "title": "Choices"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/CompletionUsage"
+          }
+        },
+        "type": "object",
+        "required": ["id", "object", "created", "model", "choices", "usage"],
+        "title": "CreateChatCompletionResponse"
+      },
+      "CreateCompletionRequest": {
+        "properties": {
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Prompt",
+            "description": "The prompt to generate completions for.",
+            "default": ""
+          },
+          "suffix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suffix",
+            "description": "A suffix to append to the generated text. If None, no suffix is appended. Useful for chatbots."
+          },
+          "max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tokens",
+            "description": "The maximum number of tokens to generate.",
+            "default": 16
+          },
+          "min_tokens": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Min Tokens",
+            "description": "The minimum number of tokens to generate. It may return fewer tokens if another condition is met (e.g. max_tokens, stop).",
+            "default": 0
+          },
+          "temperature": {
+            "type": "number",
+            "title": "Temperature",
+            "description": "Adjust the randomness of the generated text.\n\nTemperature is a hyperparameter that controls the randomness of the generated text. It affects the probability distribution of the model's output tokens. A higher temperature (e.g., 1.5) makes the output more random and creative, while a lower temperature (e.g., 0.5) makes the output more focused, deterministic, and conservative. The default value is 0.8, which provides a balance between randomness and determinism. At the extreme, a temperature of 0 will always pick the most likely next token, leading to identical outputs in each run.",
+            "default": 0.8
+          },
+          "top_p": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Top P",
+            "description": "Limit the next token selection to a subset of tokens with a cumulative probability above a threshold P.\n\nTop-p sampling, also known as nucleus sampling, is another text generation method that selects the next token from a subset of tokens that together have a cumulative probability of at least p. This method provides a balance between diversity and quality by considering both the probabilities of tokens and the number of tokens to sample from. A higher value for top_p (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text.",
+            "default": 0.95
+          },
+          "min_p": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Min P",
+            "description": "Sets a minimum base probability threshold for token selection.\n\nThe Min-P sampling method was designed as an alternative to Top-P, and aims to ensure a balance of quality and variety. The parameter min_p represents the minimum probability for a token to be considered, relative to the probability of the most likely token. For example, with min_p=0.05 and the most likely token having a probability of 0.9, logits with a value less than 0.045 are filtered out.",
+            "default": 0.05
+          },
+          "echo": {
+            "type": "boolean",
+            "title": "Echo",
+            "description": "Whether to echo the prompt in the generated text. Useful for chatbots.",
+            "default": false
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stop",
+            "description": "A list of tokens at which to stop generation. If None, no stop tokens are used."
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "description": "Whether to stream the results as they are generated. Useful for chatbots.",
+            "default": false
+          },
+          "stream_options": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StreamOptions"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Options for streaming response. Only set this when you set stream: true."
+          },
+          "logprobs": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logprobs",
+            "description": "The number of logprobs to generate. If None, no logprobs are generated."
+          },
+          "presence_penalty": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 2.0,
+                "minimum": -2.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Presence Penalty",
+            "description": "Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
+            "default": 0.0
+          },
+          "frequency_penalty": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 2.0,
+                "minimum": -2.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Penalty",
+            "description": "Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.",
+            "default": 0.0
+          },
+          "logit_bias": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logit Bias"
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "description": "The model to use for generating completions."
+          },
+          "n": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N",
+            "default": 1
+          },
+          "best_of": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Best Of",
+            "default": 1
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          },
+          "top_k": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Top K",
+            "description": "Limit the next token selection to the K most probable tokens.\n\nTop-k sampling is a text generation method that selects the next token only from the top k most likely tokens predicted by the model. It helps reduce the risk of generating low-probability or nonsensical tokens, but it may also limit the diversity of the output. A higher value for top_k (e.g., 100) will consider more tokens and lead to more diverse text, while a lower value (e.g., 10) will focus on the most probable tokens and generate more conservative text.",
+            "default": 40
+          },
+          "repeat_penalty": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Repeat Penalty",
+            "description": "A penalty applied to each token that is already generated. This helps prevent the model from repeating itself.\n\nRepeat penalty is a hyperparameter used to penalize the repetition of token sequences during text generation. It helps prevent the model from generating repetitive or monotonous text. A higher value (e.g., 1.5) will penalize repetitions more strongly, while a lower value (e.g., 0.9) will be more lenient.",
+            "default": 1.1
+          },
+          "logit_bias_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["input_ids", "tokens"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logit Bias Type"
+          },
+          "mirostat_mode": {
+            "type": "integer",
+            "maximum": 2.0,
+            "minimum": 0.0,
+            "title": "Mirostat Mode",
+            "description": "Enable Mirostat constant-perplexity algorithm of the specified version (1 or 2; 0 = disabled)",
+            "default": 0
+          },
+          "mirostat_tau": {
+            "type": "number",
+            "maximum": 10.0,
+            "minimum": 0.0,
+            "title": "Mirostat Tau",
+            "description": "Mirostat target entropy, i.e. the target perplexity - lower values produce focused and coherent text, larger values produce more diverse and less coherent text",
+            "default": 5.0
+          },
+          "mirostat_eta": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.001,
+            "title": "Mirostat Eta",
+            "description": "Mirostat learning rate",
+            "default": 0.1
+          },
+          "grammar": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grammar"
+          }
+        },
+        "type": "object",
+        "title": "CreateCompletionRequest",
+        "examples": [
+          {
+            "prompt": "\n\n### Instructions:\nWhat is the capital of France?\n\n### Response:\n",
+            "stop": ["\n", "###"]
+          }
+        ]
+      },
+      "CreateCompletionResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "text_completion",
+            "title": "Object"
+          },
+          "created": {
+            "type": "integer",
+            "title": "Created"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "choices": {
+            "items": {
+              "$ref": "#/components/schemas/CompletionChoice"
+            },
+            "type": "array",
+            "title": "Choices"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/CompletionUsage"
+          }
+        },
+        "type": "object",
+        "required": ["id", "object", "created", "model", "choices"],
+        "title": "CreateCompletionResponse"
+      },
+      "CreateEmbeddingRequest": {
+        "properties": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "description": "The model to use for generating completions."
+          },
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Input",
+            "description": "The input to embed."
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          }
+        },
+        "type": "object",
+        "required": ["input"],
+        "title": "CreateEmbeddingRequest",
+        "examples": [
+          {
+            "input": "The food was delicious and the waiter..."
+          }
+        ]
+      },
+      "DetokenizeInputRequest": {
+        "properties": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "description": "The model to use for generating completions."
+          },
+          "tokens": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Tokens",
+            "description": "A list of toekns to detokenize."
+          }
+        },
+        "type": "object",
+        "required": ["tokens"],
+        "title": "DetokenizeInputRequest",
+        "example": [
+          {
+            "tokens": [123, 321, 222]
+          }
+        ]
+      },
+      "DetokenizeInputResponse": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text",
+            "description": "The detokenized text."
+          }
+        },
+        "type": "object",
+        "required": ["text"],
+        "title": "DetokenizeInputResponse",
+        "example": {
+          "text": "How many tokens in this query?"
+        }
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ModelData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "object": {
+            "type": "string",
+            "const": "model",
+            "title": "Object"
+          },
+          "owned_by": {
+            "type": "string",
+            "title": "Owned By"
+          },
+          "permissions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Permissions"
+          }
+        },
+        "type": "object",
+        "required": ["id", "object", "owned_by", "permissions"],
+        "title": "ModelData"
+      },
+      "ModelList": {
+        "properties": {
+          "object": {
+            "type": "string",
+            "const": "list",
+            "title": "Object"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ModelData"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": ["object", "data"],
+        "title": "ModelList"
+      },
+      "StreamOptions": {
+        "properties": {
+          "include_usage": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Usage"
+          }
+        },
+        "type": "object",
+        "required": ["include_usage"],
+        "title": "StreamOptions"
+      },
+      "TokenizeInputCountResponse": {
+        "properties": {
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "description": "The number of tokens in the input."
+          }
+        },
+        "type": "object",
+        "required": ["count"],
+        "title": "TokenizeInputCountResponse",
+        "example": {
+          "count": 5
+        }
+      },
+      "TokenizeInputRequest": {
+        "properties": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "description": "The model to use for generating completions."
+          },
+          "input": {
+            "type": "string",
+            "title": "Input",
+            "description": "The input to tokenize."
+          }
+        },
+        "type": "object",
+        "required": ["input"],
+        "title": "TokenizeInputRequest",
+        "examples": [
+          {
+            "input": "How many tokens in this query?"
+          }
+        ]
+      },
+      "TokenizeInputResponse": {
+        "properties": {
+          "tokens": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array",
+            "title": "Tokens",
+            "description": "A list of tokens."
+          }
+        },
+        "type": "object",
+        "required": ["tokens"],
+        "title": "TokenizeInputResponse",
+        "example": {
+          "tokens": [123, 321, 222]
+        }
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}

--- a/packages/backend/src/managers/apiServer.spec.ts
+++ b/packages/backend/src/managers/apiServer.spec.ts
@@ -220,6 +220,7 @@ test('/api-docs/9000 returns swagger UI', async () => {
   }
   const response = await request(listener).get('/api-docs/9000/').expect(200);
   expect(response.status).toBe(200);
+
   // Ensure it returns the Swagger UI page
   expect(response.text).toContain('<title>Swagger UI</title>');
 });

--- a/packages/backend/src/managers/apiServer.spec.ts
+++ b/packages/backend/src/managers/apiServer.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 /* eslint-disable sonarjs/no-nested-functions */
 
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ApiServer, PREFERENCE_RANDOM_PORT } from './apiServer';
 import request from 'supertest';
 import type * as podmanDesktopApi from '@podman-desktop/api';
@@ -209,6 +209,19 @@ test('/api/tags returns ok', async () => {
     name: 'model-name',
     model: 'model-name',
   });
+});
+
+test('/api-docs/9000 returns swagger UI', async () => {
+  expect(server.getListener()).toBeDefined();
+  vi.mocked(modelsManager.getModelsInfo).mockRejectedValue({});
+  const listener = server.getListener();
+  if (!listener) {
+    assert.fail('listener is not defined');
+  }
+  const response = await request(listener).get('/api-docs/9000/').expect(200);
+  expect(response.status).toBe(200);
+  // Ensure it returns the Swagger UI page
+  expect(response.text).toContain('<title>Swagger UI</title>');
 });
 
 test('verify listening on localhost', async () => {

--- a/packages/backend/src/managers/apiServer.ts
+++ b/packages/backend/src/managers/apiServer.ts
@@ -151,8 +151,6 @@ export class ApiServer implements Disposable {
     app.use('/api', router);
     app.use('/spec', this.getSpec.bind(this));
 
-    const options = {};
-
     // get swagger-ui path from dist/swagger-ui
     const swaggerPath = resolve(getAbsoluteFSPath(), 'swagger-ui');
 
@@ -172,7 +170,7 @@ export class ApiServer implements Disposable {
 
         next();
       },
-      swaggerUi.serveFiles(openAiApi, options),
+      swaggerUi.serveFiles(openAiApi),
       swaggerUi.setup(),
     );
 

--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -184,7 +184,7 @@ describe('perform', () => {
       labels: {
         [LABEL_INFERENCE_SERVER]: `["${DummyModel.id}"]`,
         api: 'http://localhost:8888/v1',
-        docs: 'http://localhost:8888/docs',
+        docs: 'http://localhost:10434/api-docs/8888',
       },
       models: [DummyModel],
       status: 'running',
@@ -230,7 +230,7 @@ describe('perform', () => {
       Labels: {
         [LABEL_INFERENCE_SERVER]: `["${DummyModel.id}"]`,
         api: 'http://localhost:8888/v1',
-        docs: 'http://localhost:8888/docs',
+        docs: 'http://localhost:10434/api-docs/8888',
       },
     });
   });

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -179,8 +179,12 @@ export class LlamaCppPython extends InferenceProvider {
       }
     }
 
+    // add the link to our openAPI instance using the instance as the host
+    const aiLabPort = this.configurationRegistry.getExtensionConfiguration().apiPort;
+    // add in the URL the port of the inference server
+    const aiLabDocsLink = `http://localhost:${aiLabPort}/api-docs/${config.port}`;
     // adding labels to inference server
-    labels['docs'] = `http://localhost:${config.port}/docs`;
+    labels['docs'] = aiLabDocsLink;
     labels['api'] = `http://localhost:${config.port}/v1`;
 
     return {

--- a/packages/backend/vite.config.js
+++ b/packages/backend/vite.config.js
@@ -20,7 +20,7 @@ import { join, resolve } from 'node:path';
 import { builtinModules } from 'module';
 import { existsSync } from 'node:fs';
 import replace from '@rollup/plugin-replace';
-import { copyFile, mkdir, readdir } from 'node:fs/promises';
+import { cp, mkdir } from 'node:fs/promises';
 
 const PACKAGE_ROOT = __dirname;
 
@@ -70,22 +70,16 @@ const config = {
             }
 
             // Copy files
-            const entries = await readdir(source, { withFileTypes: true });
-
-            for (const entry of entries) {
-              const srcFile = join(source, entry.name);
-              const destFile = join(destination, entry.name);
-
-              if (entry.isFile()) {
-                await copyFile(srcFile, destFile);
-              }
-            }
+            await cp(source, destination, {
+              recursive: true,
+              filter: source => !source.includes('.map'),
+            });
             console.info(`Swagger UI files copied in ${Math.round(performance.now() - start)}ms to dist/swagger-ui`);
           },
         },
       ],
     },
-    emptyOutDir: true,
+    emptyOutDir: false,
     reportCompressedSize: false,
   },
   plugins: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,12 @@ importers:
       semver:
         specifier: ^7.7.1
         version: 7.7.1
+      swagger-ui-dist:
+        specifier: ^5.20.1
+        version: 5.20.1
+      swagger-ui-express:
+        specifier: ^5.0.1
+        version: 5.0.1(express@4.21.2)
       systeminformation:
         specifier: ^5.25.11
         version: 5.25.11
@@ -175,6 +181,12 @@ importers:
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
+      '@types/swagger-ui-dist':
+        specifier: ^3.30.5
+        version: 3.30.5
+      '@types/swagger-ui-express':
+        specifier: ^4.1.8
+        version: 4.1.8
       openapi-typescript:
         specifier: ^7.6.1
         version: 7.6.1(typescript@5.7.3)
@@ -1224,6 +1236,9 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -1475,6 +1490,12 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/swagger-ui-dist@3.30.5':
+    resolution: {integrity: sha512-SrXhD9L8qeIxJzN+o1kmf3wXeVf/+Km3jIdRM1+Yq3I5b/dlF5TcGr5WCVM7I/cBYpgf43/gCPIucQ13AhICiw==}
+
+  '@types/swagger-ui-express@4.1.8':
+    resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -4565,6 +4586,15 @@ packages:
     resolution: {integrity: sha512-J9rcZ/xVJonAoESqVGHHZhrNdVbrCfkdB41BP6eiwHMoFShD9it3yZXApVYMHdGfCshBsZCKsajwJeBbS/M1zg==}
     engines: {node: '>=18'}
 
+  swagger-ui-dist@5.20.1:
+    resolution: {integrity: sha512-qBPCis2w8nP4US7SvUxdJD3OwKcqiWeZmjN2VWhq2v+ESZEXOP/7n4DeiOiiZcGYTKMHAHUUrroHaTsjUWTEGw==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4573,9 +4603,6 @@ packages:
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
-
-  tailwindcss@4.0.15:
-    resolution: {integrity: sha512-6ZMg+hHdMJpjpeCCFasX7K+U615U9D+7k5/cDK/iRwl6GptF24+I/AbKgOnXhVKePzrEyIXutLv36n4cRsq3Sg==}
 
   tailwindcss@4.0.16:
     resolution: {integrity: sha512-i/SbG7ThTIcLshcFJL+je7hCv9dPis4Xl4XNeel6iZNX42pp/BZ+la+SbZIPoYE+PN8zhKbnHblpQ/lhOWwIeQ==}
@@ -5882,6 +5909,8 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@scarf/scarf@1.4.0': {}
+
   '@sindresorhus/is@4.6.0': {}
 
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.14.1)':
@@ -6148,6 +6177,13 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/swagger-ui-dist@3.30.5': {}
+
+  '@types/swagger-ui-express@4.1.8':
+    dependencies:
+      '@types/express': 4.17.21
+      '@types/serve-static': 1.15.7
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -9668,11 +9704,18 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
+  swagger-ui-dist@5.20.1:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@4.21.2):
+    dependencies:
+      express: 4.21.2
+      swagger-ui-dist: 5.20.1
+
   symbol-tree@3.2.4: {}
 
   systeminformation@5.25.11: {}
-
-  tailwindcss@4.0.15: {}
 
   tailwindcss@4.0.16: {}
 


### PR DESCRIPTION
### What does this PR do?
introduce again the swagger-ui served by ApiServer.
This time, copy the swagger-ui-dist content to the vite dist folder so files will be found (so no need to exclude swagger-ui-express from vite)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/2695

### How to test this PR?

try dev mode and production mode (create the image, push it to a OCI registry and install extension from there)

go to services/service and click on 'Swagger link' and try it