### PR TITLE
chore(ci): add disk cleanup before running tests

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -130,14 +130,8 @@ jobs:
         working-directory: ./podman-desktop-extension-ai-lab
         run: pnpm install
 
-      - name: Show disk space before cleanup
-        run: df -h
-      
       - name: Free up disk space
-        run: |
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/* /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost /usr/local/share/powershell /usr/local/share/chromium /usr/local/share/edge /usr/local/share/firefox /usr/local/share/google
-          df -h
+        uses: podman-desktop/e2e/.github/actions/disk-cleanup@6a406f8f24bacffc481553266f9ba8a5293f3077
 
       - name: Run All E2E tests
         working-directory: ./podman-desktop-extension-ai-lab

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -160,15 +160,8 @@ jobs:
           podman rm -f $CONTAINER_ID
           podman rmi -f localhost/local_ai_lab_image:latest
 
-      # Show disk space before cleanup
-      - name: Show disk space before cleanup
-        run: df -h
-      # Minimal disk cleanup after install/build
       - name: Free up disk space
-        run: |
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/* /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost /usr/local/share/powershell /usr/local/share/chromium /usr/local/share/edge /usr/local/share/firefox /usr/local/share/google
-          df -h
+        uses: podman-desktop/e2e/.github/actions/disk-cleanup@6a406f8f24bacffc481553266f9ba8a5293f3077
 
       - name: Run E2E Smoke tests
         working-directory: ./podman-desktop-extension-ai-lab

--- a/.github/workflows/ramalama.yaml
+++ b/.github/workflows/ramalama.yaml
@@ -125,6 +125,9 @@ jobs:
           podman rm -f $CONTAINER_ID
           podman rmi -f localhost/local_ai_lab_image:latest
 
+      - name: Free up disk space
+        uses: podman-desktop/e2e/.github/actions/disk-cleanup@6a406f8f24bacffc481553266f9ba8a5293f3077
+
       - name: Run E2E tests
         working-directory: ./podman-desktop-extension-ai-lab
         env:


### PR DESCRIPTION
### What does this PR do?
Update workflows: free disk space on agents before running the tests.
Relates to https://github.com/containers/podman-desktop-extension-ai-lab/issues/3632
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
