### PR TITLE
chore(test): update playground test to use most frequent model, increase timeout

### DIFF
--- a/tests/playwright/src/ai-lab-extension.spec.ts
+++ b/tests/playwright/src/ai-lab-extension.spec.ts
@@ -333,7 +333,7 @@ test.describe.serial(`AI Lab extension installation and verification`, () => {
   });
 
   ['ibm-research/granite-3.2-8b-instruct-GGUF'].forEach(modelName => {
-    test.describe.serial(`AI Lab playground creation and deletion`, () => {
+    test.describe.serial(`AI Lab playground creation and deletion`, { tag: '@smoke' }, () => {
       let catalogPage: AILabCatalogPage;
       let playgroundsPage: AILabPlaygroundsPage;
       let playgroundDetailsPage: AILabPlaygroundDetailsPage;
@@ -357,7 +357,7 @@ test.describe.serial(`AI Lab extension installation and verification`, () => {
         }
         await playExpect
           // eslint-disable-next-line sonarjs/no-nested-functions
-          .poll(async () => await waitForCatalogModel(modelName), { timeout: 300_000, intervals: [5_000] })
+          .poll(async () => await waitForCatalogModel(modelName), { timeout: 600_000, intervals: [5_000] })
           .toBeTruthy();
       });
 


### PR DESCRIPTION
### What does this PR do?
* Switches playgroundmodel to `ibm-research/granite-3.2-8b-instruct-GGUF`
* Adds Playground test to smoke suite
* Increases model download timeout to 600s

### Screenshot / video of UI
N/A
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#3095 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
PR-check
<!-- Please explain steps to reproduce -->
