### PR TITLE
feat: register models for llama stack

### DIFF
--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -316,6 +316,7 @@ export class Studio {
       this.#containerRegistry,
       this.#configurationRegistry,
       this.#telemetry,
+      this.#modelsManager,
     );
     this.#extensionContext.subscriptions.push(this.#llamaStackManager);
     this.#llamaStackManager.init();


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

During llama stack container creation:
- all models present on disk are auto-registered on the llama stack

### Screenshot / video of UI

(in the demo below, the chat completion with the model `MaziyarPanahi/Mistral-7B-Instruct-v0.3.Q4` fails because the output of `llama-stack-client models list` truncates the names of models - the name to use should have been `MaziyarPanahi/Mistral-7B-Instruct-v0.3.Q4_K_M`) 

You can see in the demo that all models are registered in the llama stack, and inference servers are started only for the ones used during a chat completion.

https://github.com/user-attachments/assets/90987d5e-38d8-4f64-b5bb-5e2ed90a809c


### What issues does this PR fix or reference?

Fixes #2840

### How to test this PR?

<!-- Please explain steps to reproduce -->
