### PR TITLE
3448 patch prcheck for model removal

### DIFF
--- a/tests/playwright/src/ai-lab-extension.spec.ts
+++ b/tests/playwright/src/ai-lab-extension.spec.ts
@@ -506,7 +506,7 @@ test.describe.serial(`AI Lab extension installation and verification`, () => {
 
   // Do not use non-instruct models in playground tests.
   // They break out of guilderails and fail the tests.
-  ['ibm-granite/granite-3.3-8b-instruct-GGUF', 'TheBloke/Mistral-7B-Instruct-v0.2-GGUF'].forEach(modelName => {
+  ['ibm-granite/granite-3.3-8b-instruct-GGUF'].forEach(modelName => {
     test.describe.serial(`AI Lab playground creation and deletion for ${modelName}`, { tag: '@smoke' }, () => {
       let catalogPage: AILabCatalogPage;
       let playgroundsPage: AILabPlaygroundsPage;


### PR DESCRIPTION
### What does this PR do?
* Removes unused model from pr-check

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#3448 
#3534 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
* `ELECTRON_ENABLE_INSPECT=true pnpm compile:current` in `podman-desktop` directory
* `PODMAN_DESKTOP_BINARY=../podman-desktop/dist/linux-unpacked/podman-desktop EXTENSION_OCI_IMAGE=quay.io/tdancs/ai-lab-indev:latest pnpm test:e2e:smoke`
<!-- Please explain steps to reproduce -->
