### PR TITLE
chore(ci): switching MAPT to resource-based request

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -67,18 +67,19 @@ on:
         type: string
         required: true
       azure_vm_size:
-        default: 'Standard_E8as_v5'
+        default: ''
         description: 'Azure VM size (Standard_E4as_v5 is cheapest, 4core AMD, 32GB RAM)'
         type: choice
-        required: true
+        required: false
         options:
+          - ''
           - Standard_D8as_v5
           - Standard_D8s_v4
           - Standard_E8as_v5
           - Standard_E4as_v5
       mapt_params:
-        default: 'IMAGE=quay.io/redhat-developer/mapt,VERSION_TAG=v0.9.3,EXCLUDED_REGIONS="westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest"'
-        description: 'MAPT image, version tag and excluded regions in format IMAGE=xxx,VERSION_TAG=xxx,EXCLUDED_REGIONS=xxx'
+        default: 'IMAGE=quay.io/redhat-developer/mapt,VERSION_TAG=v0.9.5,CPUS=4,MEMORY=32,EXCLUDED_REGIONS="westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest"'
+        description: 'MAPT image, version tag and excluded regions in format IMAGE=xxx,VERSION_TAG=xxx,CPUS=xxx,MEMORY=xxx,EXCLUDED_REGIONS=xxx'
         required: true
         type: string
 
@@ -116,8 +117,7 @@ jobs:
         DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.2' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
         DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3-windows'
-        DEFAULT_MAPT_VM_SIZE: "${{ vars.MAPT_VM_SIZE || 'Standard_D8s_v4' }}"
-        DEFAULT_MAPT_PARAMS: "IMAGE=${{ vars.MAPT_IMAGE || 'quay.io/redhat-developer/mapt' }},VERSION_TAG=${{ vars.MAPT_VERSION_TAG || 'v0.9.3' }},EXCLUDED_REGIONS=\"${{ vars.MAPT_EXCLUDED_REGIONS || 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest' }}\""
+        DEFAULT_MAPT_PARAMS: "IMAGE=${{ vars.MAPT_IMAGE || 'quay.io/redhat-developer/mapt' }},VERSION_TAG=${{ vars.MAPT_VERSION_TAG || 'v0.9.5' }},CPUS=${{ vars.MAPT_CPUS || '4' }},MEMORY=${{ vars.MAPT_MEMORY || '32' }},EXCLUDED_REGIONS=\"${{ vars.MAPT_EXCLUDED_REGIONS || 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest' }}\""
       run: |
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
@@ -131,33 +131,61 @@ jobs:
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.ext_repo_options || env.DEFAULT_EXT_REPO_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "MAPT_VM_SIZE=${{ github.event.inputs.azure_vm_size || env.DEFAULT_MAPT_VM_SIZE }}" >> $GITHUB_ENV
+        echo "MAPT_VM_SIZE=${{ github.event.inputs.azure_vm_size || '' }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.mapt_params || env.DEFAULT_MAPT_PARAMS }}" | awk -F ',' \
           '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "MAPT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
     - name: Create instance
       run: |
         # Create instance
