### PR TITLE
chore(ci): run junit reporter always

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -279,8 +279,9 @@ jobs:
 
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v5
+      if: always()
       with:
-        annotate_only: false
+        annotate_only: true
         fail_on_failure: true
         include_passed: true
         detailed_summary: true

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -135,8 +135,9 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-          annotate_only: false
+          annotate_only: true
           fail_on_failure: true
           include_passed: true
           detailed_summary: true

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -165,8 +165,9 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
-          annotate_only: false
+          annotate_only: true
           fail_on_failure: true
           include_passed: true
           detailed_summary: true

--- a/.github/workflows/ramalama.yaml
+++ b/.github/workflows/ramalama.yaml
@@ -131,6 +131,7 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
+        if: always()
         with:
           annotate_only: true
           fail_on_failure: true


### PR DESCRIPTION
### What does this PR do?
Runs junit reporter always, especially when there are test failures to be details summary.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#2953 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
PR check should show summary of test results even if there is a failure.
<!-- Please explain steps to reproduce -->
