### PR TITLE
fix: added missing icon brain.woff2 to container build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,6 +21,7 @@ COPY packages/backend/package.json /extension/
 COPY packages/backend/media/ /extension/media
 COPY LICENSE /extension/
 COPY packages/backend/icon.png /extension/
+COPY packages/backend/brain.woff2 /extension/
 COPY README.md /extension/
 COPY api/openapi.yaml /extension/api/
 


### PR DESCRIPTION
Signed-off-by: Marcel Bertagnini <mbertagn@redhat.com>

### What does this PR do?

Added the missing icon path when generating a build in Containerfile

### Screenshot / video of UI

![Screenshot_20250604_165442](https://github.com/user-attachments/assets/c4977c29-af55-4422-b8c4-ed6312bf7319)
<img width="1041" alt="Captura de pantalla 2025-06-23 a las 15 19 23" src="https://github.com/user-attachments/assets/95c52fd3-b984-4a6f-9db5-6d6285349885" />

### What issues does this PR fix or reference?

fixes #3086 

### How to test this PR?

1- Go to AI-lab extension
2- Go to recipe catalog
3- download and start, for example the object detection recipe
4- Go to images section and check the icons.
