### PR TITLE
chore(ci): removing Windows 10 Pro pipeline from Nightly e2e tests

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -85,14 +85,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows-version: ['10','11']
-        windows-featurepack: ['22h2-pro', '25h2-ent']
-        exclude:
-        - windows-version: '10'
-          windows-featurepack: '25h2-ent'
-        - windows-version: '11'
-          windows-featurepack: '22h2-pro'
-
+        windows-version: ['11']
+        windows-featurepack: ['25h2-ent']
 
     steps:
     - name: Fetch latest Podman version


### PR DESCRIPTION
### What does this PR do?
* Removes deprecated Windows 10 Pro from e2e CI

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop-internal/issues/909
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
