### PR TITLE
ci(workflow): updated ubuntu runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2024-2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ jobs:
 
   tag:
     name: Tagging
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
       extVersion: ${{ steps.TAG_UTIL.outputs.extVersion}}


### PR DESCRIPTION
### What does this PR do?
Updates ubuntu runner to 22.04. 
20.04 is now deprecated  `This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101`

### Screenshot / video of UI
### What issues does this PR fix or reference?
Required for Releasing AI Lab https://github.com/containers/podman-desktop-extension-ai-lab/actions/runs/15116717255

### How to test this PR?
Tagging in this action should be :heavy_check_mark: 
https://github.com/gastoner/podman-desktop-extension-ai-lab/actions/runs/15129385374/job/42527314022