### PR TITLE
chore(ci): update win 11 pipelines to 25h2

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -86,10 +86,10 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-pro', '24h2-ent']
+        windows-featurepack: ['22h2-pro', '25h2-ent']
         exclude:
         - windows-version: '10'
-          windows-featurepack: '24h2-ent'
+          windows-featurepack: '25h2-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-pro'
 

--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['11']
-        windows-featurepack: ['24h2-ent']
+        windows-featurepack: ['25h2-ent']
 
     steps:
     - name: Add PR check status


### PR DESCRIPTION
### What does this PR do?
* Updates win 11 version to 25h2

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #4152 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
