### PR TITLE
fix(e2e): remove unnecessary workaround for tests-playwright version

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -113,9 +113,6 @@ jobs:
         working-directory: ./podman-desktop
         run: pnpm test:e2e:build
 
-      - name: Ensure getting current HEAD version of the test framework
-        working-directory: ./podman-desktop-extension-ai-lab/tests/playwright
-        run: pnpm add -D @podman-desktop/tests-playwright@next
 
       - name: Execute pnpm in AI Lab Extension
         working-directory: ./podman-desktop-extension-ai-lab

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -120,17 +120,10 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm test:e2e:build
 
-      - name: Ensure getting current HEAD version of the test framework
-        working-directory: ./podman-desktop-extension-ai-lab/tests/playwright
-        run: |
-          # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
-          version=$(npm view @podman-desktop/tests-playwright@next version)
-          echo "Version of @podman-desktop/tests-playwright to be used: $version"
-          jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
 
       - name: Execute pnpm in AI Lab Extension
         working-directory: ./podman-desktop-extension-ai-lab
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: Build Image
         working-directory: ./podman-desktop-extension-ai-lab

--- a/.github/workflows/ramalama.yaml
+++ b/.github/workflows/ramalama.yaml
@@ -81,17 +81,10 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm test:e2e:build
 
-      - name: Ensure getting current HEAD version of the test framework
-        working-directory: ./podman-desktop-extension-ai-lab/tests/playwright
-        run: |
-          # workaround for https://github.com/podman-desktop/podman-desktop-extension-bootc/issues/712
-          version=$(npm view @podman-desktop/tests-playwright@next version)
-          echo "Version of @podman-desktop/tests-playwright to be used: $version"
-          jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
 
       - name: Execute pnpm in AI Lab Extension
         working-directory: ./podman-desktop-extension-ai-lab
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: Update ramalama image references in AI Lab Extension
         working-directory: ./podman-desktop-extension-ai-lab


### PR DESCRIPTION
## Description

The step was dynamically replacing the `@podman-desktop/tests-playwright` version with the latest @next release before running pnpm install. With pnpm v11 minimumReleaseAge defaulting to 1440 minutes, this breaks CI when a @next version was published within the last 24 hours.

The workaround referenced https://github.com/containers/podman-desktop-extension-bootc/issues/712 and is no longer needed.

## Related issues

Required for https://github.com/containers/podman-desktop-extension-ai-lab/pull/4682