-        podman run -d --name windows-create --rm \
-          -v ${PWD}:/workspace:z \
-          -e ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }} \
-          -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
-          -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
-          -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          --user 0 \
-          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION_TAG }} azure \
-            windows create \
-            --project-name 'windows-desktop' \
-            --backed-url 'file:///workspace' \
-            --conn-details-output '/workspace' \
-            --windows-version '${{ matrix.windows-version }}' \
-            --windows-featurepack '${{ matrix.windows-featurepack }}' \
-            --vmsize '${{ env.MAPT_VM_SIZE }}' \
-            --tags project=podman-desktop \
-            --spot-excluded-regions ${{ env.MAPT_EXCLUDED_REGIONS }} \
-            --spot
-        # Check logs
-        podman logs -f windows-create
+        if [ -z "${{ env.MAPT_VM_SIZE }}" ]; then
+          echo "MAPT_VM_SIZE is not set, using resources approach"
+          podman run -d --name windows-create --rm \
+            -v ${PWD}:/workspace:z \
+            -e ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }} \
+            -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
+            -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
+            -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
+            --user 0 \
+            ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION_TAG }} azure \
+              windows create \
+              --project-name 'windows-desktop' \
+              --backed-url 'file:///workspace' \
+              --conn-details-output '/workspace' \
+              --windows-version '${{ matrix.windows-version }}' \
+              --windows-featurepack '${{ matrix.windows-featurepack }}' \
+              --cpus ${{ env.MAPT_CPUS }} \
+              --memory ${{env.MAPT_MEMORY}} \
+              --nested-virt \
+              --tags project=podman-desktop \
+              --spot-excluded-regions ${{ env.MAPT_EXCLUDED_REGIONS }} \
+              --spot
+          # Check logs
+          podman logs -f windows-create
+        else
+          echo "MAPT_VM_SIZE is set to '${{ env.MAPT_VM_SIZE }}', using size approach"
+          # Create instance with VM size
+          podman run -d --name windows-create --rm \
+            -v ${PWD}:/workspace:z \
+            -e ARM_TENANT_ID=${{ secrets.ARM_TENANT_ID }} \
+            -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
+            -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
+            -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
+            --user 0 \
+            ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION_TAG }} azure \
+              windows create \
+              --project-name 'windows-desktop' \
+              --backed-url 'file:///workspace' \
+              --conn-details-output '/workspace' \
+              --windows-version '${{ matrix.windows-version }}' \
+              --windows-featurepack '${{ matrix.windows-featurepack }}' \
+              --vmsize '${{ env.MAPT_VM_SIZE }}' \
+              --tags project=podman-desktop \
+              --spot-excluded-regions ${{ env.MAPT_EXCLUDED_REGIONS }} \
+              --spot
+          # Check logs
+          podman logs -f windows-create
+        fi
 
     - name: Check instance system info
       run: |

--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -97,7 +97,7 @@ jobs:
         DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.2' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
         DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3-windows'
-        DEFAULT_MAPT_PARAMS: "IMAGE=${{ vars.MAPT_IMAGE || 'quay.io/redhat-developer/mapt' }},VERSION_TAG=${{ vars.MAPT_VERSION_TAG || 'v0.9.3' }},VM_SIZE=${{ vars.MAPT_VM_SIZE || 'Standard_D8s_v4' }},EXCLUDED_REGIONS=\"${{ vars.MAPT_EXCLUDED_REGIONS || 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest' }}\""
+        DEFAULT_MAPT_PARAMS: "IMAGE=${{ vars.MAPT_IMAGE || 'quay.io/redhat-developer/mapt' }},VERSION_TAG=${{ vars.MAPT_VERSION_TAG || 'v0.9.5' }},CPUS=${{ vars.MAPT_CPUS || '4' }},MEMORY=${{ vars.MAPT_MEMORY || '32' }},EXCLUDED_REGIONS=\"${{ vars.MAPT_EXCLUDED_REGIONS || 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest' }}\""
       run: |
         echo "FORK=${{ inputs.pd-fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
         echo "BRANCH=${{ inputs.pd-branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
@@ -134,7 +134,9 @@ jobs:
             --conn-details-output '/workspace' \
             --windows-version '${{ matrix.windows-version }}' \
             --windows-featurepack '${{ matrix.windows-featurepack }}' \
-            --vmsize '${{ env.MAPT_VM_SIZE }}' \
+            --cpus ${{ env.MAPT_CPUS }} \
+            --memory ${{ env.MAPT_MEMORY }} \
+            --nested-virt \
             --tags project=podman-desktop \
             --spot-excluded-regions ${{ env.MAPT_EXCLUDED_REGIONS }} \
             --spot


### PR DESCRIPTION
### What does this PR do?
* Removes default vmsize for windows nightly workflow dispatch
* Updated MAPT to 0.9.5
* Switches to default resource-based MAPT request approach, while leaving the vmsize as optional back-up

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #3350

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
* Create a PR that changes ai.json
* Observe catalog-change trigger test
<!-- Please explain steps to reproduce -->
