### PR TITLE
chore(ci): fix catalog change test status badge in PRs

### DIFF
--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -64,14 +64,14 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        status_context="ci/gh/e2e/windows-matrix-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}"
+        status_context="catalog-change-windows-matrix-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}"
         echo "status_context=${status_context}" >> "$GITHUB_ENV"
         set -xuo
         # Status msg
         data="{\"state\":\"pending\""
         data="${data},\"description\":\"Running recipe tests on catalog change on Windows ${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}\""
         data="${data},\"context\":\"$status_context\""
-        data="${data},\"target_url\":\"https://github.com/${{ inputs.trigger-workflow-base-repo }}/actions/runs/${{ inputs.trigger-workflow-run-id }}\"}"
+        data="${data},\"target_url\":\"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
         # Create status by API call
         curl -L -v -X POST \
           -H "Accept: application/vnd.github+json" \
@@ -266,8 +266,8 @@ jobs:
           data="{\"state\":\"failure\""
         fi
         data="${data},\"description\":\"Finished recipe tests on catalog change on Windows ${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}\""
-        data="${data},\"context\":\"$status_context\""
-        data="${data},\"target_url\":\"https://github.com/${{ inputs.trigger-workflow-base-repo }}/actions/runs/${{ inputs.trigger-workflow-run-id }}\"}"
+        data="${data},\"context\":\"${{ env.status_context }}\""
+        data="${data},\"target_url\":\"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
         # Create status by API call
         curl -L -v -X POST \
           -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
### What does this PR do?
* Updates the status badge in PRs
* Fixes the URL to point to appropriate run

### Screenshot / video of UI

<img width="1538" height="524" alt="Screenshot_20250718_135656" src="https://github.com/user-attachments/assets/e2f2757b-f60b-485f-9359-82aff1967084" />
<img width="847" height="172" alt="Screenshot_20250718_135713" src="https://github.com/user-attachments/assets/6113eb05-9162-4ecb-bd08-7b7ff8e48c72" />
<img width="1075" height="655" alt="Screenshot_20250718_173834" src="https://github.com/user-attachments/assets/9abc59dd-8d55-4f45-9fda-a25f6930adaa" />

Ignore the failed test - this is from my fork, cannot create Azure masine because of missing credentials

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #3326 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
