### PR TITLE
MCP integration in the playground

### DIFF
--- a/packages/backend/src/managers/playground/McpServerManager.spec.ts
+++ b/packages/backend/src/managers/playground/McpServerManager.spec.ts
@@ -51,8 +51,7 @@ describe('McpServerManager', () => {
     });
     test('with empty file, returns empty array', async () => {
       const mcpServerManager = new McpServerManager(appUserDirectory);
-      const mcpSettingsFile = path.join(appUserDirectory, 'mcp-settings.json');
-      await fs.promises.writeFile(mcpSettingsFile, '{}');
+      vi.spyOn(fs.promises, 'readFile').mockImplementation(async () => '{}');
       const mcpServers = await mcpServerManager.load();
       expect(mcpServers).toEqual([]);
       expect(consoleErrors).toBe('');
@@ -60,8 +59,7 @@ describe('McpServerManager', () => {
     });
     test('with invalid JSON, returns empty array', async () => {
       const mcpServerManager = new McpServerManager(appUserDirectory);
-      const mcpSettingsFile = path.join(appUserDirectory, 'mcp-settings.json');
-      await fs.promises.writeFile(mcpSettingsFile, '{invalid json}');
+      vi.spyOn(fs.promises, 'readFile').mockImplementation(async () => '{invalid json}');
       const mcpServers = await mcpServerManager.load();
       expect(mcpServers).toEqual([]);
       expect(consoleErrors).toContain('McpServerManager: Failed to load MCP settings');
@@ -70,7 +68,6 @@ describe('McpServerManager', () => {
     describe('with valid JSON', () => {
       let mcpServers: McpServer[];
       beforeEach(async () => {
-        const mcpSettingsFile = path.join(appUserDirectory, 'mcp-settings.json');
         const mcpSettings = {
           servers: {
             'stdio-ok': {
@@ -94,7 +91,7 @@ describe('McpServerManager', () => {
             },
           },
         };
-        fs.writeFileSync(mcpSettingsFile, JSON.stringify(mcpSettings));
+        vi.spyOn(fs.promises, 'readFile').mockImplementation(async () => JSON.stringify(mcpSettings));
         mcpServers = await new McpServerManager(appUserDirectory).load();
       });
       test('parses stdio server', async () => {

--- a/packages/backend/src/managers/playground/McpServerManager.spec.ts
+++ b/packages/backend/src/managers/playground/McpServerManager.spec.ts
@@ -1,0 +1,127 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { McpServer } from './McpServerManager';
+import { McpServerType, McpServerManager } from './McpServerManager';
+
+/* eslint-disable sonarjs/no-nested-functions */
+describe('McpServerManager', () => {
+  let appUserDirectory: string;
+  let consoleErrors: string;
+  let consoleWarnings: string;
+  beforeEach(async () => {
+    appUserDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mcp-server-manager-test-'));
+    consoleErrors = '';
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      consoleErrors += args.join(' ') + '\n';
+    });
+    consoleWarnings = '';
+    vi.spyOn(console, 'warn').mockImplementation((...args) => {
+      consoleWarnings += args.join(' ') + '\n';
+    });
+  });
+  afterEach(async () => {
+    await fs.promises.rm(appUserDirectory, { recursive: true });
+  });
+  describe('load', () => {
+    test('with no file, returns empty array', async () => {
+      const mcpServerManager = new McpServerManager(appUserDirectory);
+      const mcpServers = await mcpServerManager.load();
+      expect(mcpServers).toEqual([]);
+      expect(consoleErrors).toContain('McpServerManager: Failed to load MCP settings');
+      expect(consoleWarnings).toBe('');
+    });
+    test('with empty file, returns empty array', async () => {
+      const mcpServerManager = new McpServerManager(appUserDirectory);
+      const mcpSettingsFile = path.join(appUserDirectory, 'mcp-settings.json');
+      await fs.promises.writeFile(mcpSettingsFile, '{}');
+      const mcpServers = await mcpServerManager.load();
+      expect(mcpServers).toEqual([]);
+      expect(consoleErrors).toBe('');
+      expect(consoleWarnings).toBe('');
+    });
+    test('with invalid JSON, returns empty array', async () => {
+      const mcpServerManager = new McpServerManager(appUserDirectory);
+      const mcpSettingsFile = path.join(appUserDirectory, 'mcp-settings.json');
+      await fs.promises.writeFile(mcpSettingsFile, '{invalid json}');
+      const mcpServers = await mcpServerManager.load();
+      expect(mcpServers).toEqual([]);
+      expect(consoleErrors).toContain('McpServerManager: Failed to load MCP settings');
+      expect(consoleWarnings).toBe('');
+    });
+    describe('with valid JSON', () => {
+      let mcpServers: McpServer[];
+      beforeEach(async () => {
+        const mcpSettingsFile = path.join(appUserDirectory, 'mcp-settings.json');
+        const mcpSettings = {
+          servers: {
+            'stdio-ok': {
+              enabled: true,
+              type: 'stdio',
+              command: 'npx',
+              args: ['-y', 'kubernetes-mcp-server'],
+            },
+            'sse-ok': {
+              enabled: true,
+              type: 'sse',
+              url: 'https://echo.example.com/sse',
+              headers: {
+                foo: 'bar',
+              },
+            },
+            'invalid-type': {
+              enabled: true,
+              type: 'invalid',
+              url: 'https://echo.example.com/sse',
+            },
+          },
+        };
+        fs.writeFileSync(mcpSettingsFile, JSON.stringify(mcpSettings));
+        mcpServers = await new McpServerManager(appUserDirectory).load();
+      });
+      test('parses stdio server', async () => {
+        const stdioOk: McpServer | undefined = mcpServers.find(server => server.name === 'stdio-ok');
+        expect(stdioOk).toEqual({
+          name: 'stdio-ok',
+          enabled: true,
+          type: McpServerType.STDIO,
+          command: 'npx',
+          args: ['-y', 'kubernetes-mcp-server'],
+        });
+      });
+      test('parses sse server', async () => {
+        const sseOk: McpServer | undefined = mcpServers.find(server => server.name === 'sse-ok');
+        expect(sseOk).toEqual({
+          name: 'sse-ok',
+          enabled: true,
+          type: McpServerType.SSE,
+          url: 'https://echo.example.com/sse',
+          headers: { foo: 'bar' },
+        });
+      });
+      test('ignores invalid type', async () => {
+        const invalidType: McpServer | undefined = mcpServers.find(server => server.name === 'invalid-type');
+        expect(invalidType).toBeUndefined();
+        expect(consoleWarnings).toContain('McpServerManager: Invalid MCP server type invalid for server invalid-type.');
+      });
+    });
+  });
+});

--- a/packages/backend/src/managers/playground/McpServerManager.ts
+++ b/packages/backend/src/managers/playground/McpServerManager.ts
@@ -1,0 +1,125 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Disposable } from '@podman-desktop/api';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ToolSet } from 'ai';
+import { experimental_createMCPClient as createMCPClient } from 'ai';
+import { Experimental_StdioMCPTransport as StdioClientTransport } from 'ai/mcp-stdio';
+
+// TODO: Agree on the name of the file and its location
+const MCP_SETTINGS = 'mcp-settings.json';
+
+export interface McpSettings {
+  servers: Record<string, McpServer>;
+}
+
+export enum McpServerType {
+  STDIO = 'stdio',
+  SSE = 'sse',
+}
+
+export interface McpServer {
+  name: string;
+  enabled: boolean;
+  type: McpServerType;
+  command: string;
+  args: string[];
+  url: string;
+  headers: Record<string, string>;
+}
+
+export interface McpClient {
+  init(): Promise<this>;
+  close(): Promise<void>;
+  tools(): Promise<ToolSet>;
+}
+
+export async function toMcpClients(...mcpServers: McpServer[]): Promise<McpClient[]> {
+  const clients: McpClient[] = [];
+  for (const server of mcpServers) {
+    switch (server.type) {
+      case McpServerType.SSE:
+        clients.push(
+          await createMCPClient({
+            name: server.name,
+            transport: {
+              type: 'sse',
+              url: server.url,
+              headers: server.headers,
+            },
+          }),
+        );
+        break;
+      case McpServerType.STDIO:
+        clients.push(
+          await createMCPClient({
+            name: server.name,
+            transport: new StdioClientTransport({
+              command: server.command,
+              args: server.args,
+            }),
+          }),
+        );
+        break;
+    }
+  }
+  return clients;
+}
+
+// TODO: Consider using JsonWatcher in case the file is going to be updated externally
+// Depending on the use case, we might want to watch for changes in the settings file.
+// 1. As a user, I want to be able to modify the mcp-settings.json file and have the changes reflected in the application without restarting it.
+// 2. As a user, I want to be able to add/remove servers from the mcp-settings.json while also having the application to provide a UI to manage the servers.
+// 3. As a user, I don't want to tinker with the mcp-settings.json file and would like to have the application to provide a UI to manage the servers.
+// Cases 1 and 2 are covered by JsonWatcher, but case 3 is not.
+// For 2 and 3, we need to implement a UI to manage the servers.
+export class McpServerManager implements Disposable {
+  private readonly settingsFile: string;
+
+  constructor(private appUserDirectory: string) {
+    this.settingsFile = path.join(this.appUserDirectory, MCP_SETTINGS);
+  }
+
+  async load(): Promise<McpServer[]> {
+    const mcpServers: McpServer[] = [];
+    try {
+      const mcpSettingsContent = await fs.promises.readFile(this.settingsFile, 'utf8');
+      const mcpSettings = JSON.parse(mcpSettingsContent) as McpSettings;
+      if (!mcpSettings?.servers) {
+        return mcpServers;
+      }
+      for (const entry of Object.entries(mcpSettings.servers)) {
+        const mcpServer: McpServer = entry[1] as McpServer;
+        mcpServer.name = entry[0];
+        if (!Object.values(McpServerType).includes(mcpServer.type)) {
+          console.warn(`McpServerManager: Invalid MCP server type ${mcpServer.type} for server ${mcpServer.name}.`);
+          continue;
+        }
+        mcpServers.push(mcpServer);
+      }
+    } catch (error: unknown) {
+      console.error(`McpServerManager: Failed to load MCP settings: ${error}`);
+    }
+    return mcpServers;
+  }
+
+  dispose(): void {
+    // NO OP
+  }
+}

--- a/packages/backend/src/managers/playground/aiSdk.ts
+++ b/packages/backend/src/managers/playground/aiSdk.ts
@@ -24,6 +24,7 @@ import type {
   CoreMessage,
   StepResult,
   StreamTextResult,
+  StreamTextOnFinishCallback,
   TextStreamPart,
   ToolCallPart,
   ToolResultPart,
@@ -185,7 +186,7 @@ export class AiStreamProcessor<TOOLS extends ToolSet> {
     }
   };
 
-  private onFinish = (stepResult: Omit<StepResult<TOOLS>, 'stepType' | 'isContinued'>): void => {
+  private onFinish: StreamTextOnFinishCallback<TOOLS> = stepResult => {
     this.conversationRegistry.setUsage(this.conversationId, {
       completion_tokens: stepResult.usage.completionTokens,
       prompt_tokens: stepResult.usage.promptTokens,

--- a/packages/backend/src/managers/playground/aiSdk.ts
+++ b/packages/backend/src/managers/playground/aiSdk.ts
@@ -17,32 +17,72 @@
  ***********************************************************************/
 
 import { streamText } from 'ai';
-import type { LanguageModel, CoreMessage, StepResult, StreamTextResult, TextStreamPart, ToolSet } from 'ai';
-import type { ModelOptions } from '@shared/models/IModelOptions';
 import type {
-  ChatMessage,
-  Choice,
-  ErrorMessage,
-  Message,
-  ModelUsage,
-  PendingChat,
+  CoreAssistantMessage,
+  CoreToolMessage,
+  LanguageModel,
+  CoreMessage,
+  StepResult,
+  StreamTextResult,
+  TextStreamPart,
+  ToolCallPart,
+  ToolResultPart,
+  ToolSet,
+} from 'ai';
+import type { ModelOptions } from '@shared/models/IModelOptions';
+import {
+  type AssistantChat,
+  type ErrorMessage,
+  isAssistantToolCall,
+  type Message,
+  type ModelUsage,
+  type PendingChat,
+  type ToolCall,
 } from '@shared/models/IPlaygroundMessage';
 import { isChatMessage } from '@shared/models/IPlaygroundMessage';
 import type { ConversationRegistry } from '../../registries/ConversationRegistry';
 
 export function toCoreMessage(...messages: Message[]): CoreMessage[] {
-  return messages
-    .filter(m => isChatMessage(m))
-    .map(
-      (message: ChatMessage) =>
-        ({
-          role: message.role,
-          content: message.content ?? '',
-        }) as CoreMessage,
-    );
+  const ret: CoreMessage[] = [];
+  for (const message of messages) {
+    if (isAssistantToolCall(message)) {
+      const toolCall = message.content as ToolCall;
+      ret.push({
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: toolCall.toolCallId,
+            toolName: toolCall.toolName,
+            args: toolCall.args,
+          } as ToolCallPart,
+        ] as ToolCallPart[],
+      } as CoreAssistantMessage);
+      if (toolCall.result) {
+        ret.push({
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              result: toolCall.result,
+            } as ToolResultPart,
+          ] as ToolResultPart[],
+        } as CoreToolMessage);
+      }
+    } else if (isChatMessage(message)) {
+      ret.push({
+        role: message.role,
+        content: message.content ?? '',
+      } as CoreMessage);
+    }
+  }
+  return ret;
 }
 
 export class AiStreamProcessor<TOOLS extends ToolSet> {
+  private stepStartTime: number | undefined;
   private currentMessageId: string | undefined;
   public readonly abortController: AbortController;
 
@@ -55,16 +95,35 @@ export class AiStreamProcessor<TOOLS extends ToolSet> {
   }
 
   private onStepFinish = (stepResult: StepResult<TOOLS>): void => {
+    this.conversationRegistry.setUsage(this.conversationId, {
+      completion_tokens: stepResult.usage.completionTokens,
+      prompt_tokens: stepResult.usage.promptTokens,
+    } as ModelUsage);
     if (this.currentMessageId !== undefined) {
-      this.conversationRegistry.setUsage(this.conversationId, this.currentMessageId, {
-        completion_tokens: stepResult.usage.completionTokens,
-        prompt_tokens: stepResult.usage.promptTokens,
-      } as ModelUsage);
-      // TODO, this doesn't seem very wise (using choices as partial state holder)
-      // Refactor to use this.conversationRegistry.update instead
       this.conversationRegistry.completeMessage(this.conversationId, this.currentMessageId);
     }
+    if (stepResult.toolCalls?.length > 0) {
+      for (const toolCall of stepResult.toolCalls) {
+        this.conversationRegistry.submit(this.conversationId, {
+          id: this.conversationRegistry.getUniqueId(),
+          role: 'assistant',
+          timestamp: this.stepStartTime,
+          content: {
+            type: 'tool-call',
+            toolCallId: toolCall.toolCallId,
+            toolName: toolCall.toolName,
+            args: toolCall.args,
+          } as ToolCall,
+        } as AssistantChat);
+      }
+    }
+    if (stepResult.toolResults?.length > 0) {
+      for (const toolResult of stepResult.toolResults) {
+        this.conversationRegistry.toolResult(this.conversationId, toolResult.toolCallId, toolResult.result);
+      }
+    }
     this.currentMessageId = undefined;
+    this.stepStartTime = Date.now();
   };
 
   private onChunk = ({
@@ -92,16 +151,12 @@ export class AiStreamProcessor<TOOLS extends ToolSet> {
       this.conversationRegistry.submit(this.conversationId, {
         id: this.currentMessageId,
         role: 'assistant',
-        timestamp: Date.now(),
+        timestamp: this.stepStartTime,
         choices: [],
         completed: undefined,
       } as PendingChat);
     }
-    // TODO, this doesn't seem very wise (using choices as partial state holder)
-    // Refactor to use this.conversationRegistry.update instead
-    this.conversationRegistry.appendChoice(this.conversationId, this.currentMessageId, {
-      content: chunk.textDelta,
-    } as Choice);
+    this.conversationRegistry.textDelta(this.conversationId, this.currentMessageId, chunk.textDelta);
   };
 
   private onError = (error: unknown): void => {
@@ -126,15 +181,23 @@ export class AiStreamProcessor<TOOLS extends ToolSet> {
   private onAbort = (): void => {
     // Ensure the last message is marked as complete to allow the user to resume the conversation
     if (this.currentMessageId !== undefined) {
-      // TODO, this doesn't seem very wise (using choices as partial state holder)
-      // Refactor to use this.conversationRegistry.update instead
       this.conversationRegistry.completeMessage(this.conversationId, this.currentMessageId);
     }
   };
 
-  stream = (model: LanguageModel, options?: ModelOptions): StreamTextResult<TOOLS, never> => {
+  private onFinish = (stepResult: Omit<StepResult<TOOLS>, 'stepType' | 'isContinued'>): void => {
+    this.conversationRegistry.setUsage(this.conversationId, {
+      completion_tokens: stepResult.usage.completionTokens,
+      prompt_tokens: stepResult.usage.promptTokens,
+    } as ModelUsage);
+  };
+
+  stream = (model: LanguageModel, tools?: TOOLS, options?: ModelOptions): StreamTextResult<TOOLS, never> => {
+    this.stepStartTime = Date.now();
     return streamText({
       model,
+      tools,
+      maxSteps: 10, // TODO: configurable option
       temperature: options?.temperature,
       maxTokens: (options?.max_tokens ?? -1) < 1 ? undefined : options?.max_tokens,
       topP: options?.top_p,
@@ -143,6 +206,7 @@ export class AiStreamProcessor<TOOLS extends ToolSet> {
       onStepFinish: this.onStepFinish,
       onError: this.onError,
       onChunk: this.onChunk,
+      onFinish: this.onFinish,
     });
   };
 }

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -30,11 +30,16 @@ import { getHash } from '../utils/sha';
 import type { RpcExtension } from '@shared/messages/MessageProxy';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { AiStreamProcessor } from './playground/aiSdk';
+import { McpServerManager, toMcpClients } from './playground/McpServerManager';
+import type { ToolSet } from 'ai';
+import { simulateStreamingMiddleware, wrapLanguageModel } from 'ai';
 
 export class PlaygroundV2Manager implements Disposable {
-  #conversationRegistry: ConversationRegistry;
+  readonly #conversationRegistry: ConversationRegistry;
+  readonly #mcpServerManager: McpServerManager;
 
   constructor(
+    appUserDirectory: string,
     rpcExtension: RpcExtension,
     private inferenceManager: InferenceManager,
     private taskRegistry: TaskRegistry,
@@ -42,6 +47,7 @@ export class PlaygroundV2Manager implements Disposable {
     private cancellationTokenRegistry: CancellationTokenRegistry,
   ) {
     this.#conversationRegistry = new ConversationRegistry(rpcExtension);
+    this.#mcpServerManager = new McpServerManager(appUserDirectory);
   }
 
   deleteConversation(conversationId: string): void {
@@ -220,20 +226,33 @@ export class PlaygroundV2Manager implements Disposable {
       modelId: getHash(modelInfo.id),
     };
 
-    const openAiClient = createOpenAICompatible({
-      name: modelInfo.name,
-      baseURL: `http://localhost:${server.connection.port}/v1`,
-    });
-    const model = openAiClient(modelInfo.name);
     const streamProcessor = new AiStreamProcessor(conversationId, this.#conversationRegistry);
-
     const cancelTokenId = this.cancellationTokenRegistry.createCancellationTokenSource(() => {
       streamProcessor.abortController.abort('cancel');
     });
 
+    const tools: ToolSet = {};
+    const mcpClients = await toMcpClients(...(await this.#mcpServerManager.load()));
+    for (const client of mcpClients) {
+      const clientTools = await client.tools();
+      for (const entry of Object.entries(clientTools)) {
+        tools[entry[0]] = entry[1];
+      }
+    }
+
+    const openAiClient = createOpenAICompatible({
+      name: modelInfo.name,
+      baseURL: `http://localhost:${server.connection.port}/v1`,
+    });
+    let model = openAiClient(modelInfo.name);
+    // Tool calling in OpenAI doesn't support streaming yet
+    if (Object.keys(tools).length > 0) {
+      model = wrapLanguageModel({ model, middleware: simulateStreamingMiddleware() });
+    }
+
     const start = Date.now();
     streamProcessor
-      .stream(model, options)
+      .stream(model, tools, options)
       .consumeStream()
       .then(() => {
         this.telemetry.logUsage('playground.message.complete', {
@@ -247,6 +266,9 @@ export class PlaygroundV2Manager implements Disposable {
       .finally(() => {
         this.telemetry.logUsage('playground.submit', telemetry);
         this.cancellationTokenRegistry.delete(cancelTokenId);
+        Promise.all(mcpClients.map(client => client.close())).catch((e: unknown) =>
+          console.error(`Error closing MCP client`, e),
+        );
       });
 
     return cancelTokenId;

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -30,9 +30,10 @@ import { getHash } from '../utils/sha';
 import type { RpcExtension } from '@shared/messages/MessageProxy';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { AiStreamProcessor } from './playground/aiSdk';
-import { McpServerManager, toMcpClients } from './playground/McpServerManager';
+import { McpServerManager } from './playground/McpServerManager';
 import type { ToolSet } from 'ai';
 import { simulateStreamingMiddleware, wrapLanguageModel } from 'ai';
+import { toMcpClients } from '../utils/mcpUtils';
 
 export class PlaygroundV2Manager implements Disposable {
   readonly #conversationRegistry: ConversationRegistry;

--- a/packages/backend/src/models/mcpTypes.ts
+++ b/packages/backend/src/models/mcpTypes.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ToolSet } from 'ai';
+
+export interface McpSettings {
+  servers: Record<string, McpServer>;
+}
+
+export enum McpServerType {
+  STDIO = 'stdio',
+  SSE = 'sse',
+}
+
+export interface McpServer {
+  name: string;
+  enabled: boolean;
+  type: McpServerType;
+  command: string;
+  args: string[];
+  url: string;
+  headers: Record<string, string>;
+}
+
+export interface McpClient {
+  init(): Promise<this>;
+  close(): Promise<void>;
+  tools(): Promise<ToolSet>;
+}

--- a/packages/backend/src/registries/ConversationRegistry.ts
+++ b/packages/backend/src/registries/ConversationRegistry.ts
@@ -154,7 +154,7 @@ export class ConversationRegistry extends Publisher<Conversation[]> implements D
   }
 
   /**
-   *
+   * Utility method to quickly add a tool-call assistant message to a conversation
    */
   toolResult(conversationId: string, toolCallId: string, toolResult: string | object): void {
     const conversation: Conversation = this.get(conversationId);

--- a/packages/backend/src/registries/ConversationRegistry.ts
+++ b/packages/backend/src/registries/ConversationRegistry.ts
@@ -125,9 +125,6 @@ export class ConversationRegistry extends Publisher<Conversation[]> implements D
    */
   setUsage(conversationId: string, usage: ModelUsage): void {
     const conversation: Conversation = this.get(conversationId);
-    if (!usage) {
-      return;
-    }
     this.#conversations.set(conversationId, {
       ...conversation,
       usage,

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -355,6 +355,7 @@ export class Studio {
      * PlaygroundV2Manager handle the conversations of the Playground by using the InferenceServer available
      */
     this.#playgroundManager = new PlaygroundV2Manager(
+      appUserDirectory,
       this.#rpcExtension,
       this.#inferenceManager,
       this.#taskRegistry,

--- a/packages/backend/src/utils/mcpUtils.ts
+++ b/packages/backend/src/utils/mcpUtils.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { experimental_createMCPClient as createMCPClient } from 'ai';
+import { Experimental_StdioMCPTransport as StdioClientTransport } from 'ai/mcp-stdio';
+import { type McpClient, type McpServer, McpServerType } from '../models/mcpTypes';
+
+export async function toMcpClients(...mcpServers: McpServer[]): Promise<McpClient[]> {
+  const clients: McpClient[] = [];
+  for (const server of mcpServers) {
+    switch (server.type) {
+      case McpServerType.SSE:
+        clients.push(
+          await createMCPClient({
+            name: server.name,
+            transport: {
+              type: 'sse',
+              url: server.url,
+              headers: server.headers,
+            },
+          }),
+        );
+        break;
+      case McpServerType.STDIO:
+        clients.push(
+          await createMCPClient({
+            name: server.name,
+            transport: new StdioClientTransport({
+              command: server.command,
+              args: server.args,
+            }),
+          }),
+        );
+        break;
+    }
+  }
+  return clients;
+}

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "lib": ["ES2017", "webworker", "dom"],
     "sourceMap": true,

--- a/packages/frontend/src/lib/conversation/ChatMessage.svelte
+++ b/packages/frontend/src/lib/conversation/ChatMessage.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import {
-  type AssistantChat,
   type ChatMessage,
   isAssistantChat,
-  isPendingChat,
+  isAssistantToolCall,
   isSystemPrompt,
   isUserChat,
 } from '@shared/models/IPlaygroundMessage';
+import ElapsedTime from '/@/lib/conversation/ElapsedTime.svelte';
 
 export let message: ChatMessage;
 
@@ -17,30 +17,10 @@ const roles = {
 };
 
 function getMessageParagraphs(message: ChatMessage): string[] {
-  if (isAssistantChat(message)) {
-    if (!isPendingChat(message)) {
-      return message.content?.split('\n') ?? [];
-    } else {
-      return message.choices
-        .map(choice => choice.content)
-        .join('')
-        .split('\n');
-    }
-  } else if (isUserChat(message) || isSystemPrompt(message)) {
-    return message.content?.split('\n') ?? [];
+  if (!isAssistantToolCall(message)) {
+    return (message.content as string)?.split('\n') ?? [];
   }
   return [];
-}
-
-function elapsedTime(msg: AssistantChat): string {
-  if (isPendingChat(msg)) {
-    return ((Date.now() - msg.timestamp) / 1000).toFixed(1);
-  } else if (msg.completed) {
-    return ((msg.completed - msg.timestamp) / 1000).toFixed(1);
-  } else {
-    // should not happen
-    return '';
-  }
 }
 </script>
 
@@ -59,10 +39,6 @@ function elapsedTime(msg: AssistantChat): string {
       <p>{paragraph}</p>
     {/each}
   </div>
-  {#if isAssistantChat(message)}
-    <div class="text-[var(--pd-content-header)] text-right" aria-label="elapsed">
-      {elapsedTime(message)} s
-    </div>
-  {/if}
+  <ElapsedTime message={message} />
   <div></div>
 </div>

--- a/packages/frontend/src/lib/conversation/ElapsedTime.svelte
+++ b/packages/frontend/src/lib/conversation/ElapsedTime.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import {
+  type AssistantChat,
+  type ChatMessage,
+  isAssistantChat,
+  isPendingChat,
+} from '@shared/models/IPlaygroundMessage';
+
+export let message: ChatMessage;
+
+function elapsedTime(msg: AssistantChat): string {
+  if (isPendingChat(msg)) {
+    return ((Date.now() - msg.timestamp) / 1000).toFixed(1);
+  } else if (msg.completed) {
+    return ((msg.completed - msg.timestamp) / 1000).toFixed(1);
+  } else {
+    // should not happen
+    return '';
+  }
+}
+</script>
+
+{#if isAssistantChat(message)}
+  <div class="text-[var(--pd-content-header)] text-right select-none" aria-label="elapsed">
+    {elapsedTime(message)} s
+  </div>
+{/if}

--- a/packages/frontend/src/lib/conversation/SystemPromptBanner.spec.ts
+++ b/packages/frontend/src/lib/conversation/SystemPromptBanner.spec.ts
@@ -22,6 +22,7 @@ import { expect, test, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import SystemPromptBanner from '/@/lib/conversation/SystemPromptBanner.svelte';
 import { studioClient } from '/@/utils/client';
+import type { SystemPrompt } from '@shared/models/IPlaygroundMessage';
 
 vi.mock('../../utils/client', async () => {
   return {
@@ -40,6 +41,8 @@ test('render empty conversation, hidden textarea', () => {
   render(SystemPromptBanner, {
     conversation: {
       id: 'dummyId',
+      modelId: 'dummyModelId',
+      name: 'dummyName',
       messages: [],
     },
   });
@@ -55,6 +58,8 @@ test('empty conversation click on edit should reveal textarea', async () => {
   render(SystemPromptBanner, {
     conversation: {
       id: 'dummyId',
+      modelId: 'dummyModelId',
+      name: 'dummyName',
       messages: [],
     },
   });
@@ -71,6 +76,8 @@ test('input in textarea should be sent to backend when valid click', async () =>
   render(SystemPromptBanner, {
     conversation: {
       id: 'dummyId',
+      modelId: 'dummyModelId',
+      name: 'dummyName',
       messages: [],
     },
   });
@@ -94,6 +101,8 @@ test('error message should be visible if submit empty', async () => {
   render(SystemPromptBanner, {
     conversation: {
       id: 'dummyId',
+      modelId: 'dummyModelId',
+      name: 'dummyName',
       messages: [],
     },
   });
@@ -118,6 +127,8 @@ test('clear button should reset editing state', async () => {
   render(SystemPromptBanner, {
     conversation: {
       id: 'dummyId',
+      modelId: 'dummyModelId',
+      name: 'dummyName',
       messages: [],
     },
   });
@@ -142,13 +153,15 @@ test('clear button should set system prompt undefined if already exist', async (
   render(SystemPromptBanner, {
     conversation: {
       id: 'dummyId',
+      modelId: 'dummyModelId',
+      name: 'dummyName',
       messages: [
         {
           id: 'random',
           content: 'existing',
           role: 'system',
           timestamp: 0,
-        },
+        } as SystemPrompt,
       ],
     },
   });
@@ -173,6 +186,8 @@ test('error message should be cleared if input change', async () => {
   render(SystemPromptBanner, {
     conversation: {
       id: 'dummyId',
+      modelId: 'dummyModelId',
+      name: 'dummyName',
       messages: [],
     },
   });

--- a/packages/frontend/src/lib/conversation/ToolCallMessage.spec.ts
+++ b/packages/frontend/src/lib/conversation/ToolCallMessage.spec.ts
@@ -15,113 +15,113 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { expect, test, beforeEach, describe } from 'vitest';
+import { expect, test, beforeEach, describe, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, within } from '@testing-library/svelte';
 import ToolCallMessage from '/@/lib/conversation/ToolCallMessage.svelte';
 
-describe('ToolCallMessage component', () => {
-  let container: HTMLElement;
-  describe('with result', () => {
-    beforeEach(() => {
-      container = render(ToolCallMessage, {
-        message: {
-          id: '1337',
-          timestamp: Date.now() - 500,
-          completed: Date.now(),
-          role: 'assistant',
-          content: {
-            type: 'tool-call',
-            toolCallId: '1-1',
-            toolName: 'weather',
-            args: { location: 'Don Benito' },
-            result: {
-              content: [{ type: 'text', text: 'The weather in Don Benito is sunny with a temperature of 25°C.' }],
-            },
+let container: HTMLElement;
+describe('with result', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    container = render(ToolCallMessage, {
+      message: {
+        id: '1337',
+        timestamp: Date.now() - 500,
+        completed: Date.now(),
+        role: 'assistant',
+        content: {
+          type: 'tool-call',
+          toolCallId: '1-1',
+          toolName: 'weather',
+          args: { location: 'Don Benito' },
+          result: {
+            content: [{ type: 'text', text: 'The weather in Don Benito is sunny with a temperature of 25°C.' }],
           },
         },
-      }).container;
-    });
-    test('Has role', () => {
-      const role = within(container).getByTestId('tool-call-role');
-      expect(role?.textContent).toBe('Assistant');
-    });
-    test('Has summary', () => {
-      const summary = within(container).getByTestId('tool-call-summary');
-      expect(summary?.textContent).toMatch(/Used tool: weather/);
-    });
-    test('Details are hidden by default', () => {
-      const result = within(container).getByTestId('tool-call-details');
-      expect(Array.from(result?.classList)).contains('h-0');
-    });
-    test('Has arguments', () => {
-      const args = within(container).getByTestId('tool-call-arguments');
-      expect(args?.textContent).toBe('{\n' + '  "location": "Don Benito"\n' + '}');
-    });
-    test('Has result', () => {
-      const result = within(container).getByTestId('tool-call-result');
-      expect(result?.textContent).toBe(
-        '{\n' +
-          '  "content": [\n' +
-          '    {\n' +
-          '      "type": "text",\n' +
-          '      "text": "The weather in Don Benito is sunny with a temperature of 25°C."\n' +
-          '    }\n' +
-          '  ]\n' +
-          '}',
-      );
-    });
-    test('Has toggle button', () => {
-      const toggleButton = within(container).getByTestId('tool-call-show-details');
-      expect(toggleButton).toBeDefined();
-    });
-    test('Clicking toggle button shows details', async () => {
-      const toggleButton = within(container).getByTestId('tool-call-show-details');
-      await fireEvent.click(toggleButton);
-      const result = within(container).getByTestId('tool-call-details');
-      expect(Array.from(result?.classList)).not.contains('h-0');
-      expect(Array.from(result?.classList)).contains('h-fit');
-    });
-    test('Has elapsed time', () => {
-      const elapsedTime = within(container).getByText('0.5 s');
-      expect(elapsedTime.ariaLabel).toBe('elapsed');
-      expect(elapsedTime).toBeDefined();
-    });
+      },
+    }).container;
   });
-  describe('without result', () => {
-    beforeEach(() => {
-      container = render(ToolCallMessage, {
-        message: {
-          id: '1337',
-          timestamp: Date.now() - 500,
-          role: 'assistant',
-          content: {
-            type: 'tool-call',
-            toolCallId: '1-1',
-            toolName: 'weather',
-            args: { location: 'Don Benito' },
-          },
+  test('Has role', () => {
+    const role = within(container).getByTestId('tool-call-role');
+    expect(role).toHaveTextContent('Assistant');
+  });
+  test('Has summary', () => {
+    const summary = within(container).getByTestId('tool-call-summary');
+    expect(summary).toHaveTextContent(/Used tool: weather/);
+  });
+  test('Details are hidden by default', () => {
+    const result = within(container).getByTestId('tool-call-details');
+    expect(result).toHaveClass('h-0');
+  });
+  test('Has arguments', () => {
+    const args = within(container).getByTestId('tool-call-arguments');
+    expect(args?.textContent).toBe('{\n' + '  "location": "Don Benito"\n' + '}');
+  });
+  test('Has result', () => {
+    const result = within(container).getByTestId('tool-call-result');
+    expect(result?.textContent).toBe(
+      '{\n' +
+        '  "content": [\n' +
+        '    {\n' +
+        '      "type": "text",\n' +
+        '      "text": "The weather in Don Benito is sunny with a temperature of 25°C."\n' +
+        '    }\n' +
+        '  ]\n' +
+        '}',
+    );
+  });
+  test('Has toggle button', () => {
+    const toggleButton = within(container).getByTestId('tool-call-show-details');
+    expect(toggleButton).toBeDefined();
+  });
+  test('Clicking toggle button shows details', async () => {
+    const toggleButton = within(container).getByTestId('tool-call-show-details');
+    await fireEvent.click(toggleButton);
+    const result = within(container).getByTestId('tool-call-details');
+    expect(result).not.toHaveClass('h-0');
+    expect(result).toHaveClass('h-fit');
+  });
+  test('Has elapsed time', () => {
+    const elapsedTime = within(container).getByText('0.5 s');
+    expect(elapsedTime.ariaLabel).toBe('elapsed');
+    expect(elapsedTime).toBeDefined();
+  });
+});
+describe('without result', () => {
+  beforeEach(() => {
+    container = render(ToolCallMessage, {
+      message: {
+        id: '1337',
+        timestamp: Date.now() - 500,
+        role: 'assistant',
+        content: {
+          type: 'tool-call',
+          toolCallId: '1-1',
+          toolName: 'weather',
+          args: { location: 'Don Benito' },
         },
-      }).container;
-    });
-    test('Has role', () => {
-      const role = within(container).getByTestId('tool-call-role');
-      expect(role?.textContent).toBe('Assistant');
-    });
-    test('Has summary', () => {
-      const summary = within(container).getByTestId('tool-call-summary');
-      expect(summary?.textContent).toMatch(/Used tool: weather/);
-    });
-    test('Details are hidden by default', () => {
-      const result = within(container).getByTestId('tool-call-details');
-      expect(Array.from(result?.classList)).contains('h-0');
-    });
-    test('Has arguments', () => {
-      const args = within(container).getByTestId('tool-call-arguments');
-      expect(args?.textContent).toBe('{\n' + '  "location": "Don Benito"\n' + '}');
-    });
-    test('Does not have result', () => {
-      const result = within(container).queryByTestId('tool-call-result');
-      expect(result).toBeNull();
-    });
+      },
+    }).container;
+  });
+  test('Has role', () => {
+    const role = within(container).getByTestId('tool-call-role');
+    expect(role).toHaveTextContent('Assistant');
+  });
+  test('Has summary', () => {
+    const summary = within(container).getByTestId('tool-call-summary');
+    expect(summary).toHaveTextContent(/Used tool: weather/);
+  });
+  test('Details are hidden by default', () => {
+    const result = within(container).getByTestId('tool-call-details');
+    expect(result).toHaveClass('h-0');
+  });
+  test('Has arguments', () => {
+    const args = within(container).getByTestId('tool-call-arguments');
+    expect(args?.textContent).toBe('{\n' + '  "location": "Don Benito"\n' + '}');
+  });
+  test('Does not have result', () => {
+    const result = within(container).queryByTestId('tool-call-result');
+    expect(result).toBeNull();
   });
 });

--- a/packages/frontend/src/lib/conversation/ToolCallMessage.spec.ts
+++ b/packages/frontend/src/lib/conversation/ToolCallMessage.spec.ts
@@ -1,0 +1,127 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { expect, test, beforeEach, describe } from 'vitest';
+import { fireEvent, render, within } from '@testing-library/svelte';
+import ToolCallMessage from '/@/lib/conversation/ToolCallMessage.svelte';
+
+describe('ToolCallMessage component', () => {
+  let container: HTMLElement;
+  describe('with result', () => {
+    beforeEach(() => {
+      container = render(ToolCallMessage, {
+        message: {
+          id: '1337',
+          timestamp: Date.now() - 500,
+          completed: Date.now(),
+          role: 'assistant',
+          content: {
+            type: 'tool-call',
+            toolCallId: '1-1',
+            toolName: 'weather',
+            args: { location: 'Don Benito' },
+            result: {
+              content: [{ type: 'text', text: 'The weather in Don Benito is sunny with a temperature of 25°C.' }],
+            },
+          },
+        },
+      }).container;
+    });
+    test('Has role', () => {
+      const role = within(container).getByTestId('tool-call-role');
+      expect(role?.textContent).toBe('Assistant');
+    });
+    test('Has summary', () => {
+      const summary = within(container).getByTestId('tool-call-summary');
+      expect(summary?.textContent).toMatch(/Used tool: weather/);
+    });
+    test('Details are hidden by default', () => {
+      const result = within(container).getByTestId('tool-call-details');
+      expect(Array.from(result?.classList)).contains('h-0');
+    });
+    test('Has arguments', () => {
+      const args = within(container).getByTestId('tool-call-arguments');
+      expect(args?.textContent).toBe('{\n' + '  "location": "Don Benito"\n' + '}');
+    });
+    test('Has result', () => {
+      const result = within(container).getByTestId('tool-call-result');
+      expect(result?.textContent).toBe(
+        '{\n' +
+          '  "content": [\n' +
+          '    {\n' +
+          '      "type": "text",\n' +
+          '      "text": "The weather in Don Benito is sunny with a temperature of 25°C."\n' +
+          '    }\n' +
+          '  ]\n' +
+          '}',
+      );
+    });
+    test('Has toggle button', () => {
+      const toggleButton = within(container).getByTestId('tool-call-show-details');
+      expect(toggleButton).toBeDefined();
+    });
+    test('Clicking toggle button shows details', async () => {
+      const toggleButton = within(container).getByTestId('tool-call-show-details');
+      await fireEvent.click(toggleButton);
+      const result = within(container).getByTestId('tool-call-details');
+      expect(Array.from(result?.classList)).not.contains('h-0');
+      expect(Array.from(result?.classList)).contains('h-fit');
+    });
+    test('Has elapsed time', () => {
+      const elapsedTime = within(container).getByText('0.5 s');
+      expect(elapsedTime.ariaLabel).toBe('elapsed');
+      expect(elapsedTime).toBeDefined();
+    });
+  });
+  describe('without result', () => {
+    beforeEach(() => {
+      container = render(ToolCallMessage, {
+        message: {
+          id: '1337',
+          timestamp: Date.now() - 500,
+          role: 'assistant',
+          content: {
+            type: 'tool-call',
+            toolCallId: '1-1',
+            toolName: 'weather',
+            args: { location: 'Don Benito' },
+          },
+        },
+      }).container;
+    });
+    test('Has role', () => {
+      const role = within(container).getByTestId('tool-call-role');
+      expect(role?.textContent).toBe('Assistant');
+    });
+    test('Has summary', () => {
+      const summary = within(container).getByTestId('tool-call-summary');
+      expect(summary?.textContent).toMatch(/Used tool: weather/);
+    });
+    test('Details are hidden by default', () => {
+      const result = within(container).getByTestId('tool-call-details');
+      expect(Array.from(result?.classList)).contains('h-0');
+    });
+    test('Has arguments', () => {
+      const args = within(container).getByTestId('tool-call-arguments');
+      expect(args?.textContent).toBe('{\n' + '  "location": "Don Benito"\n' + '}');
+    });
+    test('Does not have result', () => {
+      const result = within(container).queryByTestId('tool-call-result');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/frontend/src/lib/conversation/ToolCallMessage.svelte
+++ b/packages/frontend/src/lib/conversation/ToolCallMessage.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+import { type AssistantChat, type ToolCall } from '@shared/models/IPlaygroundMessage';
+import ElapsedTime from '/@/lib/conversation/ElapsedTime.svelte';
+
+interface Props {
+  message: AssistantChat;
+}
+let { message }: Props = $props();
+let toolCall = $derived(message.content as ToolCall);
+let result: string | object | undefined = $derived(toolCall?.result);
+
+let open: boolean = $state(false);
+const toggle = (): void => {
+  open = !open;
+};
+</script>
+
+<div>
+  <div data-testid="tool-call-role" class="text-[var(--pd-content-header)] text-right">Assistant</div>
+  <div
+    data-testid="tool-call-container"
+    class="p-4 rounded-md text-[var(--pd-content-card-text)] bg-[var(--pd-content-card-inset-bg)] ml-8 flex flex-col">
+    <div data-testid="tool-call-summary" class="flex gap-1.5 justify-items-center">
+      <i class="fa-solid fa-wrench before:h-full before:flex before:items-center"></i>
+      <span>Used tool:</span>
+      <strong>{toolCall.toolName}</strong>
+      <div class="flex-grow"></div>
+      <button
+        data-testid="tool-call-show-details"
+        onclick={toggle}
+        aria-label="Show tool details"
+        title="Show tool details">
+        <i
+          class="fas text-[var(--pd-content-card-icon)] fa-angle-up transition-all before:h-full before:flex before:items-center"
+          class:rotate-180={open}></i>
+      </button>
+    </div>
+    <div
+      data-testid="tool-call-details"
+      class="overflow-hidden transition-[height]"
+      class:mt-2={open}
+      class:h-fit={open}
+      class:h-0={!open}
+      style="interpolate-size: allow-keywords">
+      <div>Arguments</div>
+      <pre data-testid="tool-call-arguments" class="text-xs p-1">{JSON.stringify(
+          toolCall.args,
+          undefined,
+          2,
+        ).trim()}</pre>
+      {#if toolCall?.result}
+        <div>Result</div>
+        <pre data-testid="tool-call-result" class="text-xs p-1">{typeof result === 'string'
+            ? result.trim()
+            : JSON.stringify(toolCall.result, undefined, 2).trim()}</pre>
+      {/if}
+    </div>
+  </div>
+  <ElapsedTime message={message} />
+</div>

--- a/packages/frontend/src/pages/Playground.spec.ts
+++ b/packages/frontend/src/pages/Playground.spec.ts
@@ -23,7 +23,7 @@ import Playground from './Playground.svelte';
 import { studioClient } from '../utils/client';
 import type { ModelInfo } from '@shared/models/IModelInfo';
 import { fireEvent } from '@testing-library/dom';
-import type { AssistantChat, Conversation, PendingChat, UserChat } from '@shared/models/IPlaygroundMessage';
+import type { AssistantChat, Conversation, ModelUsage, PendingChat, UserChat } from '@shared/models/IPlaygroundMessage';
 import * as conversationsStore from '/@/stores/conversations';
 import * as inferenceServersStore from '/@/stores/inferenceServers';
 import { readable, writable } from 'svelte/store';
@@ -65,6 +65,7 @@ const customConversations = writable<Conversation[]>([
     name: 'Playground 1',
     modelId: 'model-1',
     messages: [],
+    usage: {} as ModelUsage,
   },
 ]);
 
@@ -244,6 +245,7 @@ test('receiving complete message should enable the input element', async () => {
           completed: Date.now(),
         } as AssistantChat,
       ],
+      usage: {} as ModelUsage,
     },
   ]);
 
@@ -284,10 +286,11 @@ test('sending prompt should display the prompt and the response', async () => {
         {
           role: 'assistant',
           id: 'message-2',
-          choices: [{ content: 'a ' }, { content: 'response ' }, { content: 'from ' }, { content: 'the ' }],
+          content: 'a response from the ',
           completed: false,
         } as unknown as PendingChat,
       ],
+      usage: {} as ModelUsage,
     },
   ]);
 
@@ -315,6 +318,7 @@ test('sending prompt should display the prompt and the response', async () => {
           completed: Date.now(),
         } as AssistantChat,
       ],
+      usage: {} as ModelUsage,
     },
   ]);
 

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -8,6 +8,7 @@ import {
   isSystemPrompt,
   isChatMessage,
   isErrorMessage,
+  isAssistantToolCall,
 } from '@shared/models/IPlaygroundMessage';
 import { catalog } from '../stores/catalog';
 import ContentDetailsLayout from '../lib/ContentDetailsLayout.svelte';
@@ -22,6 +23,7 @@ import { Button, Tooltip, DetailsPage, StatusIcon } from '@podman-desktop/ui-sve
 import { router } from 'tinro';
 import ConversationActions from '../lib/conversation/ConversationActions.svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
+import ToolCallMessage from '/@/lib/conversation/ToolCallMessage.svelte';
 
 interface Props {
   playgroundId: string;
@@ -44,8 +46,8 @@ let messages = $derived(
   conversation?.messages.filter(message => isChatMessage(message)).filter(message => !isSystemPrompt(message)) ?? [],
 );
 let model = $derived($catalog.models.find(model => model.id === conversation?.modelId));
-let completion_tokens = $derived(messages.findLast(message => message.usage)?.usage?.completion_tokens ?? 0);
-let prompt_tokens = $derived(messages.findLast(message => message.usage)?.usage?.prompt_tokens ?? 0);
+let completion_tokens = $derived(conversation?.usage?.completion_tokens ?? 0);
+let prompt_tokens = $derived(conversation?.usage?.prompt_tokens ?? 0);
 
 let inProgress = $state(false);
 let sendEnabled = $derived.by(() => {
@@ -228,7 +230,11 @@ function handleOnClick(): void {
                       <ul>
                         {#each messages as message (message.id)}
                           <li>
-                            <ChatMessage message={message} />
+                            {#if isAssistantToolCall(message)}
+                              <ToolCallMessage message={message} />
+                            {:else}
+                              <ChatMessage message={message} />
+                            {/if}
                           </li>
                         {/each}
                       </ul>

--- a/packages/shared/src/models/IPlaygroundMessage.ts
+++ b/packages/shared/src/models/IPlaygroundMessage.ts
@@ -34,13 +34,13 @@ export interface ModelUsage {
 
 export interface ChatMessage extends Message {
   role: 'system' | 'user' | 'assistant';
-  content?: string;
-  usage?: ModelUsage;
+  content?: string | object;
 }
 
 export interface AssistantChat extends ChatMessage {
   role: 'assistant';
   completed?: number;
+  content?: string | ToolCall;
 }
 
 export interface SystemPrompt extends ChatMessage {
@@ -63,10 +63,19 @@ export interface Conversation {
   messages: Message[];
   modelId: string;
   name: string;
+  usage?: ModelUsage;
 }
 
 export interface Choice {
   content: string;
+}
+
+export interface ToolCall {
+  type: 'tool-call';
+  toolCallId: string;
+  toolName: string;
+  args: object;
+  result?: string | object;
 }
 
 export function isErrorMessage(msg: Message): msg is ErrorMessage {
@@ -79,6 +88,10 @@ export function isChatMessage(msg: Message): msg is ChatMessage {
 
 export function isAssistantChat(msg: Message): msg is AssistantChat {
   return isChatMessage(msg) && msg.role === 'assistant';
+}
+
+export function isAssistantToolCall(msg: Message): msg is AssistantChat {
+  return isAssistantChat(msg) && (msg.content as ToolCall)?.type === 'tool-call';
 }
 
 export function isUserChat(msg: Message): msg is UserChat {


### PR DESCRIPTION
### What does this PR do?

Adds Model Context Protocol (MCP) support to the playground.

#### Notes

- The presence of the `~/.local/share/containers/podman-desktop/extensions-storage/redhat.ai-lab/mcp-settings.json` file acts as a feature flag.
  - Adding/removing the file or renaming it will enable or disable the feature.
- Streaming is not supported when using tool/function calling with the OpenAI compatible inference servers.
  - I've added streaming emulation, but the UX is not great in the current state.
  - I'd suggest to add some sort of animation in the chat that tells the user that the model is working.
    (I can implement this as a subsequent PR so we can comment on it).
- This feature will only work with the **Granite 3.3 model**.
  I can improve other models to support it too, but will require additional work.
- In the demos I'm using a very simple MCP server that gets the current time at different timezones: https://github.com/modelcontextprotocol/servers/tree/main/src/time
- Adding MCP servers that provide multiple tools/functions will not work since the model context is very limited and can't be configured at the moment.
- Even if the model context is improved, will still won't work as smooth as other inference servers (such as Ollama).
  I assume that the limited amount of memory while running the server in a Podman container is what affects the performance. The end result is that chat completions that take seconds in Ollama, end up taking minutes when run within the container.

### Screenshot / video of UI

#### With the feature enabled

https://github.com/user-attachments/assets/78cb8963-80b1-4d6f-845b-7d1fec495b5f

#### With the feature disabled (nothing should be broken)

https://github.com/user-attachments/assets/d3f9a7fd-4bfd-4371-afd3-0bc1b72a0033

### What issues does this PR fix or reference?

- Fixes #2884
- Supersedes #2916

### How to test this PR?

- Create a file `~/.local/share/containers/podman-desktop/extensions-storage/redhat.ai-lab/mcp-settings.json`.
- Add the following content to the file:
  ```json
  {
    "servers": {
      "time": {
        "enabled": true,
        "type": "stdio",
        "command": "podman",
        "args": ["run", "-i", "--rm", "docker.io/mcp/time"]
      }
    }
  }
  ```
- Create a new playground and select the `ibm-granite/granite-3.3-8b-instruct-GGUF` model.
- Write a prompt that makes use of one of the MCP server's functions:
  ```
  Get the time in the Paris timezone
  ```
- Continue to chat to ensure follow-ups work
