### PR TITLE
refactor: introduce ApplicationOptions

### DIFF
--- a/packages/backend/src/managers/application/applicationManager.spec.ts
+++ b/packages/backend/src/managers/application/applicationManager.spec.ts
@@ -160,11 +160,11 @@ function getInitializedApplicationManager(): ApplicationManager {
 describe('requestPullApplication', () => {
   test('task should be set to error if pull application raise an error', async () => {
     vi.mocked(window.withProgress).mockRejectedValue(new Error('pull application error'));
-    const trackingId = await getInitializedApplicationManager().requestPullApplication(
-      connectionMock,
-      recipeMock,
-      remoteModelMock,
-    );
+    const trackingId = await getInitializedApplicationManager().requestPullApplication({
+      connection: connectionMock,
+      recipe: recipeMock,
+      model: remoteModelMock,
+    });
 
     // ensure the task is created
     await vi.waitFor(() => {
@@ -292,9 +292,16 @@ describe('startApplication', () => {
 
 describe('pullApplication', () => {
   test('labels should be propagated', async () => {
-    await getInitializedApplicationManager().pullApplication(connectionMock, recipeMock, remoteModelMock, {
-      'test-label': 'test-value',
-    });
+    await getInitializedApplicationManager().pullApplication(
+      {
+        connection: connectionMock,
+        recipe: recipeMock,
+        model: remoteModelMock,
+      },
+      {
+        'test-label': 'test-value',
+      },
+    );
 
     // clone the recipe
     expect(recipeManager.cloneRecipe).toHaveBeenCalledWith(recipeMock, {
@@ -314,11 +321,18 @@ describe('pullApplication', () => {
       'model-id': remoteModelMock.id,
     });
     // build the recipe
-    expect(recipeManager.buildRecipe).toHaveBeenCalledWith(connectionMock, recipeMock, remoteModelMock, {
-      'test-label': 'test-value',
-      'recipe-id': recipeMock.id,
-      'model-id': remoteModelMock.id,
-    });
+    expect(recipeManager.buildRecipe).toHaveBeenCalledWith(
+      {
+        connection: connectionMock,
+        recipe: recipeMock,
+        model: remoteModelMock,
+      },
+      {
+        'test-label': 'test-value',
+        'recipe-id': recipeMock.id,
+        'model-id': remoteModelMock.id,
+      },
+    );
     // create AI App task must be created
     expect(taskRegistryMock.createTask).toHaveBeenCalledWith('Creating AI App', 'loading', {
       'test-label': 'test-value',
@@ -361,9 +375,17 @@ describe('pullApplication', () => {
         },
       } as InferenceServer,
     });
-    await getInitializedApplicationManager().pullApplication(connectionMock, recipeMock, remoteModelMock, {
-      'test-label': 'test-value',
-    });
+    vi.mocked(modelsManagerMock.requestDownloadModel).mockResolvedValue('/path/to/model');
+    await getInitializedApplicationManager().pullApplication(
+      {
+        connection: connectionMock,
+        recipe: recipeMock,
+        model: remoteModelMock,
+      },
+      {
+        'test-label': 'test-value',
+      },
+    );
 
     // clone the recipe
     expect(recipeManager.cloneRecipe).toHaveBeenCalledWith(recipeMock, {
@@ -379,11 +401,18 @@ describe('pullApplication', () => {
     // upload model to podman machine
     expect(modelsManagerMock.uploadModelToPodmanMachine).not.toHaveBeenCalled();
     // build the recipe
-    expect(recipeManager.buildRecipe).toHaveBeenCalledWith(connectionMock, recipeMock, remoteModelMock, {
-      'test-label': 'test-value',
-      'recipe-id': recipeMock.id,
-      'model-id': remoteModelMock.id,
-    });
+    expect(recipeManager.buildRecipe).toHaveBeenCalledWith(
+      {
+        connection: connectionMock,
+        recipe: recipeMock,
+        model: remoteModelMock,
+      },
+      {
+        'test-label': 'test-value',
+        'recipe-id': recipeMock.id,
+        'model-id': remoteModelMock.id,
+      },
+    );
     // create AI App task must be created
     expect(taskRegistryMock.createTask).toHaveBeenCalledWith('Creating AI App', 'loading', {
       'test-label': 'test-value',
@@ -427,7 +456,11 @@ describe('pullApplication', () => {
       },
     } as unknown as PodInfo);
 
-    await getInitializedApplicationManager().pullApplication(connectionMock, recipeMock, remoteModelMock);
+    await getInitializedApplicationManager().pullApplication({
+      connection: connectionMock,
+      recipe: recipeMock,
+      model: remoteModelMock,
+    });
 
     // removing existing application should create a task to notify the user
     expect(taskRegistryMock.createTask).toHaveBeenCalledWith('Removing AI App', 'loading', {
@@ -456,7 +489,11 @@ describe('pullApplication', () => {
       ],
     });
 
-    await getInitializedApplicationManager().pullApplication(connectionMock, recipeMock, remoteModelMock);
+    await getInitializedApplicationManager().pullApplication({
+      connection: connectionMock,
+      recipe: recipeMock,
+      model: remoteModelMock,
+    });
 
     // the remove pod should have been called
     expect(containerEngine.createContainer).toHaveBeenCalledWith(

--- a/packages/backend/src/managers/application/applicationManager.ts
+++ b/packages/backend/src/managers/application/applicationManager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Recipe, RecipeComponents, RecipeImage } from '@shared/models/IRecipe';
+import type { RecipeComponents, RecipeImage } from '@shared/models/IRecipe';
 import * as path from 'node:path';
 import { containerEngine, Disposable, window, ProgressLocation } from '@podman-desktop/api';
 import type {
@@ -28,7 +28,6 @@ import type {
   PodContainerInfo,
   ContainerProviderConnection,
 } from '@podman-desktop/api';
-import type { ModelInfo } from '@shared/models/IModelInfo';
 import type { ModelsManager } from '../modelsManager';
 import { getPortsFromLabel, getPortsInfo } from '../../utils/ports';
 import { getDurationSecondsSince, timeout } from '../../utils/utils';
@@ -55,6 +54,7 @@ import { RECIPE_START_ROUTE } from '../../registries/NavigationRegistry';
 import type { RpcExtension } from '@shared/messages/MessageProxy';
 import { TaskRunner } from '../TaskRunner';
 import { getInferenceType } from '../../utils/inferenceUtils';
+import { type ApplicationOptions } from '../../models/ApplicationOptions';
 
 export class ApplicationManager extends Publisher<ApplicationState[]> implements Disposable {
   #applications: ApplicationRegistry<ApplicationState>;
@@ -78,11 +78,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
     this.#disposables = [];
   }
 
-  async requestPullApplication(
-    connection: ContainerProviderConnection,
-    recipe: Recipe,
-    model: ModelInfo,
-  ): Promise<string> {
+  async requestPullApplication(options: ApplicationOptions): Promise<string> {
     // create a tracking id to put in the labels
     const trackingId: string = getRandomString();
 
@@ -94,23 +90,23 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
       .runAsTask(
         {
           ...labels,
-          'recipe-pulling': recipe.id, // this label should only be on the master task
+          'recipe-pulling': options.recipe.id, // this label should only be on the master task
         },
         {
-          loadingLabel: `Pulling ${recipe.name} recipe`,
-          errorMsg: err => `Something went wrong while pulling ${recipe.name}: ${String(err)}`,
+          loadingLabel: `Pulling ${options.recipe.name} recipe`,
+          errorMsg: err => `Something went wrong while pulling ${options.recipe.name}: ${String(err)}`,
         },
         () =>
           window.withProgress(
             {
               location: ProgressLocation.TASK_WIDGET,
-              title: `Pulling ${recipe.name}.`,
+              title: `Pulling ${options.recipe.name}.`,
               details: {
                 routeId: RECIPE_START_ROUTE,
-                routeArgs: [recipe.id, trackingId],
+                routeArgs: [options.recipe.id, trackingId],
               },
             },
-            () => this.pullApplication(connection, recipe, model, labels),
+            () => this.pullApplication(options, labels),
           ),
       )
       .catch(() => {});
@@ -118,37 +114,36 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
     return trackingId;
   }
 
-  async pullApplication(
-    connection: ContainerProviderConnection,
-    recipe: Recipe,
-    model: ModelInfo,
-    labels: Record<string, string> = {},
-  ): Promise<void> {
+  async pullApplication(options: ApplicationOptions, labels: Record<string, string> = {}): Promise<void> {
     // clear any existing status / tasks related to the pair recipeId-modelId.
     this.taskRegistry.deleteByLabels({
-      'recipe-id': recipe.id,
-      'model-id': model.id,
+      'recipe-id': options.recipe.id,
+      'model-id': options.model.id,
     });
 
     const startTime = performance.now();
     try {
       // init application (git clone, models download etc.)
-      const podInfo: PodInfo = await this.initApplication(connection, recipe, model, labels);
+      const podInfo: PodInfo = await this.initApplication(options, labels);
       // start the pod
       await this.runApplication(podInfo, {
         ...labels,
-        'recipe-id': recipe.id,
-        'model-id': model.id,
+        'recipe-id': options.recipe.id,
+        'model-id': options.model.id,
       });
 
       // measure init + start time
       const durationSeconds = getDurationSecondsSince(startTime);
-      this.telemetry.logUsage('recipe.pull', { 'recipe.id': recipe.id, 'recipe.name': recipe.name, durationSeconds });
+      this.telemetry.logUsage('recipe.pull', {
+        'recipe.id': options.recipe.id,
+        'recipe.name': options.recipe.name,
+        durationSeconds,
+      });
     } catch (err: unknown) {
       const durationSeconds = getDurationSecondsSince(startTime);
       this.telemetry.logError('recipe.pull', {
-        'recipe.id': recipe.id,
-        'recipe.name': recipe.name,
+        'recipe.id': options.recipe.id,
+        'recipe.name': options.recipe.name,
         durationSeconds,
         message: 'error pulling application',
         error: err,
@@ -173,48 +168,42 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
    * @param labels
    * @private
    */
-  private async initApplication(
-    connection: ContainerProviderConnection,
-    recipe: Recipe,
-    model: ModelInfo,
-    labels: Record<string, string> = {},
-  ): Promise<PodInfo> {
+  private async initApplication(options: ApplicationOptions, labels: Record<string, string> = {}): Promise<PodInfo> {
     // clone the recipe
-    await this.recipeManager.cloneRecipe(recipe, { ...labels, 'model-id': model.id });
+    await this.recipeManager.cloneRecipe(options.recipe, { ...labels, 'model-id': options.model.id });
 
     // get model by downloading it or retrieving locally
-    let modelPath = await this.modelsManager.requestDownloadModel(model, {
+    let modelPath = await this.modelsManager.requestDownloadModel(options.model, {
       ...labels,
-      'recipe-id': recipe.id,
-      'model-id': model.id,
+      'recipe-id': options.recipe.id,
+      'model-id': options.model.id,
     });
-
     // build all images, one per container (for a basic sample we should have 2 containers = sample app + model service)
-    const recipeComponents = await this.recipeManager.buildRecipe(connection, recipe, model, {
+    const recipeComponents = await this.recipeManager.buildRecipe(options, {
       ...labels,
-      'recipe-id': recipe.id,
-      'model-id': model.id,
+      'recipe-id': options.recipe.id,
+      'model-id': options.model.id,
     });
 
     // upload model to podman machine if user system is supported
     if (!recipeComponents.inferenceServer) {
-      modelPath = await this.modelsManager.uploadModelToPodmanMachine(connection, model, {
+      modelPath = await this.modelsManager.uploadModelToPodmanMachine(options.connection, options.model, {
         ...labels,
-        'recipe-id': recipe.id,
-        'model-id': model.id,
+        'recipe-id': options.recipe.id,
+        'model-id': options.model.id,
       });
     }
 
     // first delete any existing pod with matching labels
-    if (await this.hasApplicationPod(recipe.id, model.id)) {
-      await this.removeApplication(recipe.id, model.id);
+    if (await this.hasApplicationPod(options.recipe.id, options.model.id)) {
+      await this.removeApplication(options.recipe.id, options.model.id);
     }
 
     // create a pod containing all the containers to run the application
-    return this.createApplicationPod(connection, recipe, model, recipeComponents, modelPath, {
+    return this.createApplicationPod(options, recipeComponents, modelPath, {
       ...labels,
-      'recipe-id': recipe.id,
-      'model-id': model.id,
+      'recipe-id': options.recipe.id,
+      'model-id': options.model.id,
     });
   }
 
@@ -257,9 +246,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
   }
 
   protected async createApplicationPod(
-    connection: ContainerProviderConnection,
-    recipe: Recipe,
-    model: ModelInfo,
+    options: ApplicationOptions,
     components: RecipeComponents,
     modelPath: string,
     labels?: { [key: string]: string },
@@ -271,25 +258,24 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
         errorMsg: err => `Something went wrong while creating pod: ${String(err)}`,
       },
       async ({ updateLabels }): Promise<PodInfo> => {
-        const podInfo = await this.createPod(connection, recipe, model, components.images);
+        const podInfo = await this.createPod(options, components.images);
         updateLabels(labels => ({
           ...labels,
           'pod-id': podInfo.Id,
         }));
-        await this.createContainerAndAttachToPod(connection, podInfo, components, model, modelPath);
+        await this.createContainerAndAttachToPod(options, podInfo, components, modelPath);
         return podInfo;
       },
     );
   }
 
   protected async createContainerAndAttachToPod(
-    connection: ContainerProviderConnection,
+    options: ApplicationOptions,
     podInfo: PodInfo,
     components: RecipeComponents,
-    modelInfo: ModelInfo,
     modelPath: string,
   ): Promise<void> {
-    const vmType = connection.vmType ?? VMType.UNKNOWN;
+    const vmType = options.connection.vmType ?? VMType.UNKNOWN;
     // temporary check to set Z flag or not - to be removed when switching to podman 5
     await Promise.all(
       components.images.map(async image => {
@@ -310,7 +296,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
             ],
           };
           envs = [`MODEL_PATH=/${modelName}`];
-          envs.push(...getModelPropertiesForEnvironment(modelInfo));
+          envs.push(...getModelPropertiesForEnvironment(options.model));
         } else if (components.inferenceServer) {
           const endPoint = `http://host.containers.internal:${components.inferenceServer.connection.port}`;
           envs = [`MODEL_ENDPOINT=${endPoint}`];
@@ -346,12 +332,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
     );
   }
 
-  protected async createPod(
-    connection: ContainerProviderConnection,
-    recipe: Recipe,
-    model: ModelInfo,
-    images: RecipeImage[],
-  ): Promise<PodInfo> {
+  protected async createPod(options: ApplicationOptions, images: RecipeImage[]): Promise<PodInfo> {
     // find the exposed port of the sample app so we can open its ports on the new pod
     const sampleAppImageInfo = images.find(image => !image.modelService);
     if (!sampleAppImageInfo) {
@@ -378,8 +359,8 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
 
     // create new pod
     const labels: Record<string, string> = {
-      [POD_LABEL_RECIPE_ID]: recipe.id,
-      [POD_LABEL_MODEL_ID]: model.id,
+      [POD_LABEL_RECIPE_ID]: options.recipe.id,
+      [POD_LABEL_MODEL_ID]: options.model.id,
     };
     // collecting all modelService ports
     const modelPorts = images
@@ -398,7 +379,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
       labels[POD_LABEL_APP_PORTS] = appPorts.join(',');
     }
     const { engineId, Id } = await this.podManager.createPod({
-      provider: connection,
+      provider: options.connection,
       name: getRandomName(`pod-${sampleAppImageInfo.appName}`),
       portmappings: portmappings,
       labels,
@@ -638,12 +619,12 @@ export class ApplicationManager extends Publisher<ApplicationState[]> implements
     const model = this.catalogManager.getModelById(appPod.Labels[POD_LABEL_MODEL_ID]);
 
     // init the recipe
-    const podInfo = await this.initApplication(connection, recipe, model);
+    const podInfo = await this.initApplication({ connection, recipe, model });
 
     // start the pod
     return this.runApplication(podInfo, {
-      'recipe-id': recipe.id,
-      'model-id': model.id,
+      'recipe-id': recipeId,
+      'model-id': modelId,
     });
   }
 

--- a/packages/backend/src/managers/recipes/RecipeManager.spec.ts
+++ b/packages/backend/src/managers/recipes/RecipeManager.spec.ts
@@ -191,16 +191,27 @@ describe('buildRecipe', () => {
     const manager = await getInitializedRecipeManager();
 
     await expect(() => {
-      return manager.buildRecipe(connectionMock, recipeMock, modelInfoMock);
+      return manager.buildRecipe({
+        connection: connectionMock,
+        recipe: recipeMock,
+        model: modelInfoMock,
+      });
     }).rejects.toThrowError('build error');
   });
 
   test('labels should be propagated', async () => {
     const manager = await getInitializedRecipeManager();
 
-    await manager.buildRecipe(connectionMock, recipeMock, modelInfoMock, {
-      'test-label': 'test-value',
-    });
+    await manager.buildRecipe(
+      {
+        connection: connectionMock,
+        recipe: recipeMock,
+        model: modelInfoMock,
+      },
+      {
+        'test-label': 'test-value',
+      },
+    );
 
     expect(taskRegistryMock.createTask).toHaveBeenCalledWith('Loading configuration', 'loading', {
       'test-label': 'test-value',

--- a/packages/backend/src/managers/recipes/RecipeManager.ts
+++ b/packages/backend/src/managers/recipes/RecipeManager.ts
@@ -26,12 +26,12 @@ import { parseYamlFile } from '../../models/AIConfig';
 import { existsSync, statSync } from 'node:fs';
 import { goarch } from '../../utils/arch';
 import type { BuilderManager } from './BuilderManager';
-import type { ContainerProviderConnection, Disposable } from '@podman-desktop/api';
+import type { Disposable } from '@podman-desktop/api';
 import { CONFIG_FILENAME } from '../../utils/RecipeConstants';
 import type { InferenceManager } from '../inference/inferenceManager';
-import type { ModelInfo } from '@shared/models/IModelInfo';
 import { withDefaultConfiguration } from '../../utils/inferenceUtils';
 import type { InferenceServer } from '@shared/models/IInference';
+import type { ApplicationOptions } from '../../models/ApplicationOptions';
 
 export interface AIContainers {
   aiConfigFile: AIConfigFile;
@@ -96,25 +96,20 @@ export class RecipeManager implements Disposable {
     });
   }
 
-  public async buildRecipe(
-    connection: ContainerProviderConnection,
-    recipe: Recipe,
-    model: ModelInfo,
-    labels?: { [key: string]: string },
-  ): Promise<RecipeComponents> {
-    const localFolder = path.join(this.appUserDirectory, recipe.id);
+  public async buildRecipe(options: ApplicationOptions, labels?: { [key: string]: string }): Promise<RecipeComponents> {
+    const localFolder = path.join(this.appUserDirectory, options.recipe.id);
 
     let inferenceServer: InferenceServer | undefined;
     // if the recipe has a defined backend, we gives priority to using an inference server
-    if (recipe.backend && recipe.backend === model.backend) {
+    if (options.recipe.backend && options.recipe.backend === options.model.backend) {
       let task: Task | undefined;
       try {
-        inferenceServer = this.inferenceManager.findServerByModel(model);
+        inferenceServer = this.inferenceManager.findServerByModel(options.model);
         task = this.taskRegistry.createTask('Starting Inference server', 'loading', labels);
         if (!inferenceServer) {
           const inferenceContainerId = await this.inferenceManager.createInferenceServer(
             await withDefaultConfiguration({
-              modelsInfo: [model],
+              modelsInfo: [options.model],
             }),
           );
           inferenceServer = this.inferenceManager.get(inferenceContainerId);
@@ -146,23 +141,23 @@ export class RecipeManager implements Disposable {
 
     // load and parse the recipe configuration file and filter containers based on architecture
     const configAndFilteredContainers = this.getConfigAndFilterContainers(
-      recipe.basedir,
+      options.recipe.basedir,
       localFolder,
       !!inferenceServer,
       {
         ...labels,
-        'recipe-id': recipe.id,
+        'recipe-id': options.recipe.id,
       },
     );
 
     const images = await this.builderManager.build(
-      connection,
-      recipe,
+      options.connection,
+      options.recipe,
       configAndFilteredContainers.containers,
       configAndFilteredContainers.aiConfigFile.path,
       {
         ...labels,
-        'recipe-id': recipe.id,
+        'recipe-id': options.recipe.id,
       },
     );
 

--- a/packages/backend/src/models/ApplicationOptions.ts
+++ b/packages/backend/src/models/ApplicationOptions.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ContainerProviderConnection } from '@podman-desktop/api';
+import type { ModelInfo } from '@shared/models/IModelInfo';
+import type { Recipe } from '@shared/models/IRecipe';
+
+export interface ApplicationOptions {
+  connection: ContainerProviderConnection;
+  recipe: Recipe;
+  model: ModelInfo;
+}

--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -190,15 +190,15 @@ test('expect requestPullApplication to provide a tracking id', async () => {
     modelId: 'model1',
     recipeId: 'recipe 1',
   });
-  expect(applicationManager.requestPullApplication).toHaveBeenCalledWith(
-    connectionMock,
-    expect.objectContaining({
+  expect(applicationManager.requestPullApplication).toHaveBeenCalledWith({
+    connection: connectionMock,
+    recipe: expect.objectContaining({
       id: 'recipe 1',
     }),
-    expect.objectContaining({
+    model: expect.objectContaining({
       id: 'model 1',
     }),
-  );
+  });
   expect(trackingId).toBe('dummy-tracker');
 });
 

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -240,7 +240,7 @@ export class StudioApiImpl implements StudioAPI {
 
     if (!connection) throw new Error('no running container provider connection found.');
 
-    return this.applicationManager.requestPullApplication(connection, recipe, model);
+    return this.applicationManager.requestPullApplication({ connection, recipe, model });
   }
 
   async getModelsInfo(): Promise<ModelInfo[]> {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Refactor prior to #3016

Introduces an `ApplicationOptions` interface, grouping `(connection, recipe, model)` parameters to methods related to starting a recipe. 

This will make it easier to make `model` optional, needed when starting a recipe with llama stack.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
