### PR TITLE
chore(test): add test analysis skill

### DIFF
--- a/.agents/skills/investigate-gh-run/SKILL.md
+++ b/.agents/skills/investigate-gh-run/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: investigate-gh-run
+description: Deep investigation of CI/CD test failures - identifies root causes by analyzing logs, artifacts, git history, and source code
+---
+
+Investigate CI test failures for the given GitHub Actions run. The user will provide a run URL or run ID as: $ARGUMENTS
+
+## Protocol
+
+This is an adaptive-depth investigation. You gather all surface-level data in one parallel batch, classify the failure, then go only as deep as needed. An infra failure resolves in one round. A clear build error in two. A subtle UI regression gets the full trace analysis pipeline.
+
+Wall-clock time is the enemy. Launch independent work in parallel. Never wait for one API call to decide whether to start another.
+
+---
+
+### Step 1: Gather Everything (one parallel batch)
+
+Extract the run ID from the URL (`https://github.com/{owner}/{repo}/actions/runs/{run-id}`), then launch ALL of these in a single message:
+
+```
+# a) Run overview
+gh run view {run-id} --repo {owner}/{repo}
+
+# b) Failed job IDs
+gh api repos/{owner}/{repo}/actions/runs/{run-id}/jobs --paginate \
+  --jq '.jobs[] | select(.conclusion == "failure") | "\(.id) \(.name)"'
+
+# c) Failed logs -> temp file (10-100x smaller than full logs)
+gh run view {run-id} --repo {owner}/{repo} --log-failed \
+  > /tmp/ci-logs-{run-id}.txt 2>&1
+
+# d) Artifacts
+gh api repos/{owner}/{repo}/actions/runs/{run-id}/artifacts \
+  --jq '.artifacts[] | "\(.id) \(.name) \(.size_in_bytes)"'
+
+# e) Workflow run history (workflow name unknown, so chain via ID)
+WF_ID=$(gh api repos/{owner}/{repo}/actions/runs/{run-id} --jq '.workflow_id') && \
+gh api "repos/{owner}/{repo}/actions/workflows/$WF_ID/runs?per_page=10" \
+  --jq '.workflow_runs[] | "\(.id) \(.conclusion // "running") \(.created_at | split("T")[0])"'
+```
+
+Combine the branch-name fetch with the log save to reduce tool calls:
+
+```
+# f) Branch name
+gh api repos/{owner}/{repo}/actions/runs/{run-id} --jq '.head_branch'
+```
+
+**Identify failing tests from the overview first.** The `gh run view` output (call a) already contains `🧪` annotations and `X` markers with test names. Read these before touching any log files — they tell you WHAT failed without any grepping.
+
+Then grep the saved log file for error DETAILS (locator, expected, received):
+
+```
+echo "=== SUMMARY ===" && \
+grep -E "failed$|🧪|passed \(" /tmp/ci-logs-{run-id}.txt | grep -v "STDERR\|npm warn" | head -15 && \
+echo "=== FAILURES ===" && \
+grep -B 1 -A 5 "Error:.*expect\|Error:.*Manifest\|Error:.*timeout\|Error encountered\|intercepts pointer\|no such file\|copier subprocess\|layer not known\|unable to copy" /tmp/ci-logs-{run-id}.txt | grep -v "STDERR\|echo\|npm\|curl\|jq\|matcherResult\|endWallTime\|Symbol\|stepId\|boxedStack\|stack:" | head -50
+```
+
+**`--log-failed` blind spot:** Many CI setups (podman-desktop/e2e, extension repos) mark the test step as ✓ (passed) even when Playwright reports failures — the exit code is 0 or `continue-on-error: true`. Only the "Publish Test Report" step fails (X). In this case, `--log-failed` captures the Publish step output which may NOT contain Playwright error details. The grep will return empty.
+
+**When the grep returns empty but the overview shows test failures**, fall back immediately — don't retry different grep patterns:
+
+1. **Download the individual job log** (contains ALL step output including the passed test step):
+   ```
+   gh api repos/{owner}/{repo}/actions/jobs/{job-id}/logs > /tmp/ci-job-{job-id}.txt 2>&1
+   ```
+2. **For blob-format logs** (entire output on one line), use `grep -o` with `cut` to extract error snippets:
+   ```
+   grep -o 'Error:.*expect[^\\]*' /tmp/ci-job-{job-id}.txt | cut -c1-300 | head -5
+   grep -o 'Locator:.*' /tmp/ci-job-{job-id}.txt | cut -c1-200 | head -5
+   ```
+3. **For Testing Farm** (Playwright runs remotely): extract JUnit XML from artifacts:
+   ```
+   unzip -o ci-results.zip "*.xml" -d /tmp/ci-artifacts && \
+   grep -A 20 "failure message" /tmp/ci-artifacts/junit*.xml | head -40
+   ```
+
+---
+
+### Step 2: Classify and Route
+
+With all data in hand, classify the failure and choose the investigation depth:
+
+**A) Infra failure -> Report immediately**
+Signals: "Create instance" step failed, "Missing file: host", tiny artifact (<10KB), "Artemis resource ended in error", "MAPT container failed", no JUnit results.
+Action: Skip everything else. Write the report now. These are provisioning failures with nothing to analyze.
+
+**B) Clear build/process error -> Report after confirming with run history**
+Signals: error message is self-explanatory ("no such file or directory", "unable to copy from source docker://...", registry HTTP errors, "copier subprocess" failures). The error context page snapshot would just show a generic page.
+Action: Check run history for pattern (isolated vs chronic), then report. Skip artifact download and trace analysis — the CI log error tells the whole story.
+
+**C) UI/test failure -> Full investigation**
+Signals: locator timeouts, assertion mismatches, "intercepts pointer events", strict mode violations, `expect(locator).toBeVisible()` failures. The error message says _what_ failed but not _why_.
+Action: Continue to Steps 3-5. Download artifacts, read error-context.md, dispatch trace subagent.
+
+**Also decide:**
+
+- **Branch context:** If the run is on a feature branch (not `main`), failures may be expected during development. Check if later runs on the same branch pass — if so, it's a **resolved regression** and the fix is already in. Note this in the report and skip deep investigation.
+- **Dedup:** Multiple jobs failing with the same test? Investigate one, note the rest share the root cause.
+- **Multi-failure:** Multiple different failures in one job? Check if they cascade from the first (serial test block) or are independent.
+- **Run history pattern:** Isolated (transient), regression (code change), chronic (systemic), alternating (flaky/environment), or **resolved** (failed then fixed — later runs pass). For resolved regressions, report what failed and note the fix, but skip deep investigation.
+
+---
+
+### Step 3: Artifacts + Trace Dispatch (Category C only)
+
+Launch artifact download alongside any remaining greps. Pick the smallest artifact from a failed job that ran tests. **Skip artifacts >500MB** (videos, build outputs — will timeout). **If all artifacts show "(expired)"**, skip this entire step — older runs lose artifacts after the retention period (typically 90 days but can be as short as 1 day). You'll have to work with CI logs and run history only. Note this limitation in the report.
+
+```
+# Download + list key files in one shot
+cd /tmp && gh api repos/{owner}/{repo}/actions/artifacts/{id}/zip > ci-results.zip && \
+unzip -l ci-results.zip | grep -E "error-context|trace\.zip|junit" && \
+unzip -o ci-results.zip "**/*error-context*" "**/*trace.zip" "*.xml" -d /tmp/ci-artifacts 2>/dev/null
+```
+
+**Artifact layouts:**
+
+- **Standard (Azure/MAPT):** `results/podman-desktop/tests-.../error-context.md`, `traces/*_trace.zip`
+- **Testing Farm (Fedora):** `results/e2e-test-1/data/traces/*_trace.zip`, `junit-playwright-results.xml` at root. No error-context.md.
+- **Extension repos:** `extension-name/junit-results.xml`, `extension-name/...-chromium/error-context.md`
+
+**Read error-context.md** — for UI failures (locator timeouts, assertion mismatches), this page snapshot often reveals the answer immediately. For build/process failures, skip it — the CI log error is more useful.
+
+**Trace analysis** — if trace.zip exists, pre-extract and dispatch a background subagent:
+
+```
+mkdir -p /tmp/ci-traces/{name} && cd /tmp/ci-traces/{name} && unzip -o /path/to/trace.zip
+```
+
+Read the last 2-3 screenshots from `resources/*.jpeg | sort | tail -3`, then dispatch:
+
+```
+Agent(run_in_background=true, prompt="""
+Analyze this Playwright trace for a CI test failure.
+
+Trace: /path/to/trace.zip
+Extracted: /tmp/ci-traces/{name}/
+Failing test: [name from logs]
+Error: [message from logs]
+Error context: [paste error-context.md if available]
+Screenshots: [describe what each shows]
+
+Use the playwright-trace-analysis skill to perform the analysis.
+MCP tools if available, otherwise read extracted files.
+
+Return: failure summary, event timeline with step refs, evidence citations,
+root cause [Confirmed|Likely|Unknown], failure type, recommended action with file:line.
+""")
+```
+
+---
+
+### Step 4: Regression Hunt + Source Code (parallel, Category C only)
+
+Skip if the run history shows a chronic or isolated pattern. Launch in parallel:
+
+1. **Verify last passing run:** `gh run view {id} --repo {owner}/{repo}`
+2. **Check adjacent failures** for same test: `gh run view {id} --repo ... | grep -E "^X|🧪|❌"`
+3. **Fetch test source:** `gh api repos/{owner}/{repo}/contents/{path} --jq '.content' | base64 --decode | sed -n '{start},{end}p'`
+   (macOS base64 fallback: pipe through `python3 -c "import sys,base64;print(base64.b64decode(sys.stdin.read()).decode())"`)
+4. **Commits between pass/fail:** `git log --oneline --since="{date}" --until="{date}" -- {paths}`
+
+---
+
+### Step 5: Report
+
+Collect trace subagent results if dispatched. Correlate all evidence: CI logs, error context, trace findings, test source, regression history, platform comparison. If CI logs and trace disagree, trust traces for UI failures, logs for infra.
+
+```
+## CI Failure Investigation
+
+### Summary
+One-sentence root cause.
+
+### What Failed
+| Job | Test | Error | Duration |
+|-----|------|-------|----------|
+
+### Root Cause
+- **What:** ...
+- **Where:** file:line
+- **When introduced:** commit or "N/A — transient"
+- **Why:** mechanism
+- **Evidence:** screenshot, log, trace step citations
+
+### Classification
+[App bug | Test bug | Likely flaky | Environment/infra] — [Confirmed | Likely | Unknown]
+
+### Fix
+Specific code change with rationale, or "No code fix — [explanation]".
+```
+
+---
+
+## Investigation Playbook
+
+Hard-earned patterns from real investigations. Use these to shortcut analysis.
+
+### Error -> Diagnosis Shortcuts
+
+| Error pattern                                                                      | Likely cause                                                          | Skip to                     |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------- | --------------------------- |
+| `Missing file: host` / `MAPT container failed` / `Artemis resource ended in error` | Azure/Testing Farm VM provisioning failure                            | Report (Category A)         |
+| `Unable to download docker-compose binary: HttpErr`                                | GitHub API download failure; test only handles success + rate-limit   | Report (Category B)         |
+| `overlay/.../merged: no such file or directory` / `copier subprocess`              | Container storage corruption, often after "Free up disk space" step   | Report (Category B)         |
+| `unable to copy from source docker://...`                                          | Registry pull failure (network/rate limit)                            | Report (Category B)         |
+| `intercepts pointer events` + `fade-bg` div                                        | Modal overlay blocking clicks; test doesn't wait for dialog dismissal | Trace analysis (Category C) |
+| `strict mode violation: ... resolved to 2 elements`                                | Locator matches multiple DOM nodes; `.or()` compound locator issue    | Error context (Category C)  |
+| `Expected: "RUNNING"` / `Received: "STOPPED"`                                      | Resource never reached target state within timeout                    | Platform comparison         |
+| `Test timeout of N ms exceeded` + `Target page closed`                             | Long operation exceeded test timeout; browser was killed              | Build/process failure       |
+
+### Platform Patterns
+
+- **Win10 vs Win11:** Win10 CI runners are consistently slower. K8s deployments, image builds, and cluster operations often timeout on Win10 while passing on Win11 with identical code.
+- **x86 vs ARM (macOS-26, Win11-ARM):** ARM runners have different timing characteristics. Tests with tight timeouts (5s) for UI rendering or provider initialization may pass on x86 but fail on ARM. If failures cluster on ARM platforms while x86 passes, suspect timing — increase timeouts.
+- **WSL vs Hyper-V:** Different networking and filesystem behavior.
+- **Linux (Testing Farm) vs Windows:** Different artifact layouts, auth file paths, filesystem watchers. No error-context.md on Testing Farm — use JUnit XML.
+- **GPU vs Default (Testing Farm):** GPU pool has been chronically unavailable. If only GPU jobs fail with provisioning errors, it's infra.
+- **Dev vs Prod mode:** Prod binaries may have different startup timing (minified, no sourcemaps, different Electron flags). A test passing in dev but failing in prod (or vice versa) on the same runner suggests mode-specific initialization differences.
+
+### Workflow Patterns
+
+- **✓ Run tests / X Publish Report:** The test step passes but the publish step fails. This means `--log-failed` won't contain Playwright errors — they're in the passed test step's log. Fall back to downloading the full job log. The `gh run view` annotations still show `🧪` with test names. This is the default pattern for podman-desktop/e2e, extension-bootc, and Testing Farm workflows.
+- **X Run tests / X Publish Report:** Both fail. `--log-failed` contains Playwright errors from the test step. Grep works normally. This is the pattern for kortex, ai-lab main e2e, and workflows where the test step exits non-zero on failure.
+
+### Noise to Ignore
+
+- `Gtk: gtk_widget_add_accelerator: assertion failed` — Electron/Gtk compat on Linux
+- `npm warn Unknown env config` — pnpm/npm config mismatch
+- `cpu-features install: Error: Unable to detect compiler type` — optional native module
+- `Error trying to run the version on docker-compose. Binary might not be there` — expected when compose isn't installed
+- `Error: Failed to execute command: spawn kind ENOENT` — expected when kind isn't installed

