### PR TITLE
display runtime for running inference servers

### DIFF
--- a/packages/frontend/src/lib/table/service/ServiceColumnRuntime.spec.ts
+++ b/packages/frontend/src/lib/table/service/ServiceColumnRuntime.spec.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { test, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ServiceColumnRuntime from './ServiceColumnRuntime.svelte';
+import { InferenceType, type InferenceServer } from '@shared/models/IInference';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('should display label for type', async () => {
+  render(ServiceColumnRuntime, {
+    object: {
+      type: InferenceType.LLAMA_CPP,
+    } as InferenceServer,
+  });
+
+  screen.getByText('llamacpp');
+});

--- a/packages/frontend/src/lib/table/service/ServiceColumnRuntime.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceColumnRuntime.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import { inferenceTypeLabel, type InferenceServer } from '@shared/models/IInference';
+import Badge from '../../Badge.svelte';
+
+export let object: InferenceServer;
+</script>
+
+<Badge content={inferenceTypeLabel(object.type)} />

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -10,11 +10,13 @@ import { studioClient } from '/@/utils/client';
 import { router } from 'tinro';
 import { onMount } from 'svelte';
 import { Button, Table, TableColumn, TableRow, NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
+import ServiceColumnRuntime from '/@/lib/table/service/ServiceColumnRuntime.svelte';
 
 const columns: TableColumn<InferenceServer>[] = [
   new TableColumn<InferenceServer>('Status', { width: '70px', renderer: ServiceStatus, align: 'center' }),
   new TableColumn<InferenceServer>('Name', { width: '1fr', renderer: ServiceColumnName, align: 'left' }),
   new TableColumn<InferenceServer>('Model', { renderer: ServiceColumnModelName, align: 'left' }),
+  new TableColumn<InferenceServer>('Runtime', { width: '90px', renderer: ServiceColumnRuntime, align: 'left' }),
   new TableColumn<InferenceServer>('Actions', { width: '80px', renderer: ServiceAction, align: 'right' }),
 ];
 const row = new TableRow<InferenceServer>({ selectable: (_service): boolean => true });

--- a/packages/shared/src/models/IInference.ts
+++ b/packages/shared/src/models/IInference.ts
@@ -23,6 +23,19 @@ export enum InferenceType {
   NONE = 'none',
 }
 
+const InferenceTypeLabel = {
+  'llama-cpp': 'llamacpp',
+  'whisper-cpp': 'whispercpp',
+  none: 'None',
+};
+
+export function inferenceTypeLabel(type: InferenceType): string {
+  if (type in InferenceTypeLabel) {
+    return InferenceTypeLabel[type];
+  }
+  return InferenceTypeLabel['none'];
+}
+
 export type InferenceServerStatus = 'stopped' | 'running' | 'deleting' | 'stopping' | 'error' | 'starting';
 
 export interface InferenceServer {


### PR DESCRIPTION
### What does this PR do?

Display runtime for running inference servers

### Screenshot / video of UI

![display-inference-server-runtime](https://github.com/user-attachments/assets/ddd384b0-a255-4df9-be55-8aa502c32bc6)


### What issues does this PR fix or reference?

Part of #2614 

### How to test this PR?

Start inference servers with different backends (llama.cpp / whisper.cpp), and check that the runtime is correctly displayed in the list 
