### PR TITLE
fix: don't show Podman Machine message on Linux when a connection is provided

### DIFF
--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -620,6 +620,27 @@ describe('checkContainerConnectionStatusAndResources', () => {
     });
   });
 
+  test('return native on Linux even when a connection is explicitly provided', async () => {
+    const manager = new PodmanConnection(rpcExtensionMock);
+    vi.mocked(env).isLinux = true;
+
+    const result = await manager.checkContainerConnectionStatusAndResources({
+      model: modelMock,
+      context: 'inference',
+      connection: {
+        providerId: 'podman',
+        name: 'podman',
+        type: 'podman',
+        status: 'started',
+        vmType: VMType.UNKNOWN,
+      },
+    });
+    expect(result).toStrictEqual({
+      status: 'native',
+      canRedirect: expect.any(Boolean),
+    });
+  });
+
   test('return noMachineInfo if there is no running podman connection', async () => {
     const manager = new PodmanConnection(rpcExtensionMock);
     vi.mocked(env).isLinux = false;

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -316,8 +316,10 @@ export class PodmanConnection extends Publisher<ContainerProviderConnectionInfo[
     // starting from podman desktop 1.10 we have the navigate functions
     const hasNavigateFunction = !!navigation.navigateToResources;
 
-    // if we do not precise the connection and are on linux we assume native usage
-    if (env.isLinux && !options.connection) {
+    // on Linux, podman runs natively without a VM, so the podman machine
+    // resource checks below (and their "Update your Podman Machine" messaging)
+    // do not apply, regardless of whether a specific connection was requested
+    if (env.isLinux) {
       return {
         status: 'native',
         canRedirect: hasNavigateFunction,


### PR DESCRIPTION
### What does this PR do?
On Linux, `checkContainerConnectionStatusAndResources()` only short-circuited to `native` status when no connection was explicitly passed. When a caller (e.g. the RAG AI Lab's model-checker) passes an explicit connection on Linux, it fell through to the podman-machine CPU/memory checks and could surface "Update your Podman Machine to improve performance" — a message that doesn't apply on Linux, where Podman runs natively.

Narrowed the guard to trigger on `env.isLinux` alone, so Linux always reports `native` regardless of whether a connection was specified.

Kept the diff minimal: did not add `'native'` to `ContainerConnectionInfoStatus` in the shared types, since it's unused anywhere in the codebase — an unrelated change that got a previous attempt (#4395) maintainer pushback ("How come is this new method changing something").

### What issues does this PR fix or reference?
Fixes #2010

### How to test this PR?
- `pnpm run test:backend` — 531 passed, including a new regression test (`'return native on Linux even when a connection is explicitly provided'`) covering this exact path.
- `pnpm run typecheck:backend` — clean.
- `npx eslint` on the changed files — clean.