### PR TITLE
feat: display application runtime

### DIFF
--- a/packages/backend/src/managers/application/applicationManager.ts
+++ b/packages/backend/src/managers/application/applicationManager.ts
@@ -54,6 +54,7 @@ import { VMType } from '@shared/models/IPodman';
 import { RECIPE_START_ROUTE } from '../../registries/NavigationRegistry';
 import type { RpcExtension } from '@shared/messages/MessageProxy';
 import { TaskRunner } from '../TaskRunner';
+import { getInferenceType } from '../../utils/inferenceUtils';
 
 export class ApplicationManager extends Publisher<ApplicationState[]> implements Disposable {
   #applications: ApplicationRegistry<ApplicationState>;
@@ -523,6 +524,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
       appPorts,
       modelPorts,
       health: 'starting',
+      backend: getInferenceType(this.modelsManager.getModelsInfo().filter(m => m.id === modelId)),
     };
     this.updateApplicationState(recipeId, modelId, state);
   }

--- a/packages/frontend/src/lib/table/application/ApplicationTable.svelte
+++ b/packages/frontend/src/lib/table/application/ApplicationTable.svelte
@@ -9,6 +9,7 @@ import ColumnAge from './ColumnAge.svelte';
 import { onMount } from 'svelte';
 import type { ApplicationState } from '@shared/models/IApplicationState';
 import { Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+import ColumnRuntime from './ColumnRuntime.svelte';
 
 export let filter: ((items: ApplicationState[]) => ApplicationState[]) | undefined = undefined;
 const columns: TableColumn<ApplicationState>[] = [
@@ -17,6 +18,7 @@ const columns: TableColumn<ApplicationState>[] = [
   new TableColumn<ApplicationState>('Recipe', { width: '2fr', renderer: ColumnRecipe }),
   new TableColumn<ApplicationState>('Pod', { width: '3fr', renderer: ColumnPod }),
   new TableColumn<ApplicationState>('Age', { width: '2fr', renderer: ColumnAge }),
+  new TableColumn<ApplicationState>('Runtime', { width: '90px', renderer: ColumnRuntime }),
   new TableColumn<ApplicationState>('Actions', {
     align: 'right',
     width: '120px',

--- a/packages/frontend/src/lib/table/application/ColumnRuntime.spec.ts
+++ b/packages/frontend/src/lib/table/application/ColumnRuntime.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodInfo } from '@podman-desktop/api';
-import type { InferenceType } from './IInference';
+import { test, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { InferenceType } from '@shared/models/IInference';
+import ColumnRuntime from './ColumnRuntime.svelte';
+import type { ApplicationState } from '@shared/models/IApplicationState';
 
-export type PodHealth = 'none' | 'starting' | 'healthy' | 'unhealthy';
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
-export interface ApplicationState {
-  recipeId: string;
-  modelId: string;
-  pod: PodInfo;
-  appPorts: number[];
-  modelPorts: number[];
-  health: PodHealth;
-  backend: InferenceType;
-}
+test('should display label for backend', async () => {
+  render(ColumnRuntime, {
+    object: {
+      backend: InferenceType.LLAMA_CPP,
+    } as ApplicationState,
+  });
+
+  screen.getByText('llamacpp');
+});

--- a/packages/frontend/src/lib/table/application/ColumnRuntime.svelte
+++ b/packages/frontend/src/lib/table/application/ColumnRuntime.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import type { ApplicationState } from '@shared/models/IApplicationState';
+import Badge from '../../Badge.svelte';
+import { inferenceTypeLabel } from '@shared/models/IInference';
+
+export let object: ApplicationState;
+</script>
+
+<Badge content={inferenceTypeLabel(object.backend)} />


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display application runtime

The models manager needs to be initialized synchronously, so the app manager has an already initialized models catalog (or depending on race condition, it is possible that the model's backend is not found)

### Screenshot / video of UI
![display-app-runtime](https://github.com/user-attachments/assets/b749c8bf-35b8-4c46-b279-8c74a5a29a25)

### What issues does this PR fix or reference?

Part of #2614 

### How to test this PR?

Start a recipe and check that the runtime is correctly displayed
Restart (PD, extension, container runtime, etc) and check that the runtime is still correct
