### PR TITLE
feat: Adds the ability to select the runtime and inference service for playground

### DIFF
--- a/packages/backend/src/registries/ConversationRegistry.ts
+++ b/packages/backend/src/registries/ConversationRegistry.ts
@@ -82,11 +82,12 @@ export class ConversationRegistry extends Publisher<Conversation[]> implements D
     this.notify();
   }
 
-  createConversation(name: string, modelId: string): string {
+  createConversation(name: string, modelId: string, containerId?: string): string {
     const conversationId = this.getUniqueId();
     this.#conversations.set(conversationId, {
       name: name,
       modelId: modelId,
+      containerId: containerId,
       messages: [],
       id: conversationId,
       usage: {

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -98,9 +98,9 @@ export class StudioApiImpl implements StudioAPI {
       });
   }
 
-  async requestCreatePlayground(name: string, model: ModelInfo): Promise<string> {
+  async requestCreatePlayground(name: string, model: ModelInfo, selectedService?: InferenceServer): Promise<string> {
     try {
-      return await this.playgroundV2.requestCreatePlayground(name, model);
+      return await this.playgroundV2.requestCreatePlayground(name, model, selectedService);
     } catch (err: unknown) {
       console.error('Something went wrong while trying to create playground environment', err);
       throw err;

--- a/packages/frontend/src/lib/select/InferenceRuntimeSelect.svelte
+++ b/packages/frontend/src/lib/select/InferenceRuntimeSelect.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import Select from '/@/lib/select/Select.svelte';
+import { InferenceType } from '@shared/models/IInference';
+
+interface Props {
+  disabled?: boolean;
+  value: InferenceType | undefined;
+}
+let { value = $bindable(), disabled }: Props = $props();
+const options = Object.values(InferenceType).filter(type => type !== InferenceType.NONE) as Array<InferenceType>;
+function handleOnChange(nValue: { value: string } | undefined): void {
+  if (nValue) {
+    value = nValue.value as InferenceType;
+  } else {
+    value = undefined;
+  }
+}
+</script>
+
+<Select
+  label="Select Inference Runtime"
+  name="select-inference-runtime"
+  disabled={disabled}
+  value={value ? { label: value, value: value } : undefined}
+  onchange={handleOnChange}
+  placeholder="Select Inference Runtime to use"
+  items={options.map(type => ({
+    value: type,
+    label: type,
+  }))} />

--- a/packages/frontend/src/lib/select/ModelServiceSelect.svelte
+++ b/packages/frontend/src/lib/select/ModelServiceSelect.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+import Select from '/@/lib/select/Select.svelte';
+import type { InferenceServer } from '@shared/models/IInference';
+
+interface Props {
+  servers: InferenceServer[];
+  disabled?: boolean;
+  value: InferenceServer | undefined;
+}
+
+let { servers = [], disabled = false, value = $bindable() }: Props = $props();
+
+// Format each server to an option for the select component
+const options = servers.map(server => ({
+  ...server,
+  value: server.container.containerId,
+  label: `${server.container.containerId.slice(0, 8)} (port ${server.connection.port}) - ${server.type} - ${server.status}`,
+}));
+
+let selected: (InferenceServer & { label: string; value: string }) | undefined = $derived.by(() => {
+  if (value) {
+    return {
+      ...value,
+      label: `${value.container.containerId.slice(0, 8)} (port ${value.connection.port}) - ${value.type} - ${value.status}`,
+      value: value.container.containerId,
+    };
+  } else {
+    return undefined;
+  }
+});
+
+function handleOnChange(nValue: (InferenceServer & { label: string; value: string }) | undefined): void {
+  if (nValue) {
+    const { label, ...server } = nValue;
+    value = server as InferenceServer;
+  } else {
+    value = undefined;
+  }
+}
+</script>
+
+<Select
+  label="Select Model Service"
+  name="select-model-service"
+  disabled={disabled}
+  value={selected}
+  onchange={handleOnChange}
+  placeholder="Select an inference server"
+  items={options} />

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -199,7 +199,7 @@ export interface StudioAPI {
    */
   createSnippet(options: RequestOptions, language: string, variant: string): Promise<string>;
 
-  requestCreatePlayground(name: string, model: ModelInfo): Promise<string>;
+  requestCreatePlayground(name: string, model: ModelInfo, selectedService?: InferenceServer): Promise<string>;
 
   /**
    * Delete a conversation

--- a/packages/shared/src/models/IPlaygroundMessage.ts
+++ b/packages/shared/src/models/IPlaygroundMessage.ts
@@ -62,6 +62,7 @@ export interface Conversation {
   id: string;
   messages: Message[];
   modelId: string;
+  containerId?: string;
   name: string;
   usage?: ModelUsage;
 }


### PR DESCRIPTION
### What does this PR do?
see above

thanks to @axel7083 for his work so far in https://github.com/containers/podman-desktop-extension-ai-lab/pull/3077
I think ill be able to use [InferenceRuntimeSelect.svelte](https://github.com/containers/podman-desktop-extension-ai-lab/pull/3077/files#diff-35d0667062ebbcec62d01a2e16b25efb5764007c3b081e8bc5f038b88b3debce) to help select the runtime and pass it to the playground creation IF there is no model services available to select. If so i think ill just point the user to create the service in the model services page

### Screenshot / video of UI

so far these are pics of selecting the inference provider
![Screenshot 2025-06-10 011247](https://github.com/user-attachments/assets/4567d448-7200-4752-b336-9536164f9d8c)

<!-- If this PR is changing UI, please include

screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/2613

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
create multiple services with the same model and see if you can choose from it in the playground
