### PR TITLE
chore(test): update workflow timeout

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -79,7 +79,7 @@ on:
 
 jobs:
   windows:
-    timeout-minutes: 120
+    timeout-minutes: 180
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
### What does this PR do?
Increases the timeout for the e2e test nightly workflow to three hours.

### What issues does this PR fix or reference?