### PR TITLE
chore(ci): pin workflow dependencies

### DIFF
--- a/.github/workflows/ai-lab-e2e-nightly-windows.yaml
+++ b/.github/workflows/ai-lab-e2e-nightly-windows.yaml
@@ -195,7 +195,7 @@ jobs:
         arm-client-secret: ${{ secrets.ARM_CLIENT_SECRET }}
 
     - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v6
+      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
       if: always()
       with:
         annotate_only: true
@@ -206,7 +206,7 @@ jobs:
         report_paths: '**/*results.xml'
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
         name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}
@@ -218,14 +218,14 @@ jobs:
           !./**/output/traces/*
 
     - name: Upload test videos
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
         name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}-videos
         path: ./**/output/videos/*
 
     - name: Upload test traces
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
         name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}-traces

--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -26,14 +26,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         name: Install pnpm
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/compute-model-sizes.yml
+++ b/.github/workflows/compute-model-sizes.yml
@@ -15,7 +15,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v6.0.3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     # Runs a single command using the runners shell
     - name: Compute model size
       run: ./tools/compute-model-sizes.sh

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -51,7 +51,7 @@ jobs:
           echo "${{ github.event.inputs.ext_repo_options || env.DEFAULT_EXT_REPO_OPTIONS }}" | awk -F ',' \
            '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         name: Checkout AI Lab - Workflow Dispatch
         if: github.event_name == 'workflow_dispatch'
         with:
@@ -59,26 +59,26 @@ jobs:
           ref: ${{ env.EXT_BRANCH }}
           path: podman-desktop-extension-ai-lab
 
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         name: Checkout AI Lab - Push or Schedule
         if: github.event_name == 'push' || github.event_name == 'schedule'
         with:
           path: podman-desktop-extension-ai-lab
 
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         name: Checkout Podman Desktop
         with:
           repository: ${{ env.PD_FORK }}/${{ env.PD_REPO }}
           ref: ${{ env.PD_BRANCH }}
           path: podman-desktop
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         name: Install pnpm
         with:
           run_install: false
           package_json_file: ./podman-desktop/package.json
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -144,7 +144,7 @@ jobs:
         run: pnpm test:e2e
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         if: always()
         with:
           annotate_only: true
@@ -154,7 +154,7 @@ jobs:
           require_tests:  true
           report_paths: '**/*results.xml'
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-tests
@@ -166,14 +166,14 @@ jobs:
             !./**/output/traces/*
 
       - name: Upload test videos
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-tests-videos
           path: ./**/output/videos/*
 
       - name: Upload test traces
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-tests-traces

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -29,14 +29,14 @@ jobs:
       matrix:
         os: [windows-2022, ubuntu-22.04, macos-14]
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         name: Install pnpm
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -74,22 +74,22 @@ jobs:
     env:
       SKIP_INSTALLATION: true
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: podman-desktop-extension-ai-lab
       # Set up pnpm
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         name: Install pnpm
         with:
           run_install: false
           package_json_file: ./podman-desktop-extension-ai-lab/package.json
       # Install Node.js
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
 
       # Checkout podman desktop
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: containers/podman-desktop
           ref: main
@@ -155,7 +155,7 @@ jobs:
         run: pnpm test:e2e:smoke
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         if: always()
         with:
           annotate_only: true
@@ -165,7 +165,7 @@ jobs:
           require_tests:  true
           report_paths: '**/*results.xml'
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-pr-check
@@ -177,14 +177,14 @@ jobs:
             !./**/output/traces/*
 
       - name: Upload test videos
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-pr-check-videos
           path: ./**/output/videos/*
 
       - name: Upload test traces
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-pr-check-traces

--- a/.github/workflows/ramalama.yaml
+++ b/.github/workflows/ramalama.yaml
@@ -36,21 +36,21 @@ jobs:
     env:
       SKIP_INSTALLATION: true
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: podman-desktop-extension-ai-lab
       # Set up pnpm
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         name: Install pnpm
         with:
           run_install: false
           package_json_file: ./podman-desktop-extension-ai-lab/package.json
       # Install Node.js
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
       # Checkout podman desktop
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: podman-desktop/podman-desktop
           ref: main
@@ -120,7 +120,7 @@ jobs:
         run: pnpm test:e2e
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         if: always()
         with:
           annotate_only: true
@@ -130,7 +130,7 @@ jobs:
           require_tests:  true
           report_paths: '**/*results.xml'
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-check
@@ -142,14 +142,14 @@ jobs:
             !./**/output/traces/*
 
       - name: Upload test videos
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-check-videos
           path: ./**/output/videos/*
 
       - name: Upload test traces
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: e2e-check-traces

--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -246,7 +246,7 @@ jobs:
 
     - name: Publish Test Report
       id: test-report
-      uses: mikepenz/action-junit-report@v6
+      uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
       if: always() # always run even if the previous step fails
       with:
         annotate_only: true
@@ -296,7 +296,7 @@ jobs:
         podman logs -f windows-destroy
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
         name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}
@@ -308,14 +308,14 @@ jobs:
           !./**/output/traces/*
 
     - name: Upload test videos
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
         name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}-videos
         path: ./**/output/videos/*
 
     - name: Upload test traces
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
         name: results-e2e-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}-traces

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       releaseId: ${{ steps.create_release.outputs.id}}
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.inputs.branch }}
       - name: Generate tag utilities
@@ -72,7 +72,7 @@ jobs:
           git push origin ${{ steps.TAG_UTIL.outputs.githubTag }}
       - name: Create Release
         id: create_release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -116,16 +116,16 @@ jobs:
     needs: [tag]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.tag.outputs.githubTag }}
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         name: Install pnpm
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -156,7 +156,7 @@ jobs:
         run: echo the release id is ${{ needs.tag.outputs.releaseId}}
 
       - name: Publish release
-        uses: StuYarrow/publish-release@v1.1.2
+        uses: StuYarrow/publish-release@01f2a1365bacd77bad861873a7fdf274ab49eefd # v1.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Actions to full-length commit SHAs instead of mutable version tags
- Follows the OpenSSF Scorecard [Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) recommendation

Related to podman-desktop/podman-desktop#16848

## Test plan
- [ ] Verify CI workflows still pass
- [ ] Confirm SHAs match upstream tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)