### PR TITLE
fix: stop scanning huggingface cache for e2e

### DIFF
--- a/packages/backend/src/models/HuggingFaceModelHandler.spec.ts
+++ b/packages/backend/src/models/HuggingFaceModelHandler.spec.ts
@@ -40,6 +40,7 @@ vi.mock('@huggingface/hub', () => {
   return {
     scanCacheDir: vi.fn(),
     snapshotDownload: vi.fn(),
+    getHFHubCachePath: vi.fn(),
   };
 });
 


### PR DESCRIPTION
### What does this PR do?

This pr fixes the error  

```
STDERR: [ai-lab] Something went wrong while scanning cache. [Error: ENOENT: no such file or directory, stat '/home/runner/.cache/huggingface/hub'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/home/runner/.cache/huggingface/hub'
}
```
during e2e

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
