### PR TITLE
feat(backend): make TaskRegistry implement disposable

### DIFF
--- a/packages/backend/src/registries/TaskRegistry.spec.ts
+++ b/packages/backend/src/registries/TaskRegistry.spec.ts
@@ -33,6 +33,16 @@ test('should not have any tasks by default', () => {
   expect(taskRegistry.getTasks().length).toBe(0);
 });
 
+test('dispose should cleanup all tasks', () => {
+  const taskRegistry = new TaskRegistry(rpcExtension);
+
+  taskRegistry.createTask('random', 'loading');
+  expect(taskRegistry.getTasks()).toHaveLength(1);
+
+  taskRegistry.dispose();
+  expect(taskRegistry.getTasks()).toHaveLength(0);
+});
+
 test('should notify when create task', () => {
   const taskRegistry = new TaskRegistry(rpcExtension);
   taskRegistry.createTask('random', 'loading');

--- a/packages/backend/src/registries/TaskRegistry.ts
+++ b/packages/backend/src/registries/TaskRegistry.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type Disposable } from '@podman-desktop/api';
 import type { Task, TaskState } from '@shared/models/ITask';
 import { MSG_TASKS_UPDATE } from '@shared/Messages';
 import type { RpcExtension } from '@shared/messages/MessageProxy';
@@ -23,7 +24,7 @@ import type { RpcExtension } from '@shared/messages/MessageProxy';
 /**
  * A registry for managing tasks.
  */
-export class TaskRegistry {
+export class TaskRegistry implements Disposable {
   private counter: number = 0;
   private tasks: Map<string, Task> = new Map<string, Task>();
 
@@ -32,6 +33,11 @@ export class TaskRegistry {
    * @param rpcExtension The rpc extension instance to use for communication.
    */
   constructor(private rpcExtension: RpcExtension) {}
+
+  dispose(): void {
+    this.counter = 0;
+    this.tasks.clear();
+  }
 
   /**
    * Retrieves a task by its ID.

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -197,6 +197,7 @@ export class Studio {
      * The task registry store the tasks
      */
     this.#taskRegistry = new TaskRegistry(this.#rpcExtension);
+    this.#extensionContext.subscriptions.push(this.#taskRegistry);
 
     /**
      * Create catalog manager, responsible for loading the catalog files and watching for changes


### PR DESCRIPTION
### What does this PR do?

While reviewing https://github.com/containers/podman-desktop-extension-ai-lab/pull/2831 I noticed that the TaskManager was **not** disposable, and therefore might never cleanup the tasks, even if the user disable the extension.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- [x] unit tests has been added
