### PR TITLE
fix: do not display instructions block when no info to display

### DIFF
--- a/packages/frontend/src/pages/llama-stack/StartLlamaStackContainer.spec.ts
+++ b/packages/frontend/src/pages/llama-stack/StartLlamaStackContainer.spec.ts
@@ -26,6 +26,7 @@ import { VMType } from '@shared/models/IPodman';
 import userEvent from '@testing-library/user-event';
 import * as tasks from '/@/stores/tasks';
 import { writable } from 'svelte/store';
+import { tick } from 'svelte';
 
 vi.mock('../../stores/tasks', async () => {
   return {
@@ -79,6 +80,22 @@ test('start button should be displayed if no Llama Stack container', async () =>
 
   const startBtn = screen.getByTitle('Start Llama Stack container');
   expect(startBtn).toBeDefined();
+});
+
+test('Instructions block should not be displayed if no Llama Stack container', async () => {
+  render(StartLlamaStackContainer);
+
+  await tick();
+  const instructions = screen.queryByText('Instructions');
+  expect(instructions).not.toBeInTheDocument();
+});
+
+test('Instructions block should be displayed if Llama Stack container is found', async () => {
+  vi.mocked(llamaStackClient.getLlamaStackContainerInfo).mockResolvedValue({ containerId: 'containerId', port: 10000 });
+  render(StartLlamaStackContainer);
+
+  await tick();
+  screen.getByText('Instructions');
 });
 
 test('start button should be displayed and enabled', async () => {

--- a/packages/frontend/src/pages/llama-stack/StartLlamaStackContainer.svelte
+++ b/packages/frontend/src/pages/llama-stack/StartLlamaStackContainer.svelte
@@ -111,36 +111,40 @@ function openLink(url: string): void {
         tasks={$tasks} />
 
       <!-- form -->
-      <div class="bg-[var(--pd-content-card-bg)] m-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg h-fit">
-        <div class="w-full text-[var(--pd-details-body-text)]">
-          <!-- container provider connection input -->
-          {#if startedContainerProviderConnectionInfo.length > 1}
-            <label for="" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
-              >Container engine</label>
-            <ContainerProviderConnectionSelect
-              bind:value={containerProviderConnection}
-              containerProviderConnections={startedContainerProviderConnectionInfo} />
-          {/if}
+      {#if startedContainerProviderConnectionInfo.length > 1 || containerInfo !== undefined || errorMsg !== undefined}
+        <div class="bg-[var(--pd-content-card-bg)] m-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg h-fit">
+          <div class="w-full text-[var(--pd-details-body-text)]">
+            <!-- container provider connection input -->
+            {#if startedContainerProviderConnectionInfo.length > 1}
+              <label for="" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
+                >Container engine</label>
+              <ContainerProviderConnectionSelect
+                bind:value={containerProviderConnection}
+                containerProviderConnections={startedContainerProviderConnectionInfo} />
+            {/if}
 
-          <h1 class="pt-4 mb-2 text-lg first-letter:uppercase">Instructions</h1>
+            {#if containerInfo !== undefined || errorMsg !== undefined}
+              <h1 class="pt-4 mb-2 text-lg first-letter:uppercase">Instructions</h1>
 
-          {#if containerInfo}
-            <p>Llama Stack API is accessible at http://localhost:{containerInfo.port}</p>
-            <p>
-              Access
-              <Tooltip tip="Open swagger documentation">
-                <Link
-                  aria-label="swagger documentation"
-                  on:click={openLink.bind(undefined, `http://localhost:${containerInfo.port}/docs`)}>
-                  swagger documentation
-                </Link>
-              </Tooltip>
-            </p>
-          {/if}
-          {#if errorMsg !== undefined}
-            <ErrorMessage error={errorMsg} />
-          {/if}
+              {#if containerInfo}
+                <p>Llama Stack API is accessible at http://localhost:{containerInfo.port}</p>
+                <p>
+                  Access
+                  <Tooltip tip="Open swagger documentation">
+                    <Link
+                      aria-label="swagger documentation"
+                      on:click={openLink.bind(undefined, `http://localhost:${containerInfo.port}/docs`)}>
+                      swagger documentation
+                    </Link>
+                  </Tooltip>
+                </p>
+              {/if}
+              {#if errorMsg !== undefined}
+                <ErrorMessage error={errorMsg} />
+              {/if}
+            {/if}
+          </div>
         </div>
-      </div>
+      {/if}
     </div></svelte:fragment>
 </FormPage>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Do not display instructions block when no info to display.

### Screenshot / video of UI

https://github.com/user-attachments/assets/faa3c2fc-386c-4210-b095-4f957e0cc151



### What issues does this PR fix or reference?

Fixes #2997 

### How to test this PR?

Start a llama stack