### PR TITLE
chore: check that we can't create multiple time a RPCChannel with same name

### DIFF
--- a/packages/frontend/src/stores/modelsInfo.spec.ts
+++ b/packages/frontend/src/stores/modelsInfo.spec.ts
@@ -20,7 +20,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { rpcBrowser } from '../utils/client';
 import type { Unsubscriber } from 'svelte/store';
 import { modelsInfo } from './modelsInfo';
-import { type RpcChannel, createRpcChannel, type Listener } from '@shared/messages/MessageProxy';
+import { type RpcChannel, createRpcChannel, type Listener, clearRpcChannelList } from '@shared/messages/MessageProxy';
 import { MSG_NEW_MODELS_STATE } from '@shared/Messages';
 
 const mocks = vi.hoisted(() => {
@@ -64,6 +64,7 @@ vi.mock('../utils/client', async () => {
 let unsubscriber: Unsubscriber | undefined;
 beforeEach(() => {
   vi.clearAllMocks();
+  clearRpcChannelList();
   unsubscriber = modelsInfo.subscribe(_ => {});
 });
 

--- a/packages/frontend/src/stores/rpcReadable.spec.ts
+++ b/packages/frontend/src/stores/rpcReadable.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { beforeEach, expect, test, vi } from 'vitest';
-import { createRpcChannel, RpcBrowser } from '@shared/messages/MessageProxy';
+import { clearRpcChannelList, createRpcChannel, RpcBrowser } from '@shared/messages/MessageProxy';
 import { RPCReadable } from './rpcReadable';
 import { studioClient, rpcBrowser } from '../utils/client';
 import type { ModelInfo } from '@shared/models/IModelInfo';
@@ -68,6 +68,7 @@ test('check updater is called once at subscription', async () => {
 
 test('check updater is called twice if there is one event fired', async () => {
   const channelModel = createRpcChannel<string[]>('event2');
+  clearRpcChannelList();
   const channel = createRpcChannel<Update>('event2');
   type Update = {
     event: () => Promise<string[]>;
@@ -91,6 +92,7 @@ test('check updater is called twice if there is one event fired', async () => {
 
 test('check updater is called only twice because of the debouncer if there is more than one event in a row', async () => {
   const channelModel = createRpcChannel<ModelInfo[]>('event3');
+  clearRpcChannelList();
   const channel = createRpcChannel<Update>('event3');
   type Update = {
     event: () => Promise<string[]>;

--- a/packages/shared/src/messages/MessageProxy.spec.ts
+++ b/packages/shared/src/messages/MessageProxy.spec.ts
@@ -240,7 +240,7 @@ describe('subscribe', () => {
     interface EventTest {
       foo: string;
     }
-    const rpcChannel = createRpcChannel<EventTest>('example');
+    const rpcChannel = createRpcChannel<EventTest>('example-all-subscribers');
     listeners.forEach(listener => rpcBrowser.subscribe(rpcChannel, listener));
 
     messageListener({
@@ -264,7 +264,7 @@ describe('subscribe', () => {
     interface EventTest {
       foo: string;
     }
-    const rpcChannel = createRpcChannel<EventTest>('example');
+    const rpcChannel = createRpcChannel<EventTest>('example-unsubscribe');
 
     const unsubscriberA = rpcBrowser.subscribe(rpcChannel, listenerA);
     const unsubscriberB = rpcBrowser.subscribe(rpcChannel, listenerB);
@@ -422,4 +422,14 @@ describe('rpcExtension onDidReceiveMessage', () => {
     // check that console.error was called
     expect(console.error).toHaveBeenCalledWith('Trying to call on an unknown channel test. Available: ');
   });
+});
+
+test('Test register duplicated channel', async () => {
+  type Double = {
+    double: (value: number) => Promise<number>;
+  };
+
+  const channel1 = createRpcChannel<Double>('existing');
+  expect(channel1.name).toBe('existing');
+  expect(() => createRpcChannel<Double>('existing')).toThrowError('Duplicate channel. Channel existing already exists');
 });

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -263,7 +263,19 @@ export class RpcChannel<T> {
   }
 }
 
+// keep the list of all RPC Channels being created
+// allow to check if a channel is already created
+const rpcChannelList = new Set<string>();
+
 // defines a channel with the given name for the interface T
 export function createRpcChannel<T>(channel: string): RpcChannel<T> {
+  if (rpcChannelList.has(channel)) {
+    throw new Error(`Duplicate channel. Channel ${channel} already exists`);
+  }
+  rpcChannelList.add(channel);
   return new RpcChannel<T>(channel);
+}
+
+export function clearRpcChannelList(): void {
+  rpcChannelList.clear();
 }


### PR DESCRIPTION
### What does this PR do?
ensure we can't create twice a RPC Channel with the same name (else we got an error)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
follow-up of https://github.com/containers/podman-desktop-extension-ai-lab/pull/2596#discussion_r2007611049

### How to test this PR?

<!-- Please explain steps to reproduce -->
