### PR TITLE
fix(playground): duplicate chat messages can be displayed

### DIFF
--- a/packages/frontend/src/lib/conversation/ChatMessage.svelte
+++ b/packages/frontend/src/lib/conversation/ChatMessage.svelte
@@ -35,7 +35,7 @@ function getMessageParagraphs(message: ChatMessage): string[] {
     class:bg-[var(--pd-content-card-inset-bg)]={isAssistantChat(message)}
     class:ml-8={isAssistantChat(message)}
     class:mr-8={isUserChat(message)}>
-    {#each getMessageParagraphs(message) as paragraph (paragraph)}
+    {#each getMessageParagraphs(message) as paragraph, idx (`${idx}-paragraph`)}
       <p>{paragraph}</p>
     {/each}
   </div>

--- a/packages/frontend/src/lib/conversation/ChatMessage.svelte
+++ b/packages/frontend/src/lib/conversation/ChatMessage.svelte
@@ -35,7 +35,7 @@ function getMessageParagraphs(message: ChatMessage): string[] {
     class:bg-[var(--pd-content-card-inset-bg)]={isAssistantChat(message)}
     class:ml-8={isAssistantChat(message)}
     class:mr-8={isUserChat(message)}>
-    {#each getMessageParagraphs(message) as paragraph, idx (`${idx}-paragraph`)}
+    {#each getMessageParagraphs(message) as paragraph, index (index)}
       <p>{paragraph}</p>
     {/each}
   </div>

--- a/packages/frontend/src/pages/Playground.spec.ts
+++ b/packages/frontend/src/pages/Playground.spec.ts
@@ -314,7 +314,7 @@ test('sending prompt should display the prompt and the response', async () => {
         {
           role: 'assistant',
           id: 'message-2',
-          content: 'a response from the assistant',
+          content: 'a response from the assistant\neat, sleep, code, repeat\neat, sleep, code, repeat',
           completed: Date.now(),
         } as AssistantChat,
       ],


### PR DESCRIPTION
### What does this PR do?

When a Chat message contains lines with the same content (or multiple empty lines), Svelte fails because it contains duplicate keys.

This fix adds an artificial key based on the index of the paragraph. Maybe completely replacing getMessageParagraphs with something else can be considered in the future.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/1760ab50-553a-4f9d-8f2b-27d9e11c1c6a)

### What issues does this PR fix or reference?

n/a

### How to test this PR?

Create a playground and ask the model to repeat something, for example `Repeat the following "Hello" 10 times, once per line`.
