### PR TITLE
fix(test): updating delete images logic

### DIFF
--- a/tests/playwright/src/ai-lab-extension.spec.ts
+++ b/tests/playwright/src/ai-lab-extension.spec.ts
@@ -811,6 +811,12 @@ async function deleteUnusedImages(navigationBar: NavigationBar): Promise<void> {
 
     await imagesPage.deleteAllUnusedImages();
     await playExpect.poll(async () => await imagesPage.getCountOfImagesByStatus('UNUSED'), { timeout: 90_000 }).toBe(0);
+    // Wait for all in-progress deletions to complete before proceeding.
+    // Without this, Podman storage may still be removing layers when the next
+    // test group starts a build, causing "image not known" / "layer not known" errors.
+    await playExpect
+      .poll(async () => await imagesPage.getCountOfImagesByStatus('DELETING'), { timeout: 90_000 })
+      .toBe(0);
   } catch (error) {
     console.error('Error during deleteUnusedImages:', error);
   }


### PR DESCRIPTION
### What does this PR do?
* Adds extra await for the image deletion logic

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
hotfix
[26-05-17_03_34_44_analysis_report.md](https://github.com/user-attachments/files/28057697/26-05-17_03_34_44_analysis_report.md)

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
<!-- Please explain steps to reproduce -->
