### PR TITLE
chore(deps): update AI SDK packages to latest major versions

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -110,11 +110,11 @@
     "typecheck": "pnpm run generate && tsc --noEmit"
   },
   "dependencies": {
-    "@ai-sdk/mcp": "^1.0.52",
-    "@ai-sdk/openai-compatible": "^2.0.51",
+    "@ai-sdk/mcp": "^2.0.14",
+    "@ai-sdk/openai-compatible": "^3.0.11",
     "@huggingface/gguf": "^0.4.2",
     "@huggingface/hub": "^2.13.3",
-    "ai": "^6.0.208",
+    "ai": "^7.0.29",
     "express": "^5.2.1",
     "express-openapi-validator": "^5.6.2",
     "isomorphic-git": "^1.38.7",
@@ -131,8 +131,8 @@
   },
   "devDependencies": {
     "@podman-desktop/api": "1.13.0-202409181313-78725a6565",
-    "@ai-sdk/provider": "^4.0.2",
-    "@ai-sdk/provider-utils": "^4.0.30",
+    "@ai-sdk/provider": "^4.0.3",
+    "@ai-sdk/provider-utils": "^5.0.10",
     "@rollup/plugin-replace": "^6.0.3",
     "@types/express": "^5.0.6",
     "@types/js-yaml": "^4.0.9",

--- a/packages/backend/src/managers/playground/aiSdk.spec.ts
+++ b/packages/backend/src/managers/playground/aiSdk.spec.ts
@@ -18,7 +18,7 @@
 
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import * as ai from 'ai';
-import { MockLanguageModelV3 } from 'ai/test';
+import { MockLanguageModelV4 } from 'ai/test';
 import { AiStreamProcessor, toCoreMessage } from './aiSdk';
 import type {
   AssistantChat,
@@ -29,12 +29,7 @@ import type {
   PendingChat,
   UserChat,
 } from '@shared/models/IPlaygroundMessage';
-import type {
-  LanguageModelV3,
-  LanguageModelV2CallWarning,
-  LanguageModelV3StreamPart,
-  LanguageModelV3GenerateResult,
-} from '@ai-sdk/provider';
+import type { LanguageModelV4, LanguageModelV4StreamPart, LanguageModelV4GenerateResult } from '@ai-sdk/provider';
 import { ConversationRegistry } from '../../registries/ConversationRegistry';
 import type { RpcExtension } from '@shared/messages/MessageProxy';
 import type { ModelOptions } from '@shared/models/IModelOptions';
@@ -159,9 +154,10 @@ describe('aiSdk', () => {
           topP: 13,
           abortSignal: expect.any(AbortSignal),
           messages: expect.any(Array),
-          onStepFinish: expect.any(Function),
+          onStepEnd: expect.any(Function),
           onError: expect.any(Function),
           onChunk: expect.any(Function),
+          onEnd: expect.any(Function),
         }),
       );
     });
