### PR TITLE
chore(test): validate for inference server type

### DIFF
--- a/tests/playwright/src/ai-lab-extension.spec.ts
+++ b/tests/playwright/src/ai-lab-extension.spec.ts
@@ -299,6 +299,7 @@ test.describe.serial(`AI Lab extension installation and verification`, () => {
 
         await playExpect(modelServiceDetailsPage.modelName).toContainText(modelName);
         await playExpect(modelServiceDetailsPage.inferenceServerType).toContainText('Inference');
+        await playExpect(modelServiceDetailsPage.inferenceServerType).toContainText(/CPU|GPU/);
       });
 
       test(`Make GET request to the model service for ${modelName}`, async ({ request }) => {


### PR DESCRIPTION
### What does this PR do?
Validates service details page for CPU or GPU inference server type.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-extension-ai-lab/issues/2559