### PR TITLE
fix(ci): replace inline kubic podman install with redhat-actions/podman-install

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -86,26 +86,10 @@ jobs:
             ./podman-desktop
             ./podman-desktop-extension-ai-lab
 
-      - name: Update podman
-        run: |
-          echo "ubuntu version from kubic repository to install podman we need (v5)"
-          ubuntu_version='23.10'
-          echo "Add unstable kubic repo into list of available sources and get the repo key"
-          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
-          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
-          echo "Updating database of packages..."
-          sudo apt-get update -qq
-          echo "install necessary dependencies for criu package which is not part of ${ubuntu_version}"
-          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
-          echo "install criu manually from static location"
-          curl -sLO http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
-          echo "installing/update podman package..."
-          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
-            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
-            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
-            sudo apt-get update && \
-            sudo apt-get -y install podman; }
-          podman version
+      - name: Install Podman v5 using external action
+        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -95,26 +95,10 @@ jobs:
           ref: main
           path: podman-desktop
 
-      - name: Update podman
-        run: |
-          echo "ubuntu version from kubic repository to install podman we need (v5)"
-          ubuntu_version='23.10'
-          echo "Add unstable kubic repo into list of available sources and get the repo key"
-          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
-          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
-          echo "Updating database of packages..."
-          sudo apt-get update -qq
-          echo "install necessary dependencies for criu package which is not part of ${ubuntu_version}"
-          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
-          echo "install criu manually from static location"
-          curl -sLO http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
-          echo "installing/update podman package..."
-          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
-            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
-            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
-            sudo apt-get update && \
-            sudo apt-get -y install podman; }
-          podman version
+      - name: Install Podman v5 using external action
+        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |

--- a/.github/workflows/ramalama.yaml
+++ b/.github/workflows/ramalama.yaml
@@ -56,26 +56,10 @@ jobs:
           ref: main
           path: podman-desktop
 
-      - name: Update podman
-        run: |
-          echo "ubuntu version from kubic repository to install podman we need (v5)"
-          ubuntu_version='23.10'
-          echo "Add unstable kubic repo into list of available sources and get the repo key"
-          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
-          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
-          echo "Updating database of packages..."
-          sudo apt-get update -qq
-          echo "install necessary dependencies for criu package which is not part of ${ubuntu_version}"
-          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
-          echo "install criu manually from static location"
-          curl -sLO http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
-          echo "installing/update podman package..."
-          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
-            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
-            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
-            sudo apt-get update && \
-            sudo apt-get -y install podman; }
-          podman version
+      - name: Install Podman v5 using external action
+        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |


### PR DESCRIPTION
### What does this PR do?

Replaces the inline podman installation script (kubic unstable repository for Ubuntu 23.10 on 24.04 runners) with the maintained `redhat-actions/podman-install` composite action across all three affected workflows:

- `.github/workflows/e2e-main.yaml`
- `.github/workflows/pr-check.yaml`
- `.github/workflows/ramalama.yaml`

This aligns with upstream `podman-desktop`, which already uses this action.

### What issues does this PR fix or reference?

Mitigates intermittent nightly E2E failures caused by broken `crun → criu` dependency chains in the kubic unstable repo. Example failure: [Run #24545384721](https://github.com/containers/podman-desktop-extension-ai-lab/actions/runs/24545384721/job/71759661522).

The `crun` package from the kubic repo intermittently requires a `criu` version that doesn't match the manually-installed `.deb`, causing `apt-get install podman` to fail with "Unable to correct problems, you have held broken packages."

### How to test this PR?

1. Merge and observe nightly E2E runs — the "Install Podman v5 using external action" step should replace the old "Update podman" step
2. Verify podman is installed correctly by checking subsequent steps (`podman info`, `podman version`) succeed
3. The `redhat-actions/podman-install` action is pinned to SHA `15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3` (same as upstream podman-desktop)

**Full analysis report:** https://gist.github.com/ScrewTSW/e417e84fd8bea1c87570cd40baad1963