--- a/.agents/skills/playwright-trace-analysis/SKILL.md
+++ b/.agents/skills/playwright-trace-analysis/SKILL.md
@@ -1,0 +1,474 @@
+---
+name: playwright-trace-analysis
+description: >-
+  Analyzes Playwright trace archives (`trace.zip`) to diagnose test failures,
+  flaky behavior, and unexpected UI states using trace steps, console output,
+  network activity, and screenshots. Use when the user provides a trace path or
+  trace artifact, asks why a Playwright or E2E test failed, wants root-cause
+  analysis from CI artifacts, mentions the trace viewer, or asks whether a
+  failure is flaky or an application bug.
+---
+
+# Playwright Trace Analysis
+
+## When to use
+
+Apply when the user provides:
+
+- A `trace.zip` path
+- A trace artifact to inspect
+- A failing Playwright/E2E test and asks for root-cause analysis from the trace
+- Two traces to compare, such as passing vs failing or retry-0 vs retry-1
+
+## Immediate behavior
+
+If the user already provided a usable trace path or attached trace artifact, start analysis immediately.
+
+Do **not** ask for extra context up front unless one of these is true:
+
+- The trace path is missing
+- The path is ambiguous or unresolved
+- The user supplied multiple traces and did not say which one to analyze
+
+Optional context like test title, CI log, expected behavior, or retry history can help, but it is not required for the first analysis pass.
+
+## Inputs
+
+- Absolute path to `trace.zip`
+- Or a workspace-relative path you can resolve safely
+- Optional: test title, spec file, CI snippet, expected behavior, retry history, second trace
+
+If the user points to a directory instead of a zip, locate the trace archive inside it before analyzing. If multiple candidate zips exist, ask one focused follow-up question.
+
+## MCP tools
+
+Use the `user-playwright-analyzer` MCP server.
+
+Before the first MCP call in a session, read the server tool descriptors from the Cursor MCP directory and use the schema exactly as written. Do not guess parameter names.
+
+All current tools require `traceZipPath`.
+
+| toolName                    | Use                                                     | Important parameters               |
+| --------------------------- | ------------------------------------------------------- | ---------------------------------- |
+| `analyze-trace`             | Combined first-pass overview. **Start here.**           | —                                  |
+| `get-trace`                 | Step-by-step actions and console context                | `filterPreset`, `raw`              |
+| `get-network-log`           | Request/response details                                | `raw`                              |
+| `get-screenshots`           | Relevant screenshots around errors and critical actions | —                                  |
+| `view-screenshot`           | Inspect one screenshot by filename                      | `filename`                         |
+| `get-raw-trace-paginated`   | Raw trace when filtered output is insufficient          | `browserIndex`, `page`, `pageSize` |
+| `get-raw-network-paginated` | Raw network when filtered output is insufficient        | `browserIndex`, `page`, `pageSize` |
+
+### MCP fallback — manually-created traces
+
+Some test frameworks create traces manually using Playwright's tracing API (`tracing.start()` / `tracing.stop()`) rather than relying on Playwright's built-in per-test trace mechanism. These traces are structurally valid but may use naming conventions or internal layouts that the MCP tool does not recognize.
+
+**When the MCP tool returns "No trace files found" or similar errors but the zip does contain `trace.trace` / `trace.network` files, fall back to manual analysis.** Do not assume the trace is empty or broken — verify by listing the zip contents first.
+
+See the [Manual trace parsing](#manual-trace-parsing) section below and [reference.md](reference.md) for the detailed file format and parsing scripts.
+
+### Escalation rules
+
+Prefer the smallest useful call sequence:
+
+1. `analyze-trace`
+2. If the MCP tool returns errors or empty results, verify the zip contents (`unzip -l`) and fall back to [manual trace parsing](#manual-trace-parsing)
+3. `get-trace` with `filterPreset: "minimal"` if the overview is not enough
+4. One or more corroborating calls based on the failure signal:
+   - `get-screenshots` for locator, visibility, or wrong-page problems
+   - `get-network-log` for failed or missing requests
+   - `get-trace` with `filterPreset: "moderate"` for console-heavy or sequence-heavy failures
+5. `get-trace` with `filterPreset: "conservative"` only if prior calls are still inconclusive
+6. Raw paginated tools only as a last resort
+
+Avoid jumping to `raw: true` early. Large raw payloads are harder to reason about and more likely to be truncated.
+
+### Parallel tool calls
+
+When the overview suggests you need multiple corroborating signals, call them in parallel rather than sequentially. For example, if a locator timed out and you suspect both a visual issue and a network issue, call `get-screenshots` and `get-network-log` in the same tool-call batch.
+
+Good parallel combinations:
+
+- `get-screenshots` + `get-network-log` — locator timeout with possible data-loading cause
+- `get-screenshots` + `get-trace` (moderate) — wrong visual state with unknown trigger
+- `get-network-log` + `get-trace` (moderate) — API failure with unclear console context
+
+Do not parallelize calls that depend on each other's output (e.g., don't call `view-screenshot` until you know the filename from `get-screenshots`).
+
+## Standard workflow
+
+### Step 1: Run the overview
+
+Call `analyze-trace` first and extract:
+
+- The failing test or action if available
+- The exact error text
+- The first meaningful failing step
+- Any obvious screenshot or network clues
+- Action durations — note any step that took significantly longer than its peers
+
+### Step 2: Read the test source
+
+Once you know the failing test file and approximate line, read the relevant spec file and any page objects it uses. This gives you:
+
+- **Intent**: what the test was trying to verify
+- **Locator context**: whether the locator is reasonable or brittle
+- **Assertion context**: whether the expected value still makes sense
+- **Flow context**: what earlier steps should have set up the state for the failing assertion
+
+If the test file path is not in the trace output, search the workspace for the test name or assertion text.
+
+### Step 3: Find the first meaningful failure
+
+Prioritize the earliest causal failure, not the later cascade.
+
+Build a mental timeline by mapping:
+
+1. The last successful action before the failure
+2. Any console errors or warnings between success and failure
+3. Any network requests initiated or completed in that window
+4. The screenshot state at the moment of failure
+
+Examples of likely causal signals:
+
+- Assertion mismatch
+- Locator timeout or actionability failure
+- Navigation timeout or unexpected URL
+- Console exception before the failing assertion
+- 4xx/5xx request or a required request never being sent
+- Action duration spike (a step taking 10x longer than similar steps)
+
+### Step 4: Corroborate with additional signals
+
+Before concluding, check at least one additional source unless the trace already contains a direct smoking gun.
+
+Recommended pairings:
+
+| Primary signal                | Best corroboration                         |
+| ----------------------------- | ------------------------------------------ |
+| Locator timeout               | Screenshots                                |
+| Assertion mismatch            | Network or console                         |
+| Wrong page / navigation issue | Screenshots and network                    |
+| Console exception             | Trace step immediately before it           |
+| API failure                   | Network details and screenshot state       |
+| Slow action duration          | Network log (pending request?) and console |
+
+### Step 5: Correlate with code changes (when useful)
+
+If the failure looks like a regression (test was previously passing), check recent changes:
+
+- Run `git log --oneline -10 -- <failing-source-file>` on the app code the trace points to
+- Run `git log --oneline -10 -- <spec-file>` on the test itself
+- Check if the locator targets something that was recently renamed or restructured
+
+This is especially valuable when the failure classification is "app bug" or "test bug" — it often reveals the introducing commit.
+
+### Step 6: Classify the failure
+
+Use one of these buckets:
+
+- **App bug**: the trace shows the application produced the wrong state or errored
+- **Test bug**: the trace shows the app behaved correctly but the test asserted the wrong thing or used a bad locator
+- **Likely flaky**: the trace shows a timing-sensitive race, loading state, animation, or ordering issue
+- **Environment / infra**: the failure is caused by CI runner state, missing dependencies, or external service unavailability
+- **Unknown**: the available trace data is insufficient
+
+Do not classify unless the trace supports it. State your confidence level explicitly.
+
+### Step 7: Report
+
+See the reporting contract below. Lead with the root cause, back every claim with trace evidence, and propose a specific fix.
+
+## Decision guide
+
+| What you see                                            | What to do next                                                                                                |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| MCP returns "No trace files found" or similar error     | List zip contents with `unzip -l`; if `trace.trace` exists, use [manual trace parsing](#manual-trace-parsing)  |
+| Clear assertion mismatch and obvious cause in overview  | Report it; extra MCP calls may be unnecessary                                                                  |
+| Locator timeout or hidden element                       | Run `get-screenshots`                                                                                          |
+| Overview mentions console errors but not enough context | Run `get-trace` with `filterPreset: "minimal"` or `"moderate"`                                                 |
+| Network summary shows 4xx/5xx or missing response       | Run `get-network-log`                                                                                          |
+| Screenshot looks wrong but not enough detail            | Run `view-screenshot` for the named frame                                                                      |
+| Filtered output omits the needed detail                 | Escalate to `conservative`, then raw paginated tools                                                           |
+| Multiple browser sessions exist                         | Use `browserIndex` on paginated raw tools                                                                      |
+| Failure looks like a regression                         | Check git history for the affected file                                                                        |
+| Test source uses a brittle locator                      | Read the spec file and propose a resilient alternative                                                         |
+| CI artifact is a nested zip (not a direct trace zip)    | Extract the inner trace zip first, then analyze                                                                |
+| Multiple runs fail the same way                         | Do **not** default to flaky; run [exhaustive console analysis](#exhaustive-console-analysis) across all traces |
+
+## Common patterns
+
+### Locator and actionability failures
+
+- `waiting for locator(...)` then timeout: element never appeared, selector changed, or page never reached the expected state
+- `not visible` / `not enabled`: overlay, modal, disabled control, or incomplete render
+- `strict mode violation`: selector is too broad and matched multiple elements
+
+Check screenshots first, then console or network if the UI looks incomplete.
+
+### Assertion failures
+
+- Expected text/value/count differs from actual: stale data, wrong element, race with data loading, or changed product behavior
+- Expected visible but got hidden: render failure, delayed data, or transient UI state
+
+Check whether the expected state arrives later than the assertion window before calling it flaky.
+
+### Navigation failures
+
+- `goto` or `waitForURL` timeout: redirect loop, app crash, auth redirect, slow load, or wrong expectation
+- Unexpected page in screenshot: navigation intercepted or user flow diverged earlier
+
+Check network and screenshots together.
+
+### Network failures
+
+- 4xx before assertion: auth/session/request contract issue
+- 5xx: backend failure
+- Request never sent: frontend logic never fired, earlier JS error blocked it, or user action failed
+- CORS/preflight issue: cross-origin misconfiguration
+
+### Timing and duration anomalies
+
+- A single action taking 5-10x longer than peers: likely waiting on a network response, animation, or resource load
+- Gradual slowdown across steps: possible memory leak or resource exhaustion
+- Timeout at exactly the configured limit (e.g., 30000ms): the condition was never met, not just slow
+
+### Electron-specific patterns
+
+- **IPC failures**: console errors mentioning `ipcRenderer`, `ipcMain`, or channel names indicate broken communication between main and renderer processes
+- **Webview loading**: if the test interacts with a webview, check whether the webview's `document` loaded (look for webview-related console messages or navigation events)
+- **Multi-window issues**: Electron apps can have multiple `BrowserWindow` instances; verify the trace is from the correct window
+- **Preload script errors**: errors during preload indicate the renderer lacks expected APIs — check console output for preload-related messages
+
+### Flakiness indicators
+
+Treat as likely flaky only when the trace suggests timing or nondeterminism, for example:
+
+- Screenshot shows spinner/loading/skeleton instead of final UI
+- Expected state appears after the timeout window
+- Animation or transition seems to block the action
+- Request ordering matters and looks variable
+- Retry history or CI context indicates pass-on-retry behavior
+
+If you suspect flakiness, say why and recommend the stabilization point, such as waiting for a specific response, element state, or post-animation condition.
+
+### Deterministic failures across multiple runs
+
+When multiple traces from separate CI runs are provided and they all fail the same way, **raise the bar significantly before classifying as flaky**. A failure that reproduces N/N times across independent runs is almost certainly deterministic. Even if the test has `continue-on-error: true` or is known to be occasionally flaky, consistent reproduction points to an app bug or environment regression — not timing luck.
+
+In this scenario:
+
+1. **Do not default to "likely flaky"** — consistent reproduction is strong counter-evidence against flakiness.
+2. **Perform an exhaustive console log scan** (see [Exhaustive console analysis](#exhaustive-console-analysis) below) before drawing conclusions. The root cause often hides in a log-level message that a severity-filtered search misses.
+3. **Look for a common causal event** across all traces rather than analyzing each in isolation. If the same console error, network failure, or UI state appears in every trace, that is almost certainly the root cause.
+4. Classify as flaky only if the traces show genuinely different failure modes or if some runs pass and others fail.
+
+## Reporting contract
+
+Every analysis must include all of the sections below. The report should be structured so a developer can read it top-to-bottom in under 2 minutes and know exactly what happened, why, and what to do.
+
+### Required sections
+
+1. **Failure summary** — One or two sentences: what failed and the most likely cause.
+2. **Event timeline** — A compact chronological sequence of the key events leading to the failure. Include timestamps or step numbers when available. This gives the reader the narrative arc.
+3. **Evidence** — Each claim must cite a specific artifact from the trace. Use this format:
+   - `[trace step N]` — reference to a specific action or event in the trace
+   - `[screenshot: filename]` — reference to a screenshot, with a brief description of what it shows
+   - `[network: METHOD url → status]` — reference to a specific request
+   - `[console: level] message` — reference to a console log entry
+4. **Root cause** — A confidence-labeled explanation. Format: `[Confirmed|Likely|Unknown] explanation`. If `Likely` or `Unknown`, briefly state what additional evidence would upgrade the confidence.
+5. **What was ruled out** — Briefly list alternative hypotheses you investigated and why they don't fit. This builds trust in the conclusion and saves the developer from re-investigating dead ends.
+6. **Recommended action** — A specific, actionable fix. When the fix is in test code, include the file path, the problematic line or locator, and the suggested replacement. When the fix is in application code, point to the relevant source file and describe the expected behavior change.
+
+### Report template
+
+Use markdown headers matching the required sections above. Cite evidence with these prefixes: `[trace step N]`, `[screenshot: filename]`, `[network: METHOD url → status]`, `[console: level] message`. See [reference.md](reference.md) for the full citation format reference.
+
+For test code fixes, include the file path, problematic line/locator, and suggested replacement. For app code fixes, point to the relevant source file and describe the expected behavior change.
+
+### Severity annotation (optional but encouraged)
+
+When context is available, annotate the failure with severity:
+
+- **Blocking**: test suite cannot proceed, or the failure indicates a critical app regression
+- **Significant**: test fails reliably, indicating a real but non-critical issue
+- **Minor**: cosmetic or low-impact, or the test itself is overly strict
+- **Infra-only**: failure is caused by CI environment, not application or test code
+
+## Multi-trace comparison
+
+When two traces are provided:
+
+1. Run `analyze-trace` on both (in parallel)
+2. Find where their step sequences diverge
+3. Compare screenshots and network behavior at the divergence point
+4. Report the **delta**, not two separate full summaries
+
+Focus on: "the failing trace diverges here, and this is the first difference that plausibly explains the failure."
+
+### Retry-trace comparison
+
+When Playwright retries produce multiple traces for the same test:
+
+1. Compare the traces to determine whether the failure is consistent or intermittent
+2. If the retry passes, focus on what differs — typically network timing, element ordering, or data availability
+3. A consistent failure across retries is likely deterministic; a pass-on-retry is likely flaky
+4. Report the specific divergence point and the stabilization needed
+
+### Batch analysis
+
+When multiple traces from a CI run are provided:
+
+1. Run `analyze-trace` on each (in parallel, up to 3-4 at a time)
+2. Look for common failure patterns — same error message, same failing API endpoint, same console exception
+3. Group failures by root cause rather than reporting each individually
+4. If a single root cause explains multiple failures, say so explicitly and list the affected tests
+
+## If the trace is insufficient
+
+State that directly. Good examples:
+
+- "The trace shows the assertion timing out, but not why the data never loaded."
+- "I can confirm the UI was still loading, but I cannot tell from this trace alone whether the delay came from the app or the test environment."
+
+Then name the single best next action:
+
+- Escalate `get-trace` to `moderate` or `conservative`
+- Inspect `get-network-log` (possibly with `raw: true` if the filtered version omits relevant requests)
+- Compare with a passing trace
+- Review the failing locator or assertion in the test source
+- Check for a video artifact alongside the trace
+- Look at CI runner logs for environment issues (OOM, disk, network)
+
+Do not leave the analysis open-ended. Always propose a concrete next step even when the trace is insufficient.
+
+## Exhaustive console analysis
+
+Console messages in Playwright traces carry a `messageType` field (`log`, `debug`, `info`, `warning`, `error`). **Do not filter solely by `error` or `warning` severity.** Application code frequently logs critical errors at `log` or `info` level — for example, a `catch` block that calls `console.log(\`Error while ...: ${err}\`)`instead of`console.error(...)`. Filtering only by severity will miss these, potentially causing you to misdiagnose the failure entirely.
+
+### Required console scanning procedure
+
+When performing manual trace parsing, always run **two passes** over console messages:
+
+1. **Severity pass** — collect all `error` and `warning` messages.
+2. **Keyword pass** — collect messages at **any** severity level whose text matches failure-related patterns. Use a broad keyword set:
+
+```
+error, fail, TypeError, ReferenceError, SyntaxError, reject, crash,
+abort, ECONNREFUSED, ENOTFOUND, ETIMEDOUT, fetch failed, tls, cert,
+ssl, socket, refused, timeout, 4xx, 5xx, unauthorized, forbidden,
+not found, unreachable, cannot, unable
+```
+
+Report the union of both passes. When a message appears at an unexpected severity (e.g., an error message at `log` level), flag the mismatch explicitly — it often indicates a swallowed error in the application code that is central to the failure.
+
+### Why this matters
+
+A real-world example: `TypeError: fetch failed` from the Kubernetes client was logged via `console.log()` (not `console.error()`). Filtering only for `error`-level messages missed it entirely, leading to a misdiagnosis of "test flakiness / timing issue" when the actual root cause was the app's `fetch()` calls failing due to a build configuration change. The error was present in all traces and was the direct cause of "Cluster not reachable" — but it was invisible to a severity-only filter.
+
+## Manual trace parsing
+
+When the MCP tool cannot parse the trace (common with manually-created traces), analyze the files directly. The trace zip typically contains three components: `trace.trace`, `trace.network`, and `resources/` with screenshots.
+
+### Step 1: Verify zip contents and extract
+
+```bash
+unzip -l /path/to/trace.zip | head -20
+```
+
+Look for `trace.trace`, `trace.network`, and `resources/*.jpeg`. If the trace zip is nested inside a CI artifact archive, extract the inner zip first.
+
+### Step 2: Parse actions and locator resolutions from trace.trace
+
+The `trace.trace` file is newline-delimited JSON. Each line is an object with a `type` field. The key types for failure analysis are `before` (action start), `after` (action result), `log` (Playwright internal logs), and `console` (browser console output). See [reference.md](reference.md) for the full format specification and ready-to-use parsing scripts.
+
+Extract the action timeline and errors:
+
+```bash
+python3 -c "
+import json
+with open('trace.trace') as f:
+    for line in f:
+        obj = json.loads(line.strip())
+        t = obj.get('type', '')
+        if t == 'before':
+            cid = obj.get('callId', '')
+            api = obj.get('apiName', '')
+            sel = obj.get('params', {}).get('selector', '')[:100]
+            print(f'[{cid}] {api} selector={sel}')
+        elif t == 'after' and obj.get('error'):
+            print(f'[{obj[\"callId\"]}] ERROR: {obj[\"error\"]}')
+        elif t == 'log':
+            msg = obj.get('message', '')[:200]
+            if any(k in msg.lower() for k in ['error', 'fail', 'timeout', 'locator resolved']):
+                print(f'  LOG: {msg}')
+        elif t == 'console':
+            args = obj.get('args', [])
+            text_parts = [a.get('preview', '') or a.get('value', '') for a in args]
+            text = ' '.join(str(p) for p in text_parts if p)[:300]
+            msg_type = obj.get('messageType', '')
+            # Always show error/warning level
+            if msg_type in ('error', 'warning'):
+                print(f'  CONSOLE [{msg_type}]: {text}')
+            # Also show ANY level if text matches failure keywords
+            elif text and any(k in text.lower() for k in [
+                'error', 'fail', 'typeerror', 'referenceerror', 'reject',
+                'crash', 'abort', 'econnrefused', 'enotfound', 'etimedout',
+                'fetch failed', 'tls', 'cert', 'ssl', 'socket', 'refused',
+                'timeout', 'unauthorized', 'forbidden', 'unreachable',
+                'cannot', 'unable']):
+                print(f'  CONSOLE [{msg_type}]: {text}')
+"
+```
+
+**Important:** The console extraction above scans messages at **all** severity levels for failure-related keywords, not just `error`/`warning`. This is essential — application code may log critical errors via `console.log()` rather than `console.error()`. See [Exhaustive console analysis](#exhaustive-console-analysis) for the rationale.
+
+The `log` entries with "locator resolved to" are critical — they show exactly which DOM element Playwright matched for each retry of an assertion. Repeated resolution to a hidden or wrong element (as seen in `.first()` matching a `class="hidden"` span) is a strong signal for locator bugs.
+
+### Step 3: View screenshots at specific timestamps
+
+Screenshot filenames encode timestamps: `page@<hash>-<timestamp>.jpeg`. Use the timestamps to correlate with trace events, or use `view-screenshot` from the MCP tool (which still works even when trace parsing fails).
+
+### Step 4: Check network log
+
+```bash
+python3 -c "
+import json
+with open('trace.network') as f:
+    for line in f:
+        obj = json.loads(line.strip())
+        snap = obj.get('snapshot', {})
+        url = snap.get('request', {}).get('url', '')
+        status = snap.get('response', {}).get('status', '')
+        if not url.startswith('file://'):
+            print(f'{snap[\"request\"][\"method\"]} {url} -> {status}')
+"
+```
+
+For Electron apps, the network log typically only captures renderer-process requests (local `file://` resource loads). API calls made by the main process (e.g., Octokit calls to GitHub) are not captured in the trace.
+
+## CI artifact structure
+
+CI artifacts nest traces inside larger archives. Extract the inner trace zip before analyzing. See [reference.md](reference.md) for the full layout, `json-results.json` parsing scripts, and `error-context.md` usage.
+
+```bash
+unzip -l artifact.zip | grep trace.zip
+unzip artifact.zip "path/to/trace.zip" -d /tmp/analysis
+```
+
+## If MCP is unavailable
+
+Fall back to the Playwright CLI viewer. See [reference.md](reference.md) for details.
+
+```bash
+pnpm exec playwright show-trace /absolute/path/to/trace.zip
+```
+
+## After analysis
+
+- If the likely issue is in the Playwright spec, page object, or test config, follow the [playwright-testing skill](../playwright-testing/SKILL.md).
+- If the trace points to application code, navigate to the relevant source and propose a fix grounded in the trace evidence.
+- When proposing fixes, always include the specific file path and line reference — never leave the developer to hunt for the right location.
+
+## Additional resources
+
+- Extended tool details, signal correlation, and Electron-specific guidance: [reference.md](reference.md)

--- a/.agents/skills/playwright-trace-analysis/reference.md
+++ b/.agents/skills/playwright-trace-analysis/reference.md
@@ -1,0 +1,516 @@
+# Playwright Trace Analysis — Reference
+
+## Agent behavior
+
+If the user already supplied a usable `trace.zip` path or attached artifact, begin analysis immediately.
+
+Ask a follow-up question only when:
+
+- No trace path or artifact was provided
+- The path cannot be resolved
+- Multiple candidate trace archives exist and the target is unclear
+
+Do not block the first pass on optional context like test name, CI logs, or expected behavior.
+
+## Path handling
+
+- Prefer absolute paths when calling MCP tools
+- Resolve workspace-relative paths before the call
+- If the user provides a directory, locate the relevant `trace.zip` inside it
+- If more than one matching archive is present, ask one targeted clarification instead of guessing
+
+## Trace archive layout
+
+A `trace.zip` typically contains (layout varies by Playwright version):
+
+| File/directory  | Contents                                                             |
+| --------------- | -------------------------------------------------------------------- |
+| `trace.trace`   | Newline-delimited JSON — actions, events, console logs, snapshots    |
+| `trace.network` | Newline-delimited JSON — HAR-like network request/response data      |
+| `resources/`    | Screenshots (JPEG), snapshot HTML, and media referenced by the trace |
+
+When MCP tools can parse the trace, use them. When they cannot (common with manually-created traces — see below), parse the files directly using the format specification in this section.
+
+## Manually-created vs automatic traces
+
+Playwright supports two trace creation modes:
+
+1. **Automatic** (per-test): configured via `playwright.config.ts` with `trace: 'on'` or `trace: 'retain-on-failure'`. Playwright creates one trace per test with rich metadata (test name, step annotations, source locations). MCP tools are designed for this format.
+
+2. **Manual** (API-driven): the test framework calls `page.context().tracing.start()` and `tracing.stop({ path })` explicitly. This produces a valid trace zip but may lack per-test metadata, use continuous recording across multiple tests, or use non-standard file naming. The MCP tool may report "No trace files found" for these.
+
+**Always verify the zip contents with `unzip -l` before concluding a trace is empty.** If `trace.trace` and `trace.network` exist, the data is there — it just needs manual parsing.
+
+## trace.trace file format
+
+Newline-delimited JSON. Each line is a self-contained JSON object with a `type` field.
+
+### Entry types
+
+| Type               | Description                                                  | Key fields                                                           |
+| ------------------ | ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `context-options`  | First line. Browser/Playwright config, env vars, launch args | `browserName`, `playwrightVersion`, `options.env`                    |
+| `before`           | Action started (click, fill, expect, etc.)                   | `callId`, `apiName`, `params.selector`, `wallTime`                   |
+| `after`            | Action completed                                             | `callId`, `error` (present only on failure)                          |
+| `log`              | Playwright internal log (locator resolution, wait status)    | `message`                                                            |
+| `console`          | Browser console output                                       | `messageType` (`log`, `error`, `warning`, `debug`), `args[].preview` |
+| `frame-snapshot`   | DOM snapshot reference                                       | `sha1` (references a file in `resources/`)                           |
+| `screencast-frame` | Screenshot frame reference                                   | `sha1`, `timestamp`                                                  |
+| `input`            | User input event                                             | `type` (e.g., `mousedown`), coordinates                              |
+
+### Critical fields for failure analysis
+
+**`before` entries:**
+
+```json
+{
+  "type": "before",
+  "callId": "call@1716",
+  "apiName": "expect.toBeVisible",
+  "params": {
+    "selector": "internal:role=region[name=\"Onboarding Body\"i] >> internal:label=\"Onboarding Status Message\"i >> ...",
+    "isNot": false
+  },
+  "wallTime": 1774063988000
+}
+```
+
+**`after` entries (with error):**
+
+```json
+{
+  "type": "after",
+  "callId": "call@1716",
+  "error": { "name": "Expect", "message": "Expect failed" }
+}
+```
+
+**`log` entries — locator resolution:**
+
+```
+locator resolved to <span contenteditable="false" class="hidden s-qNHuh0m3pQVo">...</span>
+```
+
+These entries are the most diagnostic for locator bugs. When the same `callId` produces repeated `log` entries showing resolution to the same element, it means Playwright is retrying the assertion and consistently matching that element. If the element is hidden or wrong, this reveals the root cause.
+
+**`console` entries:**
+
+```json
+{
+  "type": "console",
+  "messageType": "error",
+  "args": [{ "preview": "main ↪️", "type": "string" }]
+}
+```
+
+Note: in Electron apps, console messages from the main process are forwarded to the renderer with a `main ↪️` prefix. These are often truncated in the `preview` field.
+
+### Parsing scripts
+
+**Full action timeline with errors and key logs:**
+
+```python
+import json
+with open('trace.trace') as f:
+    for line in f:
+        obj = json.loads(line.strip())
+        t = obj.get('type', '')
+        if t == 'before':
+            cid = obj.get('callId', '')
+            api = obj.get('apiName', '')
+            sel = obj.get('params', {}).get('selector', '')[:120]
+            print(f'[{cid}] BEFORE {api} selector={sel}')
+        elif t == 'after':
+            cid = obj.get('callId', '')
+            err = obj.get('error')
+            if err:
+                print(f'[{cid}] AFTER error={err}')
+        elif t == 'log':
+            msg = obj.get('message', '')[:200]
+            if any(k in msg.lower() for k in ['error', 'fail', 'timeout', 'locator resolved']):
+                print(f'  LOG: {msg}')
+        elif t == 'console':
+            args = obj.get('args', [])
+            text = args[0].get('preview', '')[:200] if args else ''
+            msgtype = obj.get('messageType', '')
+            if msgtype == 'error' or 'rate limit' in text.lower():
+                print(f'  CONSOLE [{msgtype}]: {text}')
+```
+
+**Summary of entry types (useful for orientation):**
+
+```python
+import json
+from collections import Counter
+types = Counter()
+with open('trace.trace') as f:
+    for line in f:
+        obj = json.loads(line.strip())
+        types[obj.get('type', 'unknown')] += 1
+for t, c in types.most_common():
+    print(f'{t}: {c}')
+```
+
+## trace.network file format
+
+Newline-delimited JSON. Each line is a `resource-snapshot` entry with HAR-like structure:
+
+```json
+{
+  "type": "resource-snapshot",
+  "snapshot": {
+    "pageref": "page@<hash>",
+    "startedDateTime": "2026-03-21T03:33:03.269Z",
+    "request": {
+      "method": "GET",
+      "url": "file:///path/to/resource.css",
+      "headers": [...]
+    },
+    "response": {
+      "status": 200,
+      "statusText": "OK",
+      "content": { "size": 168765, "mimeType": "text/css" }
+    }
+  }
+}
+```
+
+**Electron caveat:** For Electron apps, the network log typically only captures renderer-process requests — local `file://` loads for CSS, JS, fonts, and images. API calls made by the main process (e.g., Octokit calls to GitHub, Docker API calls) are **not** captured because they run in Node.js, not the browser context. Do not expect to find external HTTP traffic here.
+
+## Screenshot naming and timestamps
+
+Screenshots in `resources/` follow the pattern:
+
+```
+page@<context-hash>-<unix-timestamp-ms>.jpeg
+```
+
+The timestamp is a Unix epoch in milliseconds. Use it to:
+
+- Correlate screenshots with trace events (match against `wallTime` in `before` entries)
+- Calculate elapsed time between screenshots
+- Identify the visual state at any point during the test
+
+To find screenshots around a specific event, compute the target timestamp from the trace and select the nearest screenshot filenames.
+
+## CI artifact structure
+
+CI runs typically package results in an outer archive containing multiple files. The trace zip is nested inside:
+
+```
+ci-artifact.zip
+└── results/
+    └── podman-desktop/
+        ├── traces/<name>_trace.zip        ← the Playwright trace
+        ├── videos/<name>.webm             ← screen recording
+        ├── html-results/                  ← Playwright HTML report
+        ├── json-results.json              ← structured test results with errors
+        ├── junit-results.xml              ← JUnit XML for CI
+        ├── output.log                     ← CI build/test output
+        └── <test-hash>/error-context.md   ← page accessibility snapshot at failure
+```
+
+### json-results.json
+
+Contains structured test results with the exact error message and locator call log. Parse it to extract failure details:
+
+```python
+import json
+with open('json-results.json') as f:
+    data = json.load(f)
+
+def walk(suites):
+    for suite in suites:
+        for spec in suite.get('specs', []):
+            for test in spec.get('tests', []):
+                for result in test.get('results', []):
+                    if result.get('status') not in ('passed', 'skipped'):
+                        error = result.get('error', {})
+                        print(f"FAILED: {spec['title']}")
+                        print(f"  {error.get('message', '')[:500]}")
+        walk(suite.get('suites', []))
+
+walk(data.get('suites', []))
+```
+
+The error message often contains the exact locator used, the element it resolved to, and the retry count — which can directly reveal the root cause without needing to parse the trace at all.
+
+### error-context.md
+
+Contains the page's accessibility tree (ARIA snapshot) at the moment of failure. This shows what Playwright "saw" in the DOM, which may differ from what was visually rendered. Key uses:
+
+- Verify whether an expected element exists in the DOM
+- Check element text content and ARIA attributes
+- Identify whether a dialog or overlay is present in the DOM tree
+- Compare against screenshots to find discrepancies between DOM state and visual state
+
+## MCP tool parameter reference
+
+All tools require `traceZipPath` (string): the absolute path to the trace zip.
+
+### analyze-trace
+
+No additional parameters. Returns a combined overview of execution steps, network summary, and key screenshots. Always call this first.
+
+### get-trace
+
+| Parameter      | Type                                            | Default     | Description                                                                                                                                                     |
+| -------------- | ----------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `filterPreset` | `"minimal"` \| `"moderate"` \| `"conservative"` | `"minimal"` | Controls how much trace data is retained (see escalation below)                                                                                                 |
+| `raw`          | boolean                                         | `false`     | When `true`, returns the complete unfiltered trace including all DOM snapshots. Overrides `filterPreset`. Use only as a last resort — output can be very large. |
+
+**Filter preset escalation:**
+
+1. `minimal` — maximum filtering. Removes DOM snapshots and redundant entries. Retains error logs, action steps, and basic console output. Start here.
+2. `moderate` — retains more console logs, context around actions, and additional event metadata. Use when `minimal` doesn't show enough detail around the failure.
+3. `conservative` — retains almost everything except raw DOM snapshots. Use for complex failures where prior levels are inconclusive.
+4. `raw: true` — completely unfiltered. Only use when even `conservative` is insufficient. Prefer the paginated tool instead to avoid output truncation.
+
+### get-network-log
+
+| Parameter | Type    | Default | Description                                                                                                   |
+| --------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `raw`     | boolean | `false` | When `true`, includes analytics, third-party services, and verbose metadata that are filtered out by default. |
+
+The filtered (default) view removes noise from analytics trackers and third-party scripts, focusing on app-relevant HTTP traffic.
+
+### get-screenshots
+
+No additional parameters. Returns screenshots around errors and critical actions, intelligently filtered to avoid timeout-duplicate frames.
+
+### view-screenshot
+
+| Parameter  | Type   | Required | Description                                                          |
+| ---------- | ------ | -------- | -------------------------------------------------------------------- |
+| `filename` | string | yes      | Screenshot filename from the trace, e.g., `page@hash-timestamp.jpeg` |
+
+Use when `get-screenshots` omitted a frame you need, or when `analyze-trace` references a filename you want to inspect closely.
+
+### get-raw-trace-paginated
+
+| Parameter      | Type   | Default | Description                                      |
+| -------------- | ------ | ------- | ------------------------------------------------ |
+| `browserIndex` | number | `0`     | Browser session index (for multi-browser traces) |
+| `page`         | number | `1`     | Page number (1-based)                            |
+| `pageSize`     | number | `50`    | Number of trace entries per page                 |
+
+Use when filtered trace tools lack the detail you need. Paginate through the full raw trace without hitting output size limits. Start at page 1 and increment until you find the relevant section, or jump to later pages if you know the failure occurred late in the test.
+
+### get-raw-network-paginated
+
+| Parameter      | Type   | Default | Description                         |
+| -------------- | ------ | ------- | ----------------------------------- |
+| `browserIndex` | number | `0`     | Browser session index               |
+| `page`         | number | `1`     | Page number (1-based)               |
+| `pageSize`     | number | `20`    | Number of network requests per page |
+
+Same pagination approach as the raw trace tool. Useful when the filtered network log omits requests you suspect are relevant (e.g., requests to third-party auth providers).
+
+## Signal correlation matrix
+
+When diagnosing a failure, cross-reference signals from multiple sources:
+
+| Primary signal                  | Secondary signal to check  | What the combination reveals                                            |
+| ------------------------------- | -------------------------- | ----------------------------------------------------------------------- |
+| Locator timeout (trace step)    | Screenshot at failure time | Whether the page rendered at all, or rendered wrong content             |
+| Locator timeout (trace step)    | Network log                | Whether a required data-fetching call failed or is still pending        |
+| Assertion mismatch (trace step) | Console output             | Whether a JS error prevented correct rendering                          |
+| Assertion mismatch (trace step) | Network response body      | Whether the API returned unexpected data                                |
+| Console error/exception         | Trace step before it       | Which user action or navigation triggered the error                     |
+| Network 4xx/5xx                 | Trace steps after it       | Whether the test continued despite the failure (missing error handling) |
+| Network timeout/no response     | Screenshot                 | Whether the UI shows a loading state or error message                   |
+| Blank page in screenshot        | Console output             | Whether there's an uncaught exception or module load failure            |
+| Wrong URL in trace step         | Network log                | Whether a redirect occurred or navigation was intercepted               |
+| Slow action duration            | Network log at same time   | Whether a pending request is blocking the UI                            |
+| Slow action duration            | Console output             | Whether a heavy computation or error-retry loop is running              |
+| IPC/preload error in console    | Trace steps around it      | Which renderer action triggered the IPC failure                         |
+
+## Minimal sufficient analysis
+
+Unless the overview is already conclusive, a good first-pass analysis usually contains:
+
+1. One `analyze-trace` result
+2. The test source code read and understood
+3. One or two corroborating signals from screenshots, console/steps, or network
+4. A confidence-labeled conclusion with a concrete next step
+
+Avoid dumping all available artifacts when one or two focused follow-up calls are enough.
+
+## Source code correlation
+
+After identifying the failing step, always read the test source to understand intent:
+
+1. **Spec file**: read the test function containing the failure. Check whether the assertion and locator are reasonable given the current app state.
+2. **Page objects**: if the failing action is in a POM method, read that method to understand what it does and what locators it uses.
+3. **App source**: if the trace points to an app-side issue (wrong rendering, missing data, console exception), navigate to the relevant component or module.
+
+This step prevents misdiagnosis. A locator timeout might look like an app bug from the trace alone, but reading the test source reveals the locator targets a removed element (test bug).
+
+## Timing and duration analysis
+
+Trace steps include duration information. Use it to identify:
+
+| Duration pattern                        | Likely cause                                         | Investigation                                                    |
+| --------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------- |
+| Single step 5-10x slower than peers     | Waiting on network, animation, or resource           | Check network log for pending request at that time               |
+| Gradual slowdown across all steps       | Memory leak, DOM bloat, or resource exhaustion       | Check console for warnings; compare early vs late step durations |
+| Step hits exact timeout (e.g., 30000ms) | Condition was never met                              | Focus on _why_ it wasn't met, not the timeout itself             |
+| All steps slow                          | CI runner under load, or app startup not complete    | Check if the first action also took unusually long               |
+| Click takes >2s                         | Element not yet actionable, or animation in progress | Check screenshot for overlay, spinner, or disabled state         |
+
+## Interpreting screenshots
+
+When viewing screenshots from `get-screenshots` or `view-screenshot`, look for:
+
+| Visual signal                         | Implication                                                 |
+| ------------------------------------- | ----------------------------------------------------------- |
+| Blank/white page                      | App crashed, failed to load, or navigated to wrong URL      |
+| Loading spinner or skeleton UI        | Data not loaded yet — timing issue, test asserted too early |
+| Error dialog or toast notification    | App-level error — read the message text                     |
+| Modal or overlay blocking content     | Locator is targeting an element behind the overlay          |
+| Different page than expected          | Navigation didn't complete, or redirected elsewhere         |
+| Partial render (missing sections)     | Component error or failed data dependency                   |
+| Stale/old data displayed              | Cache issue or API returned outdated response               |
+| Element present but visually obscured | CSS overlap, z-index issue, or off-screen position          |
+
+### Sequential screenshot comparison
+
+When `get-screenshots` returns multiple frames, compare consecutive screenshots to understand state transitions:
+
+- **What changed** between action N and action N+1? A new element appearing, data loading, a navigation.
+- **What didn't change** when it should have? A click that didn't navigate, a form submission that didn't update the UI.
+- **What disappeared** unexpectedly? An element that was present then removed by a re-render.
+
+This before/after comparison is often the fastest way to pinpoint the exact moment things went wrong.
+
+## Flakiness investigation
+
+### Common flakiness patterns
+
+| Pattern                              | How it manifests in trace                                                    | Stabilization approach                                                 |
+| ------------------------------------ | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Race between data load and assertion | Assertion step fires while network request is still pending                  | Wait for the network response or use `expect` with auto-retry          |
+| Animation/transition timing          | Click targets an element that's mid-animation                                | Add `waitFor({ state: 'stable' })` or wait for animation class removal |
+| Non-deterministic list ordering      | `toHaveText` fails because items rendered in different order                 | Sort before comparing, or use `toContainText` for individual items     |
+| Websocket reconnection               | Console shows disconnect/reconnect around failure                            | Wait for connection re-establishment before asserting                  |
+| Shared state between tests           | Test passes in isolation but fails in suite                                  | Check for missing cleanup in `afterEach`/`afterAll`                    |
+| Viewport-dependent rendering         | Element off-screen on CI runner's viewport size                              | Check viewport config; use `scrollIntoViewIfNeeded`                    |
+| Stale Electron IPC state             | First test passes, later test sees stale data from previous test's IPC calls | Ensure proper state reset between tests                                |
+
+### Confirming flakiness vs deterministic failure
+
+A failure is more likely **deterministic** if:
+
+- It reproduces on every retry (check CI retry history).
+- The trace shows a clear app error (500 response, unhandled exception).
+- The expected value in the assertion is fundamentally wrong (code change broke the contract).
+
+A failure is more likely **flaky** if:
+
+- It passes on retry without code changes.
+- The trace shows the correct state arriving _after_ the assertion timeout.
+- Network response times vary significantly between runs.
+
+### Retry trace analysis
+
+When multiple trace files exist for the same test (retry-0, retry-1, etc.):
+
+1. Run `analyze-trace` on each retry's trace in parallel
+2. Identify whether the failure is identical across retries (same step, same error, same screenshot state)
+3. If the failure differs between retries, focus on what varies — this points to the nondeterministic factor
+4. If a later retry passes, the failing retry's trace shows the flaky window — identify the timing-sensitive point
+
+## Electron and Podman Desktop patterns
+
+### IPC communication failures
+
+- Console messages containing `ipcRenderer`, `ipcMain`, or channel name strings indicate IPC issues
+- A missing or undefined return value from an IPC call causes downstream rendering failures
+- Check whether the preload script exposed the expected API by looking for preload-related console errors
+
+### Webview interactions
+
+- Webviews in Electron have separate document contexts; a locator targeting the main page won't find webview content
+- If the trace shows a click on a webview element that doesn't respond, the webview may not have finished loading
+- Look for webview navigation events and `dom-ready` signals in console output
+
+### Extension loading
+
+- Extensions load asynchronously; tests that depend on extension-provided UI must wait for the extension to activate
+- Console messages about extension activation, provider registration, or extension errors are key signals
+- A missing provider or command often means the extension failed to load rather than an app bug
+
+### Multi-window
+
+- Electron apps can spawn multiple `BrowserWindow` instances
+- Verify the trace corresponds to the correct window (check URL, page title, or content in screenshots)
+- If the trace shows actions on the wrong window, the test's page reference may have shifted
+
+## Git history correlation
+
+When a failure looks like a regression, use git history to narrow the cause:
+
+```bash
+git log --oneline -10 -- path/to/affected/file
+git log --oneline --since="3 days ago" -- path/to/affected/directory/
+```
+
+Useful when:
+
+- The test was previously passing and started failing without test code changes
+- The locator targets something that may have been renamed or restructured
+- The assertion's expected value may be outdated after a product change
+
+Include the relevant commit in the report when it strengthens the root cause explanation.
+
+## CI artifact locations
+
+Traces from this project's CI are typically stored at:
+
+```
+tests/playwright/output/traces/<test-name>_trace.zip
+```
+
+The naming pattern is `{videoAndTraceName}_trace.zip`, set by the test runner. Traces for passing tests are removed by default unless `KEEP_TRACES_ON_PASS` is set.
+
+Other CI artifacts that may complement trace analysis:
+
+| Artifact    | Location                                    | Use                                                          |
+| ----------- | ------------------------------------------- | ------------------------------------------------------------ |
+| Video       | `tests/playwright/output/videos/`           | Shows real-time playback; useful for animation/timing issues |
+| HTML report | `tests/playwright/output/html-results/`     | Provides test-level pass/fail summary and embedded traces    |
+| JUnit XML   | `tests/playwright/output/junit-results.xml` | Machine-readable results for CI integration                  |
+| Screenshots | `tests/playwright/output/screenshots/`      | Failure screenshots captured by Playwright config            |
+
+## CLI viewer
+
+When MCP tools are unavailable:
+
+```bash
+pnpm exec playwright show-trace /absolute/path/to/trace.zip
+```
+
+The viewer provides:
+
+- **Timeline**: visual step-by-step with duration bars
+- **Actions**: each Playwright action with before/after screenshots
+- **Console**: browser console output
+- **Network**: request waterfall with timing
+- **Source**: test source code highlighting the current line
+
+Navigate to the failing step and work backwards from there.
+
+## Evidence citation format
+
+When writing the report, cite trace evidence consistently:
+
+| Prefix     | Format                           | Example                                                                                   |
+| ---------- | -------------------------------- | ----------------------------------------------------------------------------------------- |
+| Trace step | `[trace step N]`                 | `[trace step 14]: click on "Submit" button timed out after 30s`                           |
+| Screenshot | `[screenshot: filename]`         | `[screenshot: page@abc-1234.jpeg]: shows empty data table with loading spinner`           |
+| Network    | `[network: METHOD url → status]` | `[network: GET /api/containers → 500]: server returned internal error`                    |
+| Console    | `[console: level] message`       | `[console: error] "TypeError: Cannot read property 'map' of undefined"`                   |
+| Duration   | `[duration: step → time]`        | `[duration: step 14 → 28500ms]: approaching 30s timeout, element never became actionable` |
+| Source     | `[source: file:line]`            | `[source: containers.spec.ts:42]: assertion expects 3 rows but API returned empty array`  |
+
+This format makes it easy for the reader to trace each claim back to its evidence and re-inspect if needed.

--- a/.agents/skills/test-failure-analysis-unattended-correction/SKILL.md
+++ b/.agents/skills/test-failure-analysis-unattended-correction/SKILL.md
@@ -4,6 +4,37 @@ description: >-
   Use when a Playwright E2E test fails and you have a trace archive to investigate.
   Optionally accepts a GitHub Actions pipeline link for additional CI context.
   Runs non-interactively.
+allowed-tools:
+  # GitHub CLI — CI investigation, PR/issue/gist creation
+  - Bash(gh run:*)
+  - Bash(gh api:*)
+  - Bash(gh pr:*)
+  - Bash(gh issue:*)
+  - Bash(gh gist:*)
+  - Bash(gh label:*)
+  # Project verification — read-only checks from package.json
+  - Bash(pnpm lint:check)
+  - Bash(pnpm format:check)
+  - Bash(pnpm typecheck*)
+  - Bash(pnpm svelte:check)
+  # Git — read-only inspection
+  - Bash(git status*)
+  - Bash(git diff*)
+  - Bash(git log*)
+  - Bash(git remote*)
+  - Bash(git branch*)
+  # Git — branch and commit operations
+  - Bash(git checkout*)
+  - Bash(git add *)
+  - Bash(git commit -m *)
+  - Bash(git push -u origin *)
+  # Artifact extraction
+  - Bash(unzip:*)
+  - Bash(mkdir -p *)
+  # YAML validation
+  - 'Bash(python3 -c "import yaml:*)'
+  # Web search for upstream context
+  - WebSearch
 ---
 
 # Test Failure Analysis & Unattended Correction
@@ -14,15 +45,22 @@ Orchestration meta-skill: dispatches parallel analysis agents against trace arti
 
 ## When NOT to Use
 
-- No trace file available
+- No trace file AND no GitHub Actions pipeline link (need at least one)
 - Unit test failures (this is E2E/Playwright focused)
 
 ## Prerequisites
 
-- Playwright trace archive (required) — may be a nested zip (artifacts zip containing a `trace.zip` inside). Extract outer zip first, then locate the inner trace zip.
-- GitHub Actions pipeline link (optional — enables CI environment analysis)
+- **At least one of:**
+  - Playwright trace archive — may be a nested zip (artifacts zip containing a `trace.zip` inside). Extract outer zip first, then locate the inner trace zip.
+  - GitHub Actions pipeline link — enables CI log analysis. Sufficient on its own when tests never executed (e.g., infrastructure/setup failures).
 - `gh` CLI installed and authenticated
 - **Upstream targeting:** PRs and issues MUST be opened against the upstream repository (organizations `github.com/containers` or `github.com/podman-desktop`). Use `git remote -v` to identify the upstream remote. Do NOT open PRs or issues in user fork repositories.
+
+## Tooling
+
+- **Use dedicated tools over Bash equivalents:** prefer `Grep` over `bash grep/rg`, `Read` over `bash cat/head/tail`, `Glob` over `bash find/ls`. Reserve Bash for operations that require shell features (piping, unzip, git, gh).
+- **Package manager:** this project uses **pnpm** (not npm/npx). Always use `pnpm` to run scripts. Available scripts are defined in the root `package.json` — read it to discover the correct commands.
+- **Artifact handling:** CI artifacts expire (typically 90 days). When `gh run download` returns "no valid artifacts found", fall back to `gh api repos/{owner}/{repo}/actions/runs/{run_id}/logs` to download raw job logs as a zip.
 
 ## Configuration
 
@@ -77,15 +115,14 @@ digraph correction_decision {
 6. Code Corrector implements corrections (see Code Corrector Agent Instructions below).
 7. Final verification:
    - Code review (superpowers:requesting-code-review) — high-confidence review of all changes
-   - Compilation validation — ensure the project compiles without errors or warnings caused by our changes
-   - Run `npm run lint:check` — no lint errors introduced
-   - Run `npm run format:check` — no formatting violations introduced
+   - Run `pnpm typecheck` — no type errors introduced
+   - Run `pnpm svelte:check` — no Svelte component errors introduced
+   - Run `pnpm lint:check` — no lint errors introduced
+   - Run `pnpm format:check` — no formatting violations introduced
    - **If any check fails:** launch a code-review sub-agent to diagnose, fix the issues, then re-run the failed checks. Max 3 fix-verify cycles. If still failing after 3 cycles, revert all code changes and follow the **Abort & Escalate** procedure (see below).
 8. **If `LOCAL=true`:** commit changes locally only. Do not create a PR, gist, or issue. End execution — the user will test and create a branch/PR manually.
-   **If `LOCAL=false` (default):** Create a **draft** PR via `gh pr create --draft`. Draft PRs prevent CI from firing on unattended changes — a human must review and mark ready before CI runs. Commits and PR title must be semantic — run `git log` to match the repository's commit message style. Keep commit messages short and precise. **IMPORTANT:** Check for a PR template at `.github/PULL_REQUEST_TEMPLATE.md` (use `gh api repos/{owner}/{repo}/contents/.github/PULL_REQUEST_TEMPLATE.md` to fetch it). The PR body MUST follow the repository's PR template structure. Only code/pipeline changes are committed — reports are local-only files.
-9. Post analysis to the PR:
-   - Create a gist containing both files: `gh gist create docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md`
-   - Post a single PR comment with the short summary inline and a link to the gist for the full analysis report. Keep the comment concise — long comments create spam in the PR.
+   **If `LOCAL=false` (default):** Create a **draft** PR via `gh pr create --draft`. Draft PRs prevent CI from firing on unattended changes — a human must review and mark ready before CI runs. Commits must be semantic — run `git log` to match the repository's commit message style. **Keep commit messages to a single subject line** (no body) — detailed context belongs in the PR description, not duplicated in the commit. **IMPORTANT:** Check for a PR template at `.github/PULL_REQUEST_TEMPLATE.md` (use `gh api repos/{owner}/{repo}/contents/.github/PULL_REQUEST_TEMPLATE.md` to fetch it). The PR body MUST follow the repository's PR template structure. Only code/pipeline changes are committed — reports are local-only files.
+9. Create a **public** gist containing both files: `gh gist create --public docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md` — include the gist link in the PR body (under the analysis/reference section of the PR template). Do NOT post a separate PR comment — all context belongs in the PR description.
 10. _Future: send `DATETIME_summary.md` to Slack channel (for internal CI integration)._
 
 ## Code Corrector Agent Instructions
@@ -110,6 +147,6 @@ When the skill cannot resolve issues after exhausting fix-verify cycles (step 7)
 1. Revert all code changes.
 2. **If `LOCAL=true`:** document failures in the analysis report. End execution.
    **If `LOCAL=false` (default):**
-3. Create a gist with the analysis report, summary, and failure documentation: `gh gist create docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md`
+3. Create a **public** gist with the analysis report, summary, and failure documentation: `gh gist create --public docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md`
 4. Open a GitHub issue using the repository's bug report template (`.github/ISSUE_TEMPLATE/bug_report.yml`). Use `gh issue create` with appropriate labels — check available labels via `gh label list` and pick what fits (e.g., `area/tests`, `kind/bug`, `qe/test-case`). Include the gist link and a concise description of the failure and what was attempted.
 5. Do not create a PR. End execution.

--- a/.agents/skills/test-failure-analysis-unattended-correction/SKILL.md
+++ b/.agents/skills/test-failure-analysis-unattended-correction/SKILL.md
@@ -5,35 +5,30 @@ description: >-
   Optionally accepts a GitHub Actions pipeline link for additional CI context.
   Runs non-interactively.
 allowed-tools:
-  # GitHub CLI — CI investigation, PR/issue/gist creation
-  - Bash(gh run:*)
-  - Bash(gh api:*)
-  - Bash(gh pr:*)
-  - Bash(gh issue:*)
-  - Bash(gh gist:*)
-  - Bash(gh label:*)
-  # Project verification — read-only checks from package.json
+  - Bash(gh run view *)
+  - Bash(gh run list *)
+  - Bash(gh run download *)
+  - Bash(gh pr create --draft *)
+  - Bash(gh gist create --public *)
+  - Bash(gh issue create *)
+  - Bash(gh label list)
   - Bash(pnpm lint:check)
   - Bash(pnpm format:check)
-  - Bash(pnpm typecheck*)
+  - Bash(pnpm typecheck)
   - Bash(pnpm svelte:check)
-  # Git — read-only inspection
-  - Bash(git status*)
-  - Bash(git diff*)
-  - Bash(git log*)
-  - Bash(git remote*)
-  - Bash(git branch*)
-  # Git — branch and commit operations
-  - Bash(git checkout*)
+  - Bash(git status)
+  - Bash(git diff)
+  - Bash(git diff --stat)
+  - Bash(git diff --cached)
+  - Bash(git log --oneline *)
+  - Bash(git remote -v)
+  - Bash(git branch)
+  - Bash(git checkout -b *)
   - Bash(git add *)
   - Bash(git commit -m *)
   - Bash(git push -u origin *)
-  # Artifact extraction
-  - Bash(unzip:*)
-  - Bash(mkdir -p *)
-  # YAML validation
-  - 'Bash(python3 -c "import yaml:*)'
-  # Web search for upstream context
+  - Bash(unzip * -d /tmp/*)
+  - Bash(mkdir -p /tmp/*)
   - WebSearch
 ---
 
@@ -55,12 +50,40 @@ Orchestration meta-skill: dispatches parallel analysis agents against trace arti
   - GitHub Actions pipeline link — enables CI log analysis. Sufficient on its own when tests never executed (e.g., infrastructure/setup failures).
 - `gh` CLI installed and authenticated
 - **Upstream targeting:** PRs and issues MUST be opened against the upstream repository (organizations `github.com/containers` or `github.com/podman-desktop`). Use `git remote -v` to identify the upstream remote. Do NOT open PRs or issues in user fork repositories.
+- **`additionalDirectories`** in `.claude/settings.local.json` must include:
+  - `/tmp` — artifact downloads, zip extraction, and log processing
+  - `~/Downloads` — local trace archives provided by the user
+  - `docs/superpowers/analysis` — analysis report output
 
 ## Tooling
 
-- **Use dedicated tools over Bash equivalents:** prefer `Grep` over `bash grep/rg`, `Read` over `bash cat/head/tail`, `Glob` over `bash find/ls`. Reserve Bash for operations that require shell features (piping, unzip, git, gh).
+- **Strict command allowlist:** only run Bash commands listed in the `allowed-tools` frontmatter and the Command Reference table below. If a command is not listed, do NOT attempt it — find an alternative using the allowed commands or dedicated tools (`Read`, `Grep`, `Glob`). A denied permission prompt will block the entire skill execution.
+- **Use dedicated tools over Bash equivalents:** prefer `Grep` over `bash grep/rg`, `Read` over `bash cat/head/tail`, `Glob` over `bash find/ls`. Reserve Bash for operations that require shell features (unzip, git, gh).
+- **Never chain Bash commands.** Each Bash tool call must contain exactly one command. Do not use `&&`, `||`, `;`, or `|` to combine commands. Make separate tool calls instead.
 - **Package manager:** this project uses **pnpm** (not npm/npx). Always use `pnpm` to run scripts. Available scripts are defined in the root `package.json` — read it to discover the correct commands.
-- **Artifact handling:** CI artifacts expire (typically 90 days). When `gh run download` returns "no valid artifacts found", fall back to `gh api repos/{owner}/{repo}/actions/runs/{run_id}/logs` to download raw job logs as a zip.
+- **Artifact handling:** CI artifacts expire (typically 90 days). When `gh run download` returns "no valid artifacts found", fall back to `gh run view {id} --log` to read job logs directly.
+- **Reading external repo files:** use `WebSearch` or `Read` on local checkouts. Do NOT use `gh api` — it is not in the allowed tools.
+- **`git add` safety:** only stage files that this skill created or modified. Never use `git add .`, `git add -A`, or stage files outside `.github/workflows/`, `tests/`, and `packages/` without explicit justification in the analysis report.
+- **`git push` safety:** before pushing, verify with `git remote -v` that `origin` points to the user's fork, not the upstream repository. Never push directly to upstream.
+- **Artifact extraction:** always extract to `/tmp/`. Never unzip into the project working tree.
+- **Repo scoping:** all `gh pr create`, `gh gist create`, and `gh issue create` commands must target the upstream repo identified via `git remote -v`. Never target arbitrary repositories.
+
+### Command Reference
+
+| Command                                                   | When to use                                               |
+| --------------------------------------------------------- | --------------------------------------------------------- |
+| `gh run view {id} --repo {owner}/{repo} --json jobs`      | Get run metadata, job details, step names and conclusions |
+| `gh run view {id} --repo {owner}/{repo} --log`            | Download job logs (fallback when artifacts expired)       |
+| `gh run list --repo {owner}/{repo} --workflow {name}`     | Check failure frequency across recent runs                |
+| `gh run download {id} --repo {owner}/{repo} --dir {path}` | Download test artifacts (traces, videos, results)         |
+| `gh pr create --draft`                                    | Create draft PR with fix                                  |
+| `gh gist create --public`                                 | Create public gist with analysis report                   |
+| `gh issue create`                                         | Escalation: file issue when fix fails                     |
+| `gh label list`                                           | List available labels for issue creation                  |
+| `pnpm typecheck`                                          | Verify no type errors introduced                          |
+| `pnpm svelte:check`                                       | Verify no Svelte component errors                         |
+| `pnpm lint:check`                                         | Verify no lint errors introduced                          |
+| `pnpm format:check`                                       | Verify no formatting violations                           |
 
 ## Configuration
 
@@ -121,7 +144,7 @@ digraph correction_decision {
    - Run `pnpm format:check` — no formatting violations introduced
    - **If any check fails:** launch a code-review sub-agent to diagnose, fix the issues, then re-run the failed checks. Max 3 fix-verify cycles. If still failing after 3 cycles, revert all code changes and follow the **Abort & Escalate** procedure (see below).
 8. **If `LOCAL=true`:** commit changes locally only. Do not create a PR, gist, or issue. End execution — the user will test and create a branch/PR manually.
-   **If `LOCAL=false` (default):** Create a **draft** PR via `gh pr create --draft`. Draft PRs prevent CI from firing on unattended changes — a human must review and mark ready before CI runs. Commits must be semantic — run `git log` to match the repository's commit message style. **Keep commit messages to a single subject line** (no body) — detailed context belongs in the PR description, not duplicated in the commit. **IMPORTANT:** Check for a PR template at `.github/PULL_REQUEST_TEMPLATE.md` (use `gh api repos/{owner}/{repo}/contents/.github/PULL_REQUEST_TEMPLATE.md` to fetch it). The PR body MUST follow the repository's PR template structure. Only code/pipeline changes are committed — reports are local-only files.
+   **If `LOCAL=false` (default):** Create a **draft** PR via `gh pr create --draft`. Draft PRs prevent CI from firing on unattended changes — a human must review and mark ready before CI runs. Commits must be semantic — run `git log` to match the repository's commit message style. **Keep commit messages to a single subject line** (no body) — detailed context belongs in the PR description, not duplicated in the commit. **IMPORTANT:** Check for a PR template at `.github/PULL_REQUEST_TEMPLATE.md` in the local checkout (use the `Read` tool). The PR body MUST follow the repository's PR template structure. Only code/pipeline changes are committed — reports are local-only files.
 9. Create a **public** gist containing both files: `gh gist create --public docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md` — include the gist link in the PR body (under the analysis/reference section of the PR template). Do NOT post a separate PR comment — all context belongs in the PR description.
 10. _Future: send `DATETIME_summary.md` to Slack channel (for internal CI integration)._
 

--- a/.agents/skills/test-failure-analysis-unattended-correction/SKILL.md
+++ b/.agents/skills/test-failure-analysis-unattended-correction/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: test-failure-analysis-unattended-correction
+description: >-
+  Use when a Playwright E2E test fails and you have a trace archive to investigate.
+  Optionally accepts a GitHub Actions pipeline link for additional CI context.
+  Runs non-interactively.
+---
+
+# Test Failure Analysis & Unattended Correction
+
+## Overview
+
+Orchestration meta-skill: dispatches parallel analysis agents against trace artifacts (and optionally CI logs), correlates findings, then proposes and implements fixes if the failure is test-side. Runs end-to-end without user interaction.
+
+## When NOT to Use
+
+- No trace file available
+- Unit test failures (this is E2E/Playwright focused)
+
+## Prerequisites
+
+- Playwright trace archive (required) — may be a nested zip (artifacts zip containing a `trace.zip` inside). Extract outer zip first, then locate the inner trace zip.
+- GitHub Actions pipeline link (optional — enables CI environment analysis)
+- `gh` CLI installed and authenticated
+- **Upstream targeting:** PRs and issues MUST be opened against the upstream repository (organizations `github.com/containers` or `github.com/podman-desktop`). Use `git remote -v` to identify the upstream remote. Do NOT open PRs or issues in user fork repositories.
+
+## Configuration
+
+| Variable | Default | Description                                                                                                                                                                |
+| -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LOCAL`  | `false` | When `true`: skip draft PR creation, gist upload, and issue filing. Commit changes locally only. The user can test modifications directly and create a branch/PR manually. |
+
+Set variables by including them when invoking the skill (e.g., `LOCAL=true`).
+
+## Conventions
+
+- **DATETIME** format throughout this skill: `YY-MM-DD_HH_mm_ss`. Derive the timestamp from the CI run time or the artifacts zip file metadata — not from when the skill executes.
+- Trace zips from CI artifacts are typically nested (e.g., `results.zip` → `traces/trace.zip`). The inner `trace.zip` is `npx playwright show-trace` compatible.
+- The outer artifacts zip also contains additional parseable files that agents should utilize for more accurate analysis:
+  - `output.log` — full console output from the test run
+  - `junit-*.xml` / `json-results.json` — structured test results (pass/fail/skip per test, durations, error messages)
+  - `html-results/index.html` — rendered HTML test report
+  - `**/error-context.md` — Playwright error context for failed tests
+  - `scripts/tmp_stdout_*.txt` / `tmp_stderr_*.txt` — setup script output and errors
+  - `*.log` files (e.g., `podman-machine-init.log`) — environment setup logs
+  - `videos/` — test execution recordings (`.webm`)
+- Artifacts can originate from CI or local runs. When no GH link is provided, note in the report that CI-side factors could not be ruled out.
+
+## Sub-Agents
+
+| Sub-Agent       | Skill                                                       | Input                                                                  | When                                             |
+| --------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| Trace Analyzer  | `playwright-trace-analysis`                                 | Inner trace zip + all supplementary files (see Conventions) → temp dir | Immediately                                      |
+| CI Investigator | `investigate-gh-run`                                        | GH Actions pipeline link                                               | Parallel with #1 (only if link provided)         |
+| Code Corrector  | brainstorming → writing-plans → subagent-driven-development | Analysis report                                                        | Only if failure is test-logic or pipeline-config |
+
+## Execution Flow
+
+1. Extract the artifacts zip into a temp folder. Locate the inner trace zip (typically under `traces/`). Dispatch Trace Analyzer immediately. If GH Actions link provided, dispatch CI Investigator in parallel.
+2. Correlate findings from agent(s) to identify potential issues. If only trace data is available, note in the report that CI-side factors (runner resources, environment config) could not be ruled out.
+3. Write analysis report → `docs/superpowers/analysis/DATETIME_analysis_report.md`
+4. Write short and concise summary → `docs/superpowers/analysis/DATETIME_summary.md`
+5. Decision point:
+
+```dot
+digraph correction_decision {
+  "Findings correlated" -> "Failure cause?";
+  "Failure cause?" -> "Dispatch Code Corrector" [label="test logic / pipeline config"];
+  "Failure cause?" -> "Report only, end execution" [label="infra / external / flaky env"];
+}
+```
+
+**If "Report only":** No further agent action. Reports remain as local files (do NOT commit them to git). _Future: send `DATETIME_summary.md` to Slack channel for visibility (CI instability notification)._ End execution here.
+
+**If "Dispatch Code Corrector":** Continue with the following steps:
+
+6. Code Corrector implements corrections (see Code Corrector Agent Instructions below).
+7. Final verification:
+   - Code review (superpowers:requesting-code-review) — high-confidence review of all changes
+   - Compilation validation — ensure the project compiles without errors or warnings caused by our changes
+   - Run `npm run lint:check` — no lint errors introduced
+   - Run `npm run format:check` — no formatting violations introduced
+   - **If any check fails:** launch a code-review sub-agent to diagnose, fix the issues, then re-run the failed checks. Max 3 fix-verify cycles. If still failing after 3 cycles, revert all code changes and follow the **Abort & Escalate** procedure (see below).
+8. **If `LOCAL=true`:** commit changes locally only. Do not create a PR, gist, or issue. End execution — the user will test and create a branch/PR manually.
+   **If `LOCAL=false` (default):** Create a **draft** PR via `gh pr create --draft`. Draft PRs prevent CI from firing on unattended changes — a human must review and mark ready before CI runs. Commits and PR title must be semantic — run `git log` to match the repository's commit message style. Keep commit messages short and precise. **IMPORTANT:** Check for a PR template at `.github/PULL_REQUEST_TEMPLATE.md` (use `gh api repos/{owner}/{repo}/contents/.github/PULL_REQUEST_TEMPLATE.md` to fetch it). The PR body MUST follow the repository's PR template structure. Only code/pipeline changes are committed — reports are local-only files.
+9. Post analysis to the PR:
+   - Create a gist containing both files: `gh gist create docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md`
+   - Post a single PR comment with the short summary inline and a link to the gist for the full analysis report. Keep the comment concise — long comments create spam in the PR.
+10. _Future: send `DATETIME_summary.md` to Slack channel (for internal CI integration)._
+
+## Code Corrector Agent Instructions
+
+When dispatched, this agent operates **fully non-interactively — no user interaction under any circumstances**.
+
+**Max recursion depth: 3.** If after 3 iterations of spec review the code-review sub-agent still finds issues, proceed with the best version available and document remaining concerns in the analysis report.
+
+1. Brainstorm corrections from the analysis report (superpowers:brainstorming — no user approval).
+2. If uncertain at any point, spawn a `code-review` sub-agent to discuss the concern. Provide it with: the specific question, the relevant analysis report section, and the affected source files. The sub-agent acts as a peer reviewer — use its recommendation or pick the best suggestion. **Never surface questions to the user.**
+3. Write spec → `docs/superpowers/specs/DATETIME_*.md` (superpowers:writing-plans).
+4. Review spec (superpowers:requesting-code-review) — max 3 review iterations.
+5. Write plan → `docs/superpowers/plans/DATETIME_*.md` (superpowers:writing-plans).
+6. Execute plan (superpowers:subagent-driven-development).
+
+**Note on test validation:** Re-running E2E tests is not feasible from this skill's execution environment. Instead, focus on high-confidence fixes validated through deep code review, compilation, lint, and format checks (Final verification step of Execution Flow).
+
+## Abort & Escalate Procedure
+
+When the skill cannot resolve issues after exhausting fix-verify cycles (step 7) or encounters an unrecoverable error:
+
+1. Revert all code changes.
+2. **If `LOCAL=true`:** document failures in the analysis report. End execution.
+   **If `LOCAL=false` (default):**
+3. Create a gist with the analysis report, summary, and failure documentation: `gh gist create docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md`
+4. Open a GitHub issue using the repository's bug report template (`.github/ISSUE_TEMPLATE/bug_report.yml`). Use `gh issue create` with appropriate labels — check available labels via `gh label list` and pick what fits (e.g., `area/tests`, `kind/bug`, `qe/test-case`). Include the gist link and a concise description of the failure and what was attempted.
+5. Do not create a PR. End execution.

--- a/.agents/skills/test-failure-analysis-unattended-correction/SKILL.md
+++ b/.agents/skills/test-failure-analysis-unattended-correction/SKILL.md
@@ -67,31 +67,45 @@ Orchestration meta-skill: dispatches parallel analysis agents against trace arti
 - **`git push` safety:** before pushing, verify with `git remote -v` that `origin` points to the user's fork, not the upstream repository. Never push directly to upstream.
 - **Artifact extraction:** always extract to `/tmp/`. Never unzip into the project working tree.
 - **Repo scoping:** all `gh pr create`, `gh gist create`, and `gh issue create` commands must target the upstream repo identified via `git remote -v`. Never target arbitrary repositories.
+- **NEVER `git checkout -b`, `git add`, or `git commit` when `COMMIT=false`.** These commands are gated. If `COMMIT` is not explicitly `true`, any attempt to branch, stage, or commit is a skill violation. Leave changes as unstaged working-tree modifications.
+- **NEVER `git push`, `gh pr create`, `gh gist create`, or `gh issue create` when `PUBLISH=false`.** These commands are gated. If `PUBLISH` is not explicitly `true`, any attempt to push or interact with GitHub is a skill violation. No remote side effects.
 
 ### Command Reference
 
-| Command                                                   | When to use                                               |
-| --------------------------------------------------------- | --------------------------------------------------------- |
-| `gh run view {id} --repo {owner}/{repo} --json jobs`      | Get run metadata, job details, step names and conclusions |
-| `gh run view {id} --repo {owner}/{repo} --log`            | Download job logs (fallback when artifacts expired)       |
-| `gh run list --repo {owner}/{repo} --workflow {name}`     | Check failure frequency across recent runs                |
-| `gh run download {id} --repo {owner}/{repo} --dir {path}` | Download test artifacts (traces, videos, results)         |
-| `gh pr create --draft`                                    | Create draft PR with fix                                  |
-| `gh gist create --public`                                 | Create public gist with analysis report                   |
-| `gh issue create`                                         | Escalation: file issue when fix fails                     |
-| `gh label list`                                           | List available labels for issue creation                  |
-| `pnpm typecheck`                                          | Verify no type errors introduced                          |
-| `pnpm svelte:check`                                       | Verify no Svelte component errors                         |
-| `pnpm lint:check`                                         | Verify no lint errors introduced                          |
-| `pnpm format:check`                                       | Verify no formatting violations                           |
+| Command                                                   | When to use                                               | Guard          |
+| --------------------------------------------------------- | --------------------------------------------------------- | -------------- |
+| `gh run view {id} --repo {owner}/{repo} --json jobs`      | Get run metadata, job details, step names and conclusions | —              |
+| `gh run view {id} --repo {owner}/{repo} --log`            | Download job logs (fallback when artifacts expired)       | —              |
+| `gh run list --repo {owner}/{repo} --workflow {name}`     | Check failure frequency across recent runs                | —              |
+| `gh run download {id} --repo {owner}/{repo} --dir {path}` | Download test artifacts (traces, videos, results)         | —              |
+| `git checkout -b`                                         | Create feature branch for committing changes              | `COMMIT=true`  |
+| `git add`                                                 | Stage code/pipeline changes (never reports)               | `COMMIT=true`  |
+| `git commit -m`                                           | Commit staged changes                                     | `COMMIT=true`  |
+| `git push -u origin`                                      | Push branch to remote                                     | `PUBLISH=true` |
+| `gh pr create --draft`                                    | Create draft PR with fix                                  | `PUBLISH=true` |
+| `gh gist create --public`                                 | Create public gist with analysis report                   | `PUBLISH=true` |
+| `gh issue create`                                         | Escalation: file issue when fix fails                     | `PUBLISH=true` |
+| `gh label list`                                           | List available labels for issue creation                  | `PUBLISH=true` |
+| `pnpm typecheck`                                          | Verify no type errors introduced                          | —              |
+| `pnpm svelte:check`                                       | Verify no Svelte component errors                         | —              |
+| `pnpm lint:check`                                         | Verify no lint errors introduced                          | —              |
+| `pnpm format:check`                                       | Verify no formatting violations                           | —              |
+
+**Guard column enforcement:** A command with a Guard value MUST NOT be executed unless that variable is `true`. Before running any guarded command, re-verify the variable value. If the guard is not satisfied, skip the command and log why.
 
 ## Configuration
 
-| Variable | Default | Description                                                                                                                                                                |
-| -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LOCAL`  | `false` | When `true`: skip draft PR creation, gist upload, and issue filing. Commit changes locally only. The user can test modifications directly and create a branch/PR manually. |
+| Variable  | Default | Description                                                                                                                       |
+| --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `COMMIT`  | `false` | When `true`: create git commits for code changes. When `false`: leave changes unstaged — the user commits manually.               |
+| `PUBLISH` | `false` | When `true`: create draft PRs, public gists, and GitHub issues. When `false`: skip all remote operations. Requires `COMMIT=true`. |
 
-Set variables by including them when invoking the skill (e.g., `LOCAL=true`).
+**Enforcement rules:**
+
+- `PUBLISH=true` is only valid when `COMMIT=true`. If `PUBLISH=true` and `COMMIT=false`, treat as a configuration error — log a warning, override `PUBLISH` to `false`, and continue.
+- Default behavior (`COMMIT=false PUBLISH=false`): analysis and code corrections are produced as local file changes only. Nothing is committed or published.
+
+Set variables by including them when invoking the skill (e.g., `COMMIT=true PUBLISH=true`).
 
 ## Conventions
 
@@ -117,6 +131,23 @@ Set variables by including them when invoking the skill (e.g., `LOCAL=true`).
 
 ## Execution Flow
 
+0. **Configuration validation (mandatory first step).** Before any other action, resolve and log the configuration:
+   - Read `COMMIT` and `PUBLISH` from the invocation. If not provided, default both to `false`.
+   - If `PUBLISH=true` and `COMMIT=false`: log `⚠ PUBLISH=true requires COMMIT=true. Overriding PUBLISH to false.` and set `PUBLISH=false`.
+   - Log the resolved configuration:
+     ```
+     ── Config ──────────────────────────
+     COMMIT:  {true|false}
+     PUBLISH: {true|false}
+     ────────────────────────────────────
+     Will commit:  {yes|no}
+     Will push:    {yes|no}
+     Will create PR: {yes|no}
+     Will create gist: {yes|no}
+     Will create issue: {yes|no}
+     ────────────────────────────────────
+     ```
+   - This log is the contract for the rest of the execution. Any action that contradicts it is a skill violation.
 1. Extract the artifacts zip into a temp folder. Locate the inner trace zip (typically under `traces/`). Dispatch Trace Analyzer immediately. If GH Actions link provided, dispatch CI Investigator in parallel.
 2. Correlate findings from agent(s) to identify potential issues. If only trace data is available, note in the report that CI-side factors (runner resources, environment config) could not be ruled out.
 3. Write analysis report → `docs/superpowers/analysis/DATETIME_analysis_report.md`
@@ -131,7 +162,7 @@ digraph correction_decision {
 }
 ```
 
-**If "Report only":** No further agent action. Reports remain as local files (do NOT commit them to git). _Future: send `DATETIME_summary.md` to Slack channel for visibility (CI instability notification)._ End execution here.
+**If "Report only":** No further agent action. Reports remain as local files (do NOT commit them to git regardless of `COMMIT` setting — reports are never committed). _Future: send `DATETIME_summary.md` to Slack channel for visibility (CI instability notification)._ End execution here.
 
 **If "Dispatch Code Corrector":** Continue with the following steps:
 
@@ -143,9 +174,16 @@ digraph correction_decision {
    - Run `pnpm lint:check` — no lint errors introduced
    - Run `pnpm format:check` — no formatting violations introduced
    - **If any check fails:** launch a code-review sub-agent to diagnose, fix the issues, then re-run the failed checks. Max 3 fix-verify cycles. If still failing after 3 cycles, revert all code changes and follow the **Abort & Escalate** procedure (see below).
-8. **If `LOCAL=true`:** commit changes locally only. Do not create a PR, gist, or issue. End execution — the user will test and create a branch/PR manually.
-   **If `LOCAL=false` (default):** Create a **draft** PR via `gh pr create --draft`. Draft PRs prevent CI from firing on unattended changes — a human must review and mark ready before CI runs. Commits must be semantic — run `git log` to match the repository's commit message style. **Keep commit messages to a single subject line** (no body) — detailed context belongs in the PR description, not duplicated in the commit. **IMPORTANT:** Check for a PR template at `.github/PULL_REQUEST_TEMPLATE.md` in the local checkout (use the `Read` tool). The PR body MUST follow the repository's PR template structure. Only code/pipeline changes are committed — reports are local-only files.
-9. Create a **public** gist containing both files: `gh gist create --public docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md` — include the gist link in the PR body (under the analysis/reference section of the PR template). Do NOT post a separate PR comment — all context belongs in the PR description.
+8. **Commit gate** — only execute this step if `COMMIT=true`:
+   - Create a feature branch via `git checkout -b`.
+   - Stage only code/pipeline changes (`git add` — never stage reports).
+   - Commits must be semantic — run `git log` to match the repository's commit message style. **Keep commit messages to a single subject line** (no body) — detailed context belongs in the PR description, not duplicated in the commit.
+   - **If `COMMIT=false`:** leave all changes unstaged. Log: `COMMIT=false — skipping git commit. Changes are local working-tree modifications only.` End execution here.
+9. **Publish gate** — only execute this step if `PUBLISH=true` (which requires `COMMIT=true`; see enforcement rules):
+   - Push the branch: `git push -u origin {branch}`.
+   - Create a **draft** PR via `gh pr create --draft`. Draft PRs prevent CI from firing on unattended changes — a human must review and mark ready before CI runs. **IMPORTANT:** Check for a PR template at `.github/PULL_REQUEST_TEMPLATE.md` in the local checkout (use the `Read` tool). The PR body MUST follow the repository's PR template structure.
+   - Create a **public** gist containing both report files: `gh gist create --public docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md` — include the gist link in the PR body (under the analysis/reference section of the PR template). Do NOT post a separate PR comment — all context belongs in the PR description.
+   - **If `PUBLISH=false`:** do NOT push, create PRs, create gists, or create issues. Log: `PUBLISH=false — skipping all remote operations.` End execution here.
 10. _Future: send `DATETIME_summary.md` to Slack channel (for internal CI integration)._
 
 ## Code Corrector Agent Instructions
@@ -168,8 +206,9 @@ When dispatched, this agent operates **fully non-interactively — no user inter
 When the skill cannot resolve issues after exhausting fix-verify cycles (step 7) or encounters an unrecoverable error:
 
 1. Revert all code changes.
-2. **If `LOCAL=true`:** document failures in the analysis report. End execution.
-   **If `LOCAL=false` (default):**
-3. Create a **public** gist with the analysis report, summary, and failure documentation: `gh gist create --public docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md`
-4. Open a GitHub issue using the repository's bug report template (`.github/ISSUE_TEMPLATE/bug_report.yml`). Use `gh issue create` with appropriate labels — check available labels via `gh label list` and pick what fits (e.g., `area/tests`, `kind/bug`, `qe/test-case`). Include the gist link and a concise description of the failure and what was attempted.
+2. Document failures in the analysis report.
+3. **If `PUBLISH=true`:**
+   - Create a **public** gist with the analysis report, summary, and failure documentation: `gh gist create --public docs/superpowers/analysis/DATETIME_summary.md docs/superpowers/analysis/DATETIME_analysis_report.md`
+   - Open a GitHub issue using the repository's bug report template (`.github/ISSUE_TEMPLATE/bug_report.yml`). Use `gh issue create` with appropriate labels — check available labels via `gh label list` and pick what fits (e.g., `area/tests`, `kind/bug`, `qe/test-case`). Include the gist link and a concise description of the failure and what was attempted.
+4. **If `PUBLISH=false`:** do NOT create gists or issues. Log: `PUBLISH=false — skipping escalation to GitHub. Failure documented in local analysis report only.`
 5. Do not create a PR. End execution.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 **/coverage
 .idea
 output
+docs/superpowers


### PR DESCRIPTION
### What does this PR do?
* Adds pipeline and trace analysis skills
* Adds a meta-skill orchestrator to perform unattended analysis and fixes for failures
* It is configurable to run locally only

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #4337 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
* Download failed job artifacts
* Get a pipeline link
* Install `gh` CLI and authenticate
* Invoke the skill using `LOCAL=true` and paste in path to your artifacts and the GH action link
<!-- Please explain steps to reproduce -->
