### PR TITLE
fix: always send mandatory message.content field

### DIFF
--- a/packages/backend/src/managers/apiServer.ts
+++ b/packages/backend/src/managers/apiServer.ts
@@ -571,7 +571,7 @@ export class ApiServer implements Disposable {
                   model: modelName,
                   message: {
                     role: 'assistant',
-                    content: chunk.choices[0].delta.content,
+                    content: chunk.choices[0].delta.content ?? '',
                   },
                   done: chunk.choices[0].finish_reason === 'stop',
                   done_reason: chunk.choices[0].finish_reason === 'stop' ? 'stop' : undefined,
@@ -585,7 +585,7 @@ export class ApiServer implements Disposable {
               model: modelName,
               message: {
                 role: 'assistant',
-                content: response.choices[0].message.content,
+                content: response.choices[0].message.content ?? '',
               },
               done: true,
               done_reason: 'stop',


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

The `message.content` field is mandatory in a chat response, and llama stack enforces that the field exists in the response. 

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-ai-lab-stack/issues/3

### How to test this PR?

See steps to reproduce in https://github.com/containers/podman-ai-lab-stack/issues/3 (needs https://github.com/containers/podman-ai-lab-stack/pull/9)