### PR TITLE
fix(docs): update Podman repository link

### DIFF
--- a/.github/workflows/recipe-catalog-change-template.yaml
+++ b/.github/workflows/recipe-catalog-change-template.yaml
@@ -95,7 +95,7 @@ jobs:
         DEFAULT_EXT_TESTS_OPTIONS: 'EXT_RUN_TESTS_FROM_EXTENSION=1,EXT_RUN_TESTS_AS_ADMIN=1,EXT_TEST_GPU_SUPPORT_ENABLED=0'
         DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-extension-ai-lab,FORK=containers,BRANCH=main'
         DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.2' }}"
-        DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
+        DEFAULT_URL: "https://github.com/podman-container-tools/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe"
         DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3-windows'
         DEFAULT_MAPT_PARAMS: "IMAGE=${{ vars.MAPT_IMAGE || 'quay.io/redhat-developer/mapt' }};VERSION_TAG=${{ vars.MAPT_VERSION_TAG || 'v0.9.7' }};CPUS=${{ vars.MAPT_CPUS || '4' }};MEMORY=${{ vars.MAPT_MEMORY || '32' }};EXCLUDED_REGIONS=\"${{ vars.MAPT_EXCLUDED_REGIONS || 'westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest' }}\""
       run: |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Podman AI Lab ships with a so-called Recipes Catalog that helps you navigate a n
 ### Software
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 - Compatible with Windows, macOS & Linux
 
 ### Hardware


### PR DESCRIPTION
### What does this PR do?

Updates Podman references to the new `podman-container-tools/podman` repository:

- `README.md` — Podman prerequisite link
- `.github/workflows/recipe-catalog-change-template.yaml` — default Windows Podman installer download URL

### Screenshot / video of UI

N/A (documentation and CI configuration only)

### What issues does this PR fix or reference?

- Related catalog update: podman-desktop/podman-desktop-catalog#1247

### How to test this PR?

- Open `README.md` and verify the Podman prerequisite points to `https://github.com/podman-container-tools/podman`.
- Confirm `recipe-catalog-change-template.yaml` uses the same org for the Podman release download URL.

Made with [Cursor](https://cursor.com)