### PR TITLE
fix: pass inference server Entrypoint as a string array

### DIFF
--- a/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.spec.ts
@@ -306,6 +306,7 @@ describe('perform', () => {
     expect(containerEngine.createContainer).toHaveBeenCalledWith(
       DummyImageInfo.engineId,
       expect.objectContaining({
+        Entrypoint: ['/usr/bin/sh'],
         Cmd: [
           '-c',
           '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && /usr/bin/llama-server.sh',
@@ -355,6 +356,7 @@ describe('perform', () => {
     expect(containerEngine.createContainer).toHaveBeenCalledWith(
       DummyImageInfo.engineId,
       expect.objectContaining({
+        Entrypoint: ['/usr/bin/sh'],
         Cmd: [
           '-c',
           '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && /usr/bin/llama-server.sh',
@@ -404,6 +406,7 @@ describe('perform', () => {
     expect(containerEngine.createContainer).toHaveBeenCalledWith(
       DummyImageInfo.engineId,
       expect.objectContaining({
+        Entrypoint: ['/usr/bin/sh'],
         Cmd: [
           '-c',
           '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && /usr/bin/llama-server.sh',

--- a/packages/backend/src/workers/provider/LlamaCppPython.ts
+++ b/packages/backend/src/workers/provider/LlamaCppPython.ts
@@ -101,7 +101,7 @@ export class LlamaCppPython extends InferenceProvider {
 
     const deviceRequests: DeviceRequest[] = [];
     const devices: Device[] = [];
-    let entrypoint: string | undefined = undefined;
+    let entrypoint: string[] | undefined = undefined;
     let cmd: string[] = [];
     let user: string | undefined = undefined;
 
@@ -125,7 +125,7 @@ export class LlamaCppPython extends InferenceProvider {
 
             user = '0';
 
-            entrypoint = '/usr/bin/sh';
+            entrypoint = ['/usr/bin/sh'];
             cmd = [
               '-c',
               '/usr/bin/ln -sfn /usr/lib/wsl/lib/* /usr/lib64/ && PATH="${PATH}:/usr/lib/wsl/lib/" && /usr/bin/llama-server.sh',


### PR DESCRIPTION
### What does this PR do?

Pass the llama.cpp inference container `Entrypoint` as a string array instead of a string.

On WSL with NVIDIA GPU, creating a model service sent `"Entrypoint":"/usr/bin/sh"`. Podman's container create API decodes `Entrypoint` as `[]string`, so a JSON string fails with HTTP 400 (`decode slice: expect [ or n, but found "`).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-ai-lab/issues/4679

### How to test this PR?

- [x] Unit tests cover the WSL NVIDIA GPU create-container options (`Entrypoint: ['/usr/bin/sh']`)
- On Windows with a WSL Podman machine and experimental GPU enabled, create a model service and confirm the inference server starts without the HTTP 400 Entrypoint error
