### PR TITLE
fix: add NVIDIA CDI device for WSL2 GPU support

### DIFF
--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -120,6 +120,12 @@ export class LlamaCppPython extends InferenceProvider {
           });
 
           devices.push({
+            PathOnHost: 'nvidia.com/gpu=all',
+            PathInContainer: '',
+            CgroupPermissions: '',
+          });
+
+          devices.push({
             PathOnHost: '/dev/dxg',
             PathInContainer: '/dev/dxg',
             CgroupPermissions: 'r',


### PR DESCRIPTION
### What does this PR do?
Adds NVIDIA CDI device (`nvidia.com/gpu=all`) to WSL2 container creation to enable actual GPU access. Previously, WSL2 containers had GPU environment variables but missing device mounting, causing inference to run on CPU despite showing "GPU Inference" badge.

### Screenshot / video of UI
No UI changes, backend fix only

### What issues does this PR fix or reference?
Fixes #3431

### How to test this PR?
1- Windows 11 + WSL2 with NVIDIA GPU and drivers installed
2- Install NVIDIA Container Toolkit in WSL2 and generate CDI config (`nvidia-ctk cdi generate`)
3- Enable "Experimental GPU" in AI Lab settings
4- Create a new service with any model
5- In WSL2, run `nvidia-smi` - should show GPU usage and llama-server process
6- Verify container devices: `podman inspect <container-id> | grep -A5 Devices` - should show nvidia.com/gpu device (not empty)
