### PR TITLE
fix: exlude none backend from model service creation

### DIFF
--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -25,8 +25,8 @@ interface Props {
 
 let { trackingId }: Props = $props();
 
-// List of the models available locally
-let localModels: ModelInfo[] = $derived($modelsInfo.filter(model => model.file));
+// List of the models available locally exlude models with none backend
+let localModels: ModelInfo[] = $derived($modelsInfo.filter(model => model.file && model.backend !== 'none'));
 
 // The container provider connection to use
 let containerProviderConnection: ContainerProviderConnectionInfo | undefined = $state(undefined);


### PR DESCRIPTION
### What does this PR do?

see above it filters models with none backend from creating a service

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/2988

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

download resnet and check the model service page it shouldnt be shown

<!-- Please explain steps to reproduce -->
