### PR TITLE
chore(ci): add missing condition, when entire trigger run was skipped…

### DIFF
--- a/.github/workflows/recipe-catalog-change-cleanup.yaml
+++ b/.github/workflows/recipe-catalog-change-cleanup.yaml
@@ -37,7 +37,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-24.04
     needs: extract-context
-    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.extract-context.outputs.trigger-template == 'skipped' }}
+    if: ${{ github.event.workflow_run.conclusion == 'skipped' || (github.event.workflow_run.conclusion == 'success' && needs.extract-context.outputs.trigger-template == 'skipped') }}
     steps:
       - name: Remove skipped or cancelled workflow run
         env:


### PR DESCRIPTION
…, because of failed linter job

### What does this PR do?
* Fixes an edge case, where linter jobs fail, but PR-check ends in success
* This causes the catalog-test to have a `skipped` run, which will persist otherwise

### Screenshot / video of UI
<img width="1378" height="801" alt="Screenshot_20250718_180438" src="https://github.com/user-attachments/assets/350d881a-42fa-404a-9891-62e4e7f25f68" />
<img width="860" height="570" alt="Screenshot_20250718_180409" src="https://github.com/user-attachments/assets/370ad0a6-897b-4328-b034-122c9adae29a" />
<img width="809" height="443" alt="Screenshot_20250718_180354" src="https://github.com/user-attachments/assets/0c282985-bd38-4f14-8982-2879b2618d43" />
<img width="1070" height="482" alt="Screenshot_20250718_180324" src="https://github.com/user-attachments/assets/e896dc50-7640-47b8-8e63-06d4b6522446" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Follow-up #2892 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
