### PR TITLE
chore(ci): updating podman install pipeline to questing repository

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -87,25 +87,9 @@ jobs:
             ./podman-desktop-extension-ai-lab
 
       - name: Update podman
-        run: |
-          echo "ubuntu version from kubic repository to install podman we need (v5)"
-          ubuntu_version='23.10'
-          echo "Add unstable kubic repo into list of available sources and get the repo key"
-          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
-          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
-          echo "Updating database of packages..."
-          sudo apt-get update -qq
-          echo "install necessary dependencies for criu package which is not part of ${ubuntu_version}"
-          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
-          echo "install criu manually from static location"
-          curl -sLO http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
-          echo "installing/update podman package..."
-          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
-            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
-            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
-            sudo apt-get update && \
-            sudo apt-get -y install podman; }
-          podman version
+        uses: redhat-actions/podman-install@92eb12467c2fc271e7781d006c413e17770230ed
+        with:
+          ubuntu-repository: 'questing'
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -96,25 +96,9 @@ jobs:
           path: podman-desktop
 
       - name: Update podman
-        run: |
-          echo "ubuntu version from kubic repository to install podman we need (v5)"
-          ubuntu_version='23.10'
-          echo "Add unstable kubic repo into list of available sources and get the repo key"
-          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
-          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
-          echo "Updating database of packages..."
-          sudo apt-get update -qq
-          echo "install necessary dependencies for criu package which is not part of ${ubuntu_version}"
-          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
-          echo "install criu manually from static location"
-          curl -sLO http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
-          echo "installing/update podman package..."
-          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
-            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
-            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
-            sudo apt-get update && \
-            sudo apt-get -y install podman; }
-          podman version
+        uses: redhat-actions/podman-install@92eb12467c2fc271e7781d006c413e17770230ed
+        with:
+          ubuntu-repository: 'questing'
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |

--- a/.github/workflows/ramalama.yaml
+++ b/.github/workflows/ramalama.yaml
@@ -57,25 +57,9 @@ jobs:
           path: podman-desktop
 
       - name: Update podman
-        run: |
-          echo "ubuntu version from kubic repository to install podman we need (v5)"
-          ubuntu_version='23.10'
-          echo "Add unstable kubic repo into list of available sources and get the repo key"
-          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
-          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
-          echo "Updating database of packages..."
-          sudo apt-get update -qq
-          echo "install necessary dependencies for criu package which is not part of ${ubuntu_version}"
-          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
-          echo "install criu manually from static location"
-          curl -sLO http://archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
-          echo "installing/update podman package..."
-          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
-            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
-            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
-            sudo apt-get update && \
-            sudo apt-get -y install podman; }
-          podman version
+        uses: redhat-actions/podman-install@92eb12467c2fc271e7781d006c413e17770230ed
+        with:
+          ubuntu-repository: 'questing'
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |


### PR DESCRIPTION
### What does this PR do?
* Updates pipelines from outdated ubuntu 23 kubic repo to questing install, podman 5.4.2

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
hotfix
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
