### PR TITLE
chore: remove kind labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug 🐞
 description: Report a bug report
 type: bug
-labels: [kind/bug 🐞]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,7 +1,6 @@
 name: Epic ⚡
 description: A high-level feature
 type: epic
-labels: [kind/epic ⚡]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature 💡
 description: A request, idea, or new functionality
 type: feature
-labels: [kind/feature 💡]
 
 body:
   - type: markdown


### PR DESCRIPTION
### What does this PR do?

Removed all kind labels from the templates now that we have issue types.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #3851.

### How to test this PR?

Will confirm labels are no longer added after merging.