### PR TITLE
feat: display runtime in service details

### DIFF
--- a/packages/frontend/src/pages/InferenceServerDetails.spec.ts
+++ b/packages/frontend/src/pages/InferenceServerDetails.spec.ts
@@ -283,6 +283,15 @@ test('ensure models to be clickable', async () => {
   expect(a.getAttribute('href')).toBe('/model/dummyModelId');
 });
 
+test('runtime label is displayed', async () => {
+  render(InferenceServerDetails, {
+    containerId: 'dummyContainerId',
+  });
+
+  const span = screen.getByText('llamacpp');
+  expect(span).toBeDefined();
+});
+
 describe('labels', () => {
   test('GPU label should display GPU Inference', async () => {
     mocks.getInferenceServersMock.mockReturnValue([

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -12,7 +12,7 @@ import {
   faMicrochip,
   faScaleBalanced,
 } from '@fortawesome/free-solid-svg-icons';
-import { type InferenceServer, InferenceType } from '@shared/models/IInference';
+import { type InferenceServer, InferenceType, inferenceTypeLabel } from '@shared/models/IInference';
 import { snippetLanguages } from '/@/stores/snippetLanguages';
 import type { LanguageVariant } from 'postman-code-generators';
 import { studioClient } from '/@/utils/client';
@@ -23,6 +23,7 @@ import CopyButton from '/@/lib/button/CopyButton.svelte';
 import type { RequestOptions } from '@shared/models/RequestOptions';
 import { filesize } from 'filesize';
 import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
+import Badge from '../lib/Badge.svelte';
 
 interface Props {
   containerId?: string;
@@ -239,6 +240,7 @@ function handleOnChange(): void {
                           {/if}
                         </div>
 
+                        <Badge content={inferenceTypeLabel(service.type)}></Badge>
                         {#if 'gpu' in service.labels}
                           <Tooltip left tip={service.labels['gpu']}>
                             <div

--- a/packages/frontend/src/pages/InferenceServerDetails.svelte
+++ b/packages/frontend/src/pages/InferenceServerDetails.svelte
@@ -23,7 +23,6 @@ import CopyButton from '/@/lib/button/CopyButton.svelte';
 import type { RequestOptions } from '@shared/models/RequestOptions';
 import { filesize } from 'filesize';
 import MonacoEditor from '/@/lib/monaco-editor/MonacoEditor.svelte';
-import Badge from '../lib/Badge.svelte';
 
 interface Props {
   containerId?: string;
@@ -240,7 +239,11 @@ function handleOnChange(): void {
                           {/if}
                         </div>
 
-                        <Badge content={inferenceTypeLabel(service.type)}></Badge>
+                        <div
+                          class="bg-[var(--pd-label-bg)] text-[var(--pd-label-text)] rounded-md p-2 flex flex-row w-min h-min text-xs text-nowrap items-center"
+                          aria-label="Service type">
+                          {inferenceTypeLabel(service.type)}
+                        </div>
                         {#if 'gpu' in service.labels}
                           <Tooltip left tip={service.labels['gpu']}>
                             <div


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display runtime in service details

### Screenshot / video of UI

![display-service-details-runtime](https://github.com/user-attachments/assets/a9de9cbf-e650-4ad5-bd3a-b010b137abb6)


### What issues does this PR fix or reference?

Fixes #2614

### How to test this PR?

Start an inference server and check in the details page that the runtime is correct
