### PR TITLE
chore(ci): update MAPT version to 0.9.3

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -87,7 +87,7 @@ jobs:
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
     env:
-      MAPT_VERSION: v0.7.4
+      MAPT_VERSION: v0.9.3
       MAPT_IMAGE: quay.io/redhat-developer/mapt
       MAPT_EXCLUDED_REGIONS: 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest'
     strategy:

--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -26,14 +26,9 @@ on:
       - 'packages/backend/src/assets/ai.json'
   workflow_dispatch:
     inputs:
-      fork:
-        default: 'containers'
-        description: 'Podman Desktop repo fork'
-        type: string
-        required: true
-      branch:
-        default: 'main'
-        description: 'Podman Desktop repo branch'
+      podman_desktop_repo_args:
+        default: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
+        description: 'Podman Desktop repo fork and branch'
         type: string
         required: true
       ext_repo_options:
@@ -81,15 +76,16 @@ on:
           - Standard_D8s_v4
           - Standard_E8as_v5
           - Standard_E4as_v5
+      mapt_params:
+        default: 'IMAGE=quay.io/redhat-developer/mapt,VERSION_TAG=v0.9.3,EXCLUDED_REGIONS="westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest"'
+        description: 'MAPT image, version tag and excluded regions in format IMAGE=xxx,VERSION_TAG=xxx,EXCLUDED_REGIONS=xxx'
+        required: true
+        type: string
 
 jobs:
   windows:
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
-    env:
-      MAPT_VERSION: v0.9.3
-      MAPT_IMAGE: quay.io/redhat-developer/mapt
-      MAPT_EXCLUDED_REGIONS: 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest'
     strategy:
       fail-fast: false
       matrix:
@@ -108,10 +104,10 @@ jobs:
         version=$(curl https://raw.githubusercontent.com/containers/podman-desktop/main/extensions/podman/packages/extension/src/podman5.json | jq -r '.version')
         echo "Default Podman Version from Podman Desktop: ${version}"
         echo "PD_PODMAN_VERSION=${version}" >> $GITHUB_ENV
+
     - name: Set the default env. variables
       env:
-        DEFAULT_FORK: 'containers'
-        DEFAULT_BRANCH: 'main'
+        DEFAULT_PODMAN_DESKTOP_REPO_ARGS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
         DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true,ELECTRON_ENABLE_INSPECT=true'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
@@ -120,21 +116,24 @@ jobs:
         DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.2' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
         DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3-windows'
-        DEFAULT_AZURE_VM_SIZE: 'Standard_D8s_v4'
+        DEFAULT_MAPT_VM_SIZE: "${{ vars.MAPT_VM_SIZE || 'Standard_D8s_v4' }}"
+        DEFAULT_MAPT_PARAMS: "IMAGE=${{ vars.MAPT_IMAGE || 'quay.io/redhat-developer/mapt' }},VERSION_TAG=${{ vars.MAPT_VERSION_TAG || '0.9.3' }},EXCLUDED_REGIONS=\"${{ vars.MAPT_EXCLUDED_REGIONS || 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest' }}\""
       run: |
-        echo "FORK=${{ github.event.inputs.fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
-        echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
         echo "PDE2E_IMAGE_VERSION=${{ github.event.inputs.pde2e_image_version || env.DEFAULT_PDE2E_IMAGE_VERSION }}" >> $GITHUB_ENV
+        echo "${{ github.event.inputs.podman_desktop_repo_args || env.DEFAULT_PODMAN_DESKTOP_REPO_ARGS }}" | awk -F ',' \
+         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PD_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.ext_tests_options || env.DEFAULT_EXT_TESTS_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.ext_repo_options || env.DEFAULT_EXT_REPO_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "AZURE_VM_SIZE=${{ github.event.inputs.azure_vm_size || env.DEFAULT_AZURE_VM_SIZE }}" >> $GITHUB_ENV
+        echo "MAPT_VM_SIZE=${{ github.event.inputs.azure_vm_size || env.DEFAULT_AZURE_VM_SIZE }}" >> $GITHUB_ENV
+        echo "${{ github.event.inputs.mapt_params || env.DEFAULT_MAPT_PARAMS }}" | awk -F ',' \
+          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "MAPT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
     - name: Create instance
       run: |
@@ -146,14 +145,14 @@ jobs:
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
           --user 0 \
-          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION_TAG }} azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
             --conn-details-output '/workspace' \
             --windows-version '${{ matrix.windows-version }}' \
             --windows-featurepack '${{ matrix.windows-featurepack }}' \
-            --vmsize '${{ env.AZURE_VM_SIZE }}' \
+            --vmsize '${{ env.MAPT_VM_SIZE }}' \
             --tags project=podman-desktop \
             --spot-excluded-regions ${{ env.MAPT_EXCLUDED_REGIONS }} \
             --spot
@@ -222,8 +221,8 @@ jobs:
             pd-e2e/builder.ps1 \
               -targetFolder pd-e2e \
               -resultsFolder results \
