### PR TITLE
chore: add github issue types to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug 🐞
 description: Report a bug report
+type: bug
 labels: [kind/bug 🐞]
 
 body:

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,5 +1,6 @@
 name: Epic ⚡
 description: A high-level feature
+type: epic
 labels: [kind/epic ⚡]
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: Feature 💡
-description: Suggest an idea for this project
+description: A request, idea, or new functionality
+type: feature
 labels: [kind/feature 💡]
 
 body:


### PR DESCRIPTION
### What does this PR do?

Adds the GitHub issue type to the three templates in addition to the kind/* label, to allow some migration time. This removes the feature request template since it was virtually identical to the enhancement and GitHub just has one type.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

First part of #3851.

### How to test this PR?

Merge, try creating new issues.