### PR TITLE
fix: always send mandatory response field

### DIFF
--- a/packages/backend/src/managers/apiServer.ts
+++ b/packages/backend/src/managers/apiServer.ts
@@ -505,7 +505,7 @@ export class ApiServer implements Disposable {
               res.write(
                 JSON.stringify({
                   model: modelName,
-                  response: chunk.choices[0].delta.content,
+                  response: chunk.choices[0].delta.content ?? '',
                   done: chunk.choices[0].finish_reason === 'stop',
                   done_reason: chunk.choices[0].finish_reason === 'stop' ? 'stop' : undefined,
                 }) + '\n',
@@ -516,7 +516,7 @@ export class ApiServer implements Disposable {
           onNonStreamResponse: response => {
             res.status(200).json({
               model: modelName,
-              response: response.choices[0].message.content,
+              response: response.choices[0].message.content ?? '',
               done: true,
               done_reason: 'stop',
             });


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

The `response` field is mandatory in a chat response, and llama stack enforces that the field exists in the response. 

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-ai-lab-stack/issues/3

### How to test this PR?

See steps to reproduce in https://github.com/containers/podman-ai-lab-stack/issues/3