### PR TITLE
fix: return model name in /api/tags

### DIFF
--- a/packages/backend/src/managers/apiServer.spec.ts
+++ b/packages/backend/src/managers/apiServer.spec.ts
@@ -192,6 +192,25 @@ test('/api/tags returns error', async () => {
   expect(res.body.message).toEqual('unable to get models');
 });
 
+test('/api/tags returns ok', async () => {
+  expect(server.getListener()).toBeDefined();
+  vi.mocked(modelsManager.getModelsInfo).mockReturnValue([
+    {
+      id: 'modelId',
+      name: 'model-name',
+      description: 'a description',
+    },
+  ]);
+  vi.mocked(modelsManager.isModelOnDisk).mockReturnValue(true);
+  const res = await request(server.getListener()!).get('/api/tags').expect(200);
+  expect(res.body).toBeDefined();
+  expect(res.body.models).toBeDefined();
+  expect(res.body.models[0]).toMatchObject({
+    name: 'model-name',
+    model: 'model-name',
+  });
+});
+
 test('verify listening on localhost', async () => {
   expect(server.getListener()).toBeDefined();
   expect((server.getListener()?.address() as AddressInfo).address).toEqual('127.0.0.1');

--- a/packages/backend/src/managers/apiServer.ts
+++ b/packages/backend/src/managers/apiServer.ts
@@ -53,7 +53,7 @@ type ProcessModelResponse = components['schemas']['ProcessModelResponse'];
 
 function asListModelResponse(model: ModelInfo): ListModelResponse {
   return {
-    model: model.id,
+    model: model.name,
     name: model.name,
     digest: toDigest(model.name, model.sha256),
     size: model.file?.size,


### PR DESCRIPTION
Fixes #2736

### What does this PR do?

Fixes /api/tags so as to return model name in the model field

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#2736 

### How to test this PR?

- [x] Test included
