### PR TITLE
fix: return native status on Linux regardless of connection

### DIFF
--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -620,6 +620,27 @@ describe('checkContainerConnectionStatusAndResources', () => {
     });
   });
 
+  test('return native on Linux even when a connection is provided', async () => {
+    const manager = new PodmanConnection(rpcExtensionMock);
+    vi.mocked(env).isLinux = true;
+
+    const result = await manager.checkContainerConnectionStatusAndResources({
+      model: modelMock,
+      context: 'inference',
+      connection: {
+        providerId: 'podman',
+        name: 'Podman Machine',
+        type: 'podman',
+        status: 'started',
+        vmType: VMType.LIBKRUNWB,
+      },
+    });
+    expect(result).toStrictEqual({
+      status: 'native',
+      canRedirect: expect.any(Boolean),
+    });
+  });
+
   test('return noMachineInfo if there is no running podman connection', async () => {
     const manager = new PodmanConnection(rpcExtensionMock);
     vi.mocked(env).isLinux = false;

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -318,8 +318,11 @@ export class PodmanConnection extends Publisher<ContainerProviderConnectionInfo[
     // starting from podman desktop 1.10 we have the navigate functions
     const hasNavigateFunction = !!navigation.navigateToResources;
 
-    // if we do not precise the connection and are on linux we assume native usage
-    if (env.isLinux && !options.connection) {
+    // On Linux, Podman runs natively without a virtual machine.
+    // The "low-resources" and "no-machine" statuses reference Podman Machine
+    // concepts that do not apply on Linux, so always return 'native' to avoid
+    // showing misleading messages like "Update your Podman Machine".
+    if (env.isLinux) {
       return {
         status: 'native',
         canRedirect: hasNavigateFunction,

--- a/packages/shared/src/models/IContainerConnectionInfo.ts
+++ b/packages/shared/src/models/IContainerConnectionInfo.ts
@@ -38,7 +38,7 @@ export type ContainerConnectionInfo =
   | NoContainerConnection
   | NativeContainerConnection;
 
-export type ContainerConnectionInfoStatus = 'running' | 'no-machine' | 'low-resources';
+export type ContainerConnectionInfoStatus = 'running' | 'no-machine' | 'low-resources' | 'native';
 
 export interface RunningContainerConnection {
   name: string;


### PR DESCRIPTION
## Problem

On Linux, when a container connection is provided to `checkContainerConnectionStatusAndResources`, the code skips the early `native` return (because the old condition was `env.isLinux && !options.connection`) and falls through to machine-based resource checks. This can return `low-resources` status with misleading messages like "Update your Podman Machine" — a concept that does not exist on Linux, where Podman runs natively without a VM.

Fixes #2010

## Changes

- **`packages/backend/src/managers/podmanConnection.ts`**: Broadened the Linux check from `env.isLinux && !options.connection` to `env.isLinux` — always returns `native` on Linux, since Podman Machine concepts do not apply.
- **`packages/shared/src/models/IContainerConnectionInfo.ts`**: Added `"native"` to the `ContainerConnectionInfoStatus` type union, which was missing despite `NativeContainerConnection` already existing.
- **`packages/backend/src/managers/podmanConnection.spec.ts`**: Added test case verifying that Linux returns `native` status even when a connection is provided.

## Testing

All 531 backend tests pass, including the new test case:
```
✓ src/managers/podmanConnection.spec.ts (44 tests) 13ms
```