### PR TITLE
fix(ci): remove git change check on pr-check that was blocking linting on Linux

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -59,15 +59,6 @@ jobs:
       - name: Run svelte check
         run: pnpm svelte:check
 
-      # Check we don't have changes in git
-      - name: Check no changes in git
-        if: ${{ matrix.os=='ubuntu-22.04'}}
-        run: |
-          if ! git diff --exit-code; then
-            echo "Found changes in git"
-            exit 1
-          fi
-
   e2e-pr-check:
     name: e2e tests smoke
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### What does this PR do?
* Fixes `pnpm install` changing lockfile on every build and causing linux lint pipeline to fail

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
hotfix

https://github.com/containers/podman-desktop-extension-ai-lab/actions/runs/25788102500/job/75746395536
https://github.com/containers/podman-desktop-extension-ai-lab/actions/runs/25339379944/job/74292729290
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
