### PR TITLE
chore(tests): follow-up removing unused instructlab/granite-7b-lab-GGUF from tests

### DIFF
--- a/tests/playwright/src/ai-lab-extension.spec.ts
+++ b/tests/playwright/src/ai-lab-extension.spec.ts
@@ -395,15 +395,10 @@ test.describe.serial(`AI Lab extension installation and verification`, () => {
     });
   });
 
-  ['ggerganov/whisper.cpp', 'instructlab/granite-7b-lab-GGUF'].forEach(modelName => {
+  ['ggerganov/whisper.cpp'].forEach(modelName => {
     test.describe.serial(`Model service creation and deletion`, { tag: '@smoke' }, () => {
       let catalogPage: AILabCatalogPage;
       let modelServiceDetailsPage: AILabServiceDetailsPage;
-
-      test.skip(
-        isLinux && modelName === 'instructlab/granite-7b-lab-GGUF',
-        `Skipping ${modelName} model service creation on linux due to known issue`,
-      );
 
       test.beforeAll(`Open AI Lab Catalog`, async ({ runner, page, navigationBar }) => {
         aiLabPage = await reopenAILabDashboard(runner, page, navigationBar);
@@ -438,8 +433,6 @@ test.describe.serial(`AI Lab extension installation and verification`, () => {
       });
 
       test(`Make GET request to the model service for ${modelName}`, async ({ request }) => {
-        test.skip(modelName === 'instructlab/granite-7b-lab-GGUF', `Skipping GET request for ${modelName}`);
-
         const port = await modelServiceDetailsPage.getInferenceServerPort();
         const url = `http://localhost:${port}`;
 


### PR DESCRIPTION
### What does this PR do?
* Removes logic that causes failure on extended test suite

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Folow-up #3448 #3540 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
* `ELECTRON_ENABLE_INSPECT=true pnpm compile:current` in `podman-desktop` directory
* `PODMAN_DESKTOP_BINARY=../podman-desktop/dist/linux-unpacked/podman-desktop EXTENSION_OCI_IMAGE=quay.io/tdancs/ai-lab-indev:latest pnpm test:e2e`
<!-- Please explain steps to reproduce -->