-              -fork ${{ env.FORK }} \
-              -branch ${{ env.BRANCH }} \
+              -fork ${{ env.PD_FORK }} \
+              -branch ${{ env.PD_BRANCH }} \
               -envVars ${{ env.ENV_VARS }}
         # check logs
         podman logs -f pde2e-builder-run
@@ -245,8 +244,8 @@ jobs:
                 -resultsFolder results \
                 -podmanPath $(cat results/podman-location.log) \
                 -pdPath "$(cat results/pde2e-binary-path.log | tr '\n' " ")" \
-                -fork ${{ env.FORK }} \
-                -branch ${{ env.BRANCH }} \
+                -fork ${{ env.PD_FORK }} \
+                -branch ${{ env.PD_BRANCH }} \
                 -extRepo ${{ env.EXT_REPO }} \
                 -extFork ${{ env.EXT_FORK }} \
                 -extBranch ${{ env.EXT_BRANCH }} \

--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -145,6 +145,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
+          --user 0 \
           ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows create \
             --project-name 'windows-desktop' \
@@ -270,7 +271,8 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
+          --user 0 \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION_TAG }} azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'

--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -54,7 +54,7 @@ jobs:
     name: recipe-catalog-windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-24.04
     env:
-      MAPT_VERSION: v0.7.4
+      MAPT_VERSION: v0.9.3
       MAPT_IMAGE: quay.io/redhat-developer/mapt
       MAPT_EXCLUDED_REGIONS: 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest'
     strategy:

--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -129,6 +129,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
+          --user 0 \
           ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows create \
             --project-name 'windows-desktop' \
@@ -287,7 +288,8 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
+          --user 0 \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION_TAG }} azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'

--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -45,7 +45,7 @@ on:
       pde2e-image-version:
         required: false
         type: string
-      azure-vm-size:
+      mapt_params:
         required: false
         type: string
 
@@ -53,10 +53,6 @@ jobs:
   windows:
     name: recipe-catalog-windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-24.04
-    env:
-      MAPT_VERSION: v0.9.3
-      MAPT_IMAGE: quay.io/redhat-developer/mapt
-      MAPT_EXCLUDED_REGIONS: 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest'
     strategy:
       fail-fast: false
       matrix:
@@ -101,7 +97,7 @@ jobs:
         DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.2' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
         DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3-windows'
-        DEFAULT_AZURE_VM_SIZE: 'Standard_E8as_v5'
+        DEFAULT_MAPT_PARAMS: "IMAGE=${{ vars.MAPT_IMAGE || 'quay.io/redhat-developer/mapt' }},VERSION_TAG=${{ vars.MAPT_VERSION_TAG || '0.9.3' }},VM_SIZE=${{ vars.MAPT_VM_SIZE || 'Standard_D8s_v4' }},EXCLUDED_REGIONS=\"${{ vars.MAPT_EXCLUDED_REGIONS || 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest' }}\""
       run: |
         echo "FORK=${{ inputs.pd-fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
         echo "BRANCH=${{ inputs.pd-branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
@@ -113,12 +109,13 @@ jobs:
           echo "DEFAULT_EXT_REPO_OPTIONS=REPO=${{ inputs.trigger-workflow-repo-name }},FORK=${{ inputs.trigger-workflow-fork }},BRANCH=${{ inputs.trigger-workflow-branch }}" >> $GITHUB_ENV
         fi
         echo "${{ github.event.inputs.ext_tests_options || env.DEFAULT_EXT_TESTS_OPTIONS }}" | awk -F ',' \
-         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print kv[1]"="kv[2]}}' >> $GITHUB_ENV
+          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
-         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ inputs.podman-options || env.DEFAULT_EXT_REPO_OPTIONS }}" | awk -F ',' \
-         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "AZURE_VM_SIZE=${{ inputs.azure-vm-size || env.DEFAULT_AZURE_VM_SIZE }}" >> $GITHUB_ENV
+          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+        echo "${{ github.event.inputs.mapt_params || env.DEFAULT_MAPT_PARAMS }}" | awk -F ',' \
+          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "MAPT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
     - name: Create instance
       run: |
@@ -130,14 +127,14 @@ jobs:
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
           --user 0 \
-          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION_TAG }} azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
             --conn-details-output '/workspace' \
             --windows-version '${{ matrix.windows-version }}' \
             --windows-featurepack '${{ matrix.windows-featurepack }}' \
-            --vmsize '${{ env.AZURE_VM_SIZE }}' \
+            --vmsize '${{ env.MAPT_VM_SIZE }}' \
             --tags project=podman-desktop \
             --spot-excluded-regions ${{ env.MAPT_EXCLUDED_REGIONS }} \
             --spot


### PR DESCRIPTION
### What does this PR do?
* Udates MAPT from 0.7.4 to 0.9.3
* Pre-creates `.pulumi` folder with RWX permissions - was causing failure with permission denied for folder creation from within `podman run`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#2891 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