@@ -183,10 +179,10 @@ describe('aiSdk', () => {
     describe('with stream error', () => {
       beforeEach(async () => {
         // eslint-disable-next-line sonarjs/no-nested-functions
-        const doStream: LanguageModelV3['doStream'] = async () => {
+        const doStream: LanguageModelV4['doStream'] = async () => {
           throw new Error('The stream is kaput.');
         };
-        const model = new MockLanguageModelV3({ doStream });
+        const model = new MockLanguageModelV4({ doStream });
         await new AiStreamProcessor(conversationId, conversationRegistry).stream(model).consumeStream();
       });
       test('appends a single message', () => {
@@ -199,7 +195,7 @@ describe('aiSdk', () => {
       });
     });
     describe('with single message stream', () => {
-      let model: LanguageModelV3;
+      let model: LanguageModelV4;
       beforeEach(async () => {
         model = createTestModel({
           stream: ai.simulateReadableStream({
@@ -245,15 +241,15 @@ describe('aiSdk', () => {
       });
     });
     describe('with wrapped generated multiple messages as stream', () => {
-      let model: LanguageModelV3;
+      let model: LanguageModelV4;
       let tools: ToolSet;
       let generateStep: number;
 
       beforeEach(async () => {
         generateStep = 0;
         model = wrapLanguageModel({
-          model: new MockLanguageModelV3({
-            doGenerate: async (): Promise<LanguageModelV3GenerateResult> => {
+          model: new MockLanguageModelV4({
+            doGenerate: async (): Promise<LanguageModelV4GenerateResult> => {
               if (generateStep++ === 0) {
                 return {
                   content: [
@@ -346,8 +342,8 @@ describe('aiSdk', () => {
       });
       test('setsUsage', async () => {
         const conversation = conversationRegistry.get(conversationId) as Conversation;
-        expect(conversation?.usage?.completion_tokens).toEqual(7);
-        expect(conversation?.usage?.prompt_tokens).toEqual(133);
+        expect(conversation?.usage?.completion_tokens).toEqual(8);
+        expect(conversation?.usage?.prompt_tokens).toEqual(134);
       });
     });
   });
@@ -355,18 +351,10 @@ describe('aiSdk', () => {
 
 export function createTestModel({
   stream = ai.simulateReadableStream({ chunks: [] }),
-  rawCall = { rawPrompt: 'prompt', rawSettings: {} },
-  rawResponse = undefined,
-  request = undefined,
-  warnings,
 }: {
-  stream?: ReadableStream<LanguageModelV3StreamPart>;
-  rawResponse?: { headers: Record<string, string> };
-  rawCall?: { rawPrompt: string; rawSettings: Record<string, unknown> };
-  request?: { body: string };
-  warnings?: LanguageModelV2CallWarning[];
-} = {}): LanguageModelV3 {
-  return new MockLanguageModelV3({
-    doStream: async () => ({ stream, rawCall, rawResponse, request, warnings }),
+  stream?: ReadableStream<LanguageModelV4StreamPart>;
+} = {}): LanguageModelV4 {
+  return new MockLanguageModelV4({
+    doStream: async () => ({ stream }),
   });
 }

--- a/packages/backend/src/managers/playground/aiSdk.ts
+++ b/packages/backend/src/managers/playground/aiSdk.ts
@@ -16,13 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { streamText, stepCountIs } from 'ai';
+import { streamText, isStepCount } from 'ai';
 import type {
+  GenerateTextOnEndCallback,
   LanguageModel,
   ModelMessage,
   StepResult,
-  StreamTextResult,
-  StreamTextOnFinishCallback,
   TextStreamPart,
   ToolCallPart,
   ToolResultPart,
@@ -172,28 +171,29 @@ export class AiStreamProcessor<TOOLS extends ToolSet> {
     }
   };
 
-  private onFinish: StreamTextOnFinishCallback<TOOLS> = stepResult => {
+  private onEnd: GenerateTextOnEndCallback<TOOLS> = stepResult => {
     this.conversationRegistry.setUsage(this.conversationId, {
       completion_tokens: stepResult.usage.outputTokens,
       prompt_tokens: stepResult.usage.inputTokens,
     } as ModelUsage);
   };
 
-  stream = (model: LanguageModel, tools?: TOOLS, options?: ModelOptions): StreamTextResult<TOOLS, never> => {
+  stream = (model: LanguageModel, tools?: TOOLS, options?: ModelOptions): ReturnType<typeof streamText<TOOLS>> => {
     this.stepStartTime = Date.now();
     return streamText({
       model,
       tools,
-      stopWhen: stepCountIs(10),
+      stopWhen: isStepCount(10),
       temperature: options?.temperature,
       maxOutputTokens: (options?.max_tokens ?? -1) < 1 ? undefined : options?.max_tokens,
       topP: options?.top_p,
       abortSignal: this.abortController.signal,
       messages: toCoreMessage(...this.conversationRegistry.get(this.conversationId).messages),
-      onStepFinish: this.onStepFinish,
+      allowSystemInMessages: true,
+      onStepEnd: this.onStepFinish,
       onError: this.onError,
       onChunk: this.onChunk,
-      onFinish: this.onFinish,
+      onEnd: this.onEnd,
     });
   };
 }

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -29,9 +29,9 @@ import type { ChatMessage, ErrorMessage } from '@shared/models/IPlaygroundMessag
 import type { CancellationTokenRegistry } from '../registries/CancellationTokenRegistry';
 import type { RpcExtension } from '@shared/messages/MessageProxy';
 import { MSG_CONVERSATIONS_UPDATE } from '@shared/Messages';
-import type { LanguageModelV2CallWarning, LanguageModelV3, LanguageModelV3StreamPart } from '@ai-sdk/provider';
+import type { LanguageModelV4, LanguageModelV4StreamPart } from '@ai-sdk/provider';
 import { type McpServerManager } from './playground/McpServerManager';
-import { MockLanguageModelV3 } from 'ai/test';
+import { MockLanguageModelV4 } from 'ai/test';
 import { simulateReadableStream } from 'ai';
 
 vi.mock('@ai-sdk/openai-compatible', () => ({
@@ -66,13 +66,7 @@ const cancellationTokenRegistryMock = {
 } as unknown as CancellationTokenRegistry;
 
 let mcpServerManager: McpServerManager;
-let createTestModel: (options: {
-  stream?: ReadableStream<LanguageModelV3StreamPart>;
-  rawResponse?: { headers: Record<string, string> };
-  rawCall?: { rawPrompt: string; rawSettings: Record<string, unknown> };
-  request?: { body: string };
-  warnings?: LanguageModelV2CallWarning[];
-}) => LanguageModelV3;
+let createTestModel: (options: { stream?: ReadableStream<LanguageModelV4StreamPart> }) => LanguageModelV4;
 
 beforeEach(async () => {
   vi.resetAllMocks();
@@ -221,8 +215,7 @@ test('valid submit should create IPlaygroundMessage and notify the webview', asy
       labels: [],
     } as unknown as InferenceServer,
   ]);
-  // @ts-expect-error - Mock return type for testing
-  vi.mocked(createOpenAICompatible).mockReturnValue(() =>
+  vi.mocked(createOpenAICompatible).mockReturnValue((() =>
     createTestModel({
       stream: simulateReadableStream({
         chunks: [
@@ -237,8 +230,7 @@ test('valid submit should create IPlaygroundMessage and notify the webview', asy
           },
         ],
       }),
-    }),
-  );
+    })) as unknown as ReturnType<typeof createOpenAICompatible>);
 
   const manager = new PlaygroundV2Manager(
     rpcExtensionMock,
@@ -310,16 +302,11 @@ test('error', async () => {
       labels: [],
     } as unknown as InferenceServer,
   ]);
-  const doStream: LanguageModelV3['doStream'] = async () => {
+  const doStream: LanguageModelV4['doStream'] = async () => {
     throw new Error('Please reduce the length of the messages or completion.');
   };
   vi.mocked(createOpenAICompatible).mockReturnValue(
-    // @ts-expect-error MockLanguageModelV2 test mock
-    // eslint-disable-next-line sonarjs/new-operator-misuse
-    () =>
-      new (
-        MockLanguageModelV3 as unknown as new (options: { doStream: LanguageModelV3['doStream'] }) => LanguageModelV3
-      )({ doStream }),
+    (() => new MockLanguageModelV4({ doStream })) as unknown as ReturnType<typeof createOpenAICompatible>,
   );
 
   const manager = new PlaygroundV2Manager(
@@ -716,8 +703,7 @@ describe('system prompt', () => {
         labels: [],
       } as unknown as InferenceServer,
     ]);
-    // @ts-expect-error - Mock return type for testing
-    vi.mocked(createOpenAICompatible).mockReturnValue(() =>
+    vi.mocked(createOpenAICompatible).mockReturnValue((() =>
       createTestModel({
         stream: simulateReadableStream({
           chunks: [
@@ -732,8 +718,7 @@ describe('system prompt', () => {
             },
           ],
         }),
-      }),
-    );
+      })) as unknown as ReturnType<typeof createOpenAICompatible>);
 
     const manager = new PlaygroundV2Manager(
       rpcExtensionMock,

--- a/packages/backend/src/utils/mcpUtils.ts
+++ b/packages/backend/src/utils/mcpUtils.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
+import { createMCPClient } from '@ai-sdk/mcp';
 import { Experimental_StdioMCPTransport as StdioClientTransport } from '@ai-sdk/mcp/mcp-stdio';
 import { type McpClient, type McpServer, McpServerType } from '@shared/models/McpSettings';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,11 +121,11 @@ importers:
   packages/backend:
     dependencies:
       '@ai-sdk/mcp':
-        specifier: ^1.0.52
-        version: 1.0.52(zod@4.4.3)
+        specifier: ^2.0.14
+        version: 2.0.14(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: ^2.0.51
-        version: 2.0.51(zod@4.4.3)
+        specifier: ^3.0.11
+        version: 3.0.11(zod@4.4.3)
       '@huggingface/gguf':
         specifier: ^0.4.2
         version: 0.4.2
@@ -133,8 +133,8 @@ importers:
         specifier: ^2.13.3
         version: 2.13.3
       ai:
-        specifier: ^6.0.208
-        version: 6.0.208(zod@4.4.3)
+        specifier: ^7.0.29
+        version: 7.0.29(zod@4.4.3)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -176,11 +176,11 @@ importers:
         version: 1.6.11
     devDependencies:
       '@ai-sdk/provider':
-        specifier: ^4.0.2
-        version: 4.0.2
+        specifier: ^4.0.3
+        version: 4.0.3
       '@ai-sdk/provider-utils':
-        specifier: ^4.0.30
-        version: 4.0.30(zod@4.4.3)
+        specifier: ^5.0.10
+        version: 5.0.10(zod@4.4.3)
       '@podman-desktop/api':
         specifier: 1.13.0-202409181313-78725a6565
         version: 1.13.0-202409181313-78725a6565
@@ -341,36 +341,32 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/gateway@3.0.133':
-    resolution: {integrity: sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.21':
+    resolution: {integrity: sha512-GafyeyHFDKJjdtbyhCQ0aC2FORdyE56IxK45EZ1JLO1iVdg8XqEU3bwnRzI0+5S1XHV7W2qQsxkZnGYPbsFiXA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mcp@1.0.52':
-    resolution: {integrity: sha512-yudE3Mdl8fsbzjMepOPbikA6nIRWOez+5e/IvOv1jK6XMAtsZ4+Xz8vjRQHI77VMv2TdiaMfsKKFoW6dlZRT3g==}
-    engines: {node: '>=18'}
+  '@ai-sdk/mcp@2.0.14':
+    resolution: {integrity: sha512-Vf2THTWylnOiPUZgPEzTcbin+6pIBKMdJnDNAMHD0u+upNoO5747HMMFUJJnNNjk8eroAPomaVmF0w8gadA4WA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.51':
-    resolution: {integrity: sha512-A6qfyaVs4lxmRxRux6U3ViOa8mMbsSd0OaHghpei2MpiBT6791J4zFH5MN7kaW1tLfQ246rSC2DVTMOavsycjQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai-compatible@3.0.11':
+    resolution: {integrity: sha512-PKLyt5PfjV2maWJPZpm3W29vCc+BbyqSPAcghXhl+iIxzFNjpGPa6UD/8J0b9l7w/lJCZKuhcef9q+Gp5WqUvw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.30':
-    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.10':
+    resolution: {integrity: sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.10':
-    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/provider@4.0.2':
-    resolution: {integrity: sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==}
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
 
   '@ampproject/remapping@2.3.0':
@@ -1140,10 +1136,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@opentelemetry/api@1.9.1':
-    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
-    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
@@ -2179,6 +2171,9 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2201,9 +2196,9 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@6.0.208:
-    resolution: {integrity: sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==}
-    engines: {node: '>=18'}
+  ai@7.0.29:
+    resolution: {integrity: sha512-q+A+skhl6SyjWliU6W7zNYgDUrEk5SbNrCc5vt4S9n6+n6e7jSorDmu51hlhjDOsS7VwzWGCgbWFvvT3iomtvg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -5130,38 +5125,35 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@3.0.133(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.21(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.10(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/mcp@1.0.52(zod@4.4.3)':
+  '@ai-sdk/mcp@2.0.14(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.10(zod@4.4.3)
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@2.0.51(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@3.0.11(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.10(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.30(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.10(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@3.0.10':
-    dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/provider@4.0.2':
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -5828,8 +5820,6 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
-
-  '@opentelemetry/api@1.9.1': {}
 
   '@oxc-project/types@0.138.0': {}
 
@@ -6827,6 +6817,8 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@workflow/serde@4.1.0': {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -6844,12 +6836,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.208(zod@4.4.3):
+  ai@7.0.29(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.133(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.21(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.10(zod@4.4.3)
       zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.17.1):


### PR DESCRIPTION
## Summary

- Update `ai` (^6.0.208 → ^7.0.29), `@ai-sdk/mcp` (^1.0.52 → ^2.0.14), `@ai-sdk/openai-compatible` (^2.0.51 → ^3.0.11), `@ai-sdk/provider-utils` (^4.0.30 → ^5.0.10), and `@ai-sdk/provider` (^4.0.2 → ^4.0.3)
- Adapt code to AI SDK 7.0 breaking changes: graduated MCP client API, renamed callbacks (`onFinish` → `onEnd`, `onStepFinish` → `onStepEnd`), renamed `stepCountIs` → `isStepCount`, migrated mock types from V3 to V4, added `allowSystemInMessages` for system prompt support
- Updated test expectations to reflect accumulated token counting in v7

## Test plan

- [x] `pnpm format:fix` passes
- [x] `pnpm lint:fix` passes
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm test:unit` passes (844 